### PR TITLE
Move fix caps function from appium driver

### DIFF
--- a/lib/commands/session.js
+++ b/lib/commands/session.js
@@ -10,6 +10,7 @@ commands.createSession = async function (caps) {
     throw new errors.SessionNotCreatedError('Cannot create a new session ' +
                                             'while one is in progress');
   }
+  caps = fixCaps(caps, this.desiredCapConstraints);
   this.validateDesiredCaps(caps);
   this.sessionId = UUID.create().hex;
   this.caps = caps;
@@ -58,5 +59,24 @@ commands.deleteSession = async function (/* sessionId */) {
   this.clearNewCommandTimeout();
   this.sessionId = null;
 };
+
+function fixCaps (originalCaps, desiredCapConstraints = {}) {
+  let caps = _.clone(originalCaps);
+
+  // boolean capabilities can be passed in as strings 'false' and 'true'
+  // which we want to translate into boolean values
+  let booleanCaps = _.keys(_.pickBy(desiredCapConstraints, (k) => k.isBoolean === true));
+  for (let cap of booleanCaps) {
+    let value = originalCaps[cap];
+    if (_.isString(value)) {
+      value = value.toLowerCase();
+      if (value === 'true' || value === 'false') {
+        log.warn(`Capability '${cap}' changed from string to boolean. This may cause unexpected behavior`);
+        caps[cap] = (value === 'true');
+      }
+    }
+  }
+  return caps;
+}
 
 export default commands;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -228,6 +228,7 @@ function getSwipeTouchDuration (waitGesture) {
   return duration;
 }
 
+
 export default { configureApp, downloadApp, downloadFile, copyLocalZip,
                  unzipApp, unzipFile, testZipArchive, isPackageOrBundle,
                  getCoordDefault, getSwipeTouchDuration };

--- a/test/capability-specs.js
+++ b/test/capability-specs.js
@@ -166,6 +166,9 @@ describe('Desired Capabilities', () => {
         'noReset': 'false'
       });
       logger.warn.callCount.should.be.above(0);
+
+      let sessions = await d.getSessions();
+      sessions[0].capabilities.noReset.should.eql(false);
     });
 
     it('should allow a string "true"', async () => {
@@ -175,6 +178,21 @@ describe('Desired Capabilities', () => {
         'noReset': 'true'
       });
       logger.warn.callCount.should.be.above(0);
+
+      let sessions = await d.getSessions();
+      sessions[0].capabilities.noReset.should.eql(true);
+    });
+
+    it('should allow a string "true" in string capabilities', async () => {
+      await d.createSession({
+        'platformName': 'iOS',
+        'deviceName': 'Delorean',
+        'language': 'true'
+      });
+      logger.warn.callCount.should.equal(0);
+
+      let sessions = await d.getSessions();
+      sessions[0].capabilities.language.should.eql('true');
     });
   });
 


### PR DESCRIPTION
We previously fixed the caps before sending them to the sub-driver. This caused problems because caps that were not supposed to be boolean, but _were_ strings with the value `"true"` or `"false"` would be converted. This particularly happened with iOS's `waitForAppScript`.

To fix this, here we parse the cap constraints to get the ones that are supposed to be booleans, before doing the transformation. This needs to be done in the driver.