### PR TITLE
Make sure the server is closed when we call close

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -17,6 +17,18 @@ async function server (configureRoutes, port, hostname = null) {
   let app = express();
   let httpServer = http.createServer(app);
 
+  // http.Server.close() only stops new connections, but we need to wait until
+  // all connections are closed and the `close` event is emitted
+  let close = httpServer.close.bind(httpServer);
+  httpServer.close = async () => {
+    return await new Promise((resolve, reject) => {
+      httpServer.on('close', resolve);
+      close((err) => {
+        if (err) reject(err);
+      });
+    });
+  };
+
   return await new Promise((resolve, reject) => {
     httpServer.on('error', (err) => {
       if (err.code === 'EADDRNOTAVAIL') {

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -14,8 +14,8 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
     before(async () => {
       baseServer = await server(routeConfiguringFunction(d), 8181);
     });
-    after(() => {
-      baseServer.close();
+    after(async () => {
+      await baseServer.close();
     });
 
     describe('session handling', () => {


### PR DESCRIPTION
We have cases (notably within the xcuitest driver) where we get odd results because the server is not closing correctly.

This is backwards compatible, in that an un-awaited promise behaves the same as a function that takes a callback but ignores that callback.