### PR TITLE
reset fix

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -207,16 +207,25 @@ class BaseDriver extends MobileJsonWireProtocol {
   async reset () {
     log.debug("Resetting app mid-session");
     log.debug("Running generic full reset");
+
+    // preserving state
     let currentConfig = {};
-    for (let k of ['implicitWaitMs', 'newCommandTimeoutMs', 'sessionId']) {
+    for (let k of ['implicitWaitMs', 'newCommandTimeoutMs', 'sessionId', 'resetOnUnexpectedShutdown']) {
       currentConfig[k] = this[k];
     }
-    await this.deleteSession();
-    log.debug("Restarting app");
-    await this.createSession(this.caps);
 
-    for (let [k,v] of _.pairs(currentConfig)) {
-      this[k] = v;
+    // We also need to preserve the unexpected shutdown, and make sure it is not cancelled during reset.
+    this.resetOnUnexpectedShutdown = () => {};
+
+    try {
+      await this.deleteSession();
+      log.debug("Restarting app");
+      await this.createSession(this.caps);
+    } finally {
+      // always restore state.
+      for (let [k,v] of _.pairs(currentConfig)) {
+        this[k] = v;
+      }
     }
     this.clearNewCommandTimeout();
   }


### PR DESCRIPTION
Now the problem is that we create a new onUnexpectedShutdown promise during reset, and cancel the old one, resulting in the session not being removed from the list on crashes.

We need to preserve resetOnUnexpectedShutdown during reset. The current logic being a little bit hardcore, just calling createSession+deleteSession, it is simpler to just disable the function for the duration of the rest.

Long term solution would be to extract a Session object and have a special constructor for reset.

ping @jlipps.