### PR TITLE
Change name of xcuitest automation name

### DIFF
--- a/lib/basedriver/desired-caps.js
+++ b/lib/basedriver/desired-caps.js
@@ -26,7 +26,7 @@ let desiredCapabilityConstraints = {
     inclusionCaseInsensitive: [
       'Appium',
       'Selendroid',
-      'WebDriverAgent',
+      'XCUITest',
       'YouiEngine'
     ]
   },


### PR DESCRIPTION
We are using `XCUITest` instead of `WebDriverAgent` as the `automationName`.