### PR TITLE
Add language and locale to desired capabilities

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -49,6 +49,12 @@ let desiredCapabilityConstraints = {
   },
   fullReset: {
     isBoolean: true
+  },
+  language: {
+    isString: true
+  },
+  locale: {
+    isString: true
   }
 };
 


### PR DESCRIPTION
Otherwise we get log messages saying they are not understood, though they are.