### PR TITLE
Make sure async is there, and add logging

### DIFF
--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -20,7 +20,7 @@ commands.timeouts = async function (type, duration) {
   }
 };
 
-commands.implicitWait = function (ms) {
+commands.implicitWait = async function (ms) {
   this.implicitWaitMs = parseInt(ms, 10);
   log.debug(`Set implicit wait to ${ms}ms`);
 };

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -191,6 +191,7 @@ class BaseDriver extends MobileJsonWireProtocol {
 
   validateLocatorStrategy (strategy, webContext = false) {
     let validStrategies = this.locatorStrategies;
+    log.debug(`Valid locator strategies for this request: ${validStrategies.join(', ')}`);
 
     if (webContext) {
       validStrategies = validStrategies.concat(this.webLocatorStrategies);


### PR DESCRIPTION
Fix a problem where a command method is not `async`, and add a little logging for valid locator strategies.