### PR TITLE
delete opts when session is deleted

### DIFF
--- a/lib/commands/session.js
+++ b/lib/commands/session.js
@@ -50,6 +50,7 @@ commands.deleteSession = async function () {
   if (this.noCommandTimer) {
     clearTimeout(this.noCommandTimer);
   }
+  this.opts = this.initialOpts;
   this.noCommandTimer = null;
   this.sessionId = null;
 };


### PR DESCRIPTION
@jlipps moiz and I did this so that multiple sessions can run on a single android driver. `opts` wasn't getting reset on session delete.

Interesting thing here: when running androidDriver standalone, multiple sessions reuse a single driver object. In the main Appium module, each session is assigned to a single object, and a new one is created for each session. Do we want to rewrite the standalone server in androidDriver so that it creates new AndroidDrivers when sessions are created?