### PR TITLE
Allow booleans to be strings

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -79,6 +79,14 @@ validator.validators.isBoolean = function (value) {
     return null;
   }
 
+  // allow a string value
+  if (typeof value === 'string' &&
+      (value.toLowerCase().match(/['"']true['"']/) || value.toLowerCase().match(/['"']false['"']/)) ||
+      (value === '')) {
+    log.warn('Boolean capability passed in as string. Functionality may be compromised.');
+    return null;
+  }
+
   if (typeof value === 'undefined') {
     return null;
   }

--- a/test/capability-specs.js
+++ b/test/capability-specs.js
@@ -158,6 +158,26 @@ describe('Desired Capabilities', () => {
     should.fail('error should have been thrown');
   });
 
+  describe('boolean capabilities', () => {
+    it('should allow a string "false"', async () => {
+      await d.createSession({
+        'platformName': 'iOS',
+        'deviceName': 'Delorean',
+        'noReset': '"false"'
+      });
+      logger.warn.callCount.should.be.above(0);
+    });
+
+    it('should allow a string "ttrue"', async () => {
+      await d.createSession({
+        'platformName': 'iOS',
+        'deviceName': 'Delorean',
+        'noReset': '"true"'
+      });
+      logger.warn.callCount.should.be.above(0);
+    });
+  });
+
   it ('should error if objects in caps', async function () {
     try {
       await d.createSession({


### PR DESCRIPTION
Our old behaviour was to allow boolean caps to be sent as strings (e.g., `"false"` being the same as `false` as a cap value). Continue that tradition.