### PR TITLE
Add ability to manage delegated drivers

### DIFF
--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -1,19 +1,23 @@
 import log from '../logger';
 import { waitForCondition } from 'asyncbox';
 import B from 'bluebird';
+import _ from 'lodash';
 import { util } from 'appium-support';
+import { errors } from '../../mjsonwp';
 
 
 let commands = {}, helpers = {}, extensions = {};
 
+const MIN_TIMEOUT = 0;
+
 commands.timeouts = async function (type, duration) {
-  let ms = parseInt(duration, 10);
+  let ms = this.parseTimeoutArgument(duration);
   switch(type) {
     case 'command':
-      this.newCommandTimeout(ms);
+      this.setNewCommandTimeout(ms);
       break;
     case 'implicit':
-      await this.implicitWait(ms);
+      this.setImplicitWait(ms);
       break;
     default:
       throw new Error(`Invalid timeout '${type}'`);
@@ -21,13 +25,33 @@ commands.timeouts = async function (type, duration) {
 };
 
 commands.implicitWait = async function (ms) {
-  this.implicitWaitMs = parseInt(ms, 10);
-  log.debug(`Set implicit wait to ${ms}ms`);
+  this.setImplicitWait(this.parseTimeoutArgument(ms));
 };
 
-helpers.newCommandTimeout = function (ms) {
+helpers.setImplicitWait = function (ms) {
+  this.implicitWaitMs = ms;
+  log.debug(`Set implicit wait to ${ms}ms`);
+  if (this.managedDrivers && this.managedDrivers.length) {
+    log.debug('Setting implicit wait on managed drivers');
+    for (let driver of this.managedDrivers) {
+      if (_.isFunction(driver.setImplicitWait)) {
+        driver.setImplicitWait(ms);
+      }
+    }
+  }
+};
+
+helpers.setNewCommandTimeout = function (ms) {
   this.newCommandTimeoutMs = ms;
   log.debug(`Set new command timeout to ${ms}ms`);
+  if (this.managedDrivers && this.managedDrivers.length) {
+    log.debug('Setting new command timeout on managed drivers');
+    for (let driver of this.managedDrivers) {
+      if (_.isFunction(driver.setNewCommandTimeout)) {
+        driver.setNewCommandTimeout(ms);
+      }
+    }
+  }
 };
 
 helpers.clearNewCommandTimeout = function () {
@@ -71,6 +95,14 @@ helpers.implicitWaitForCondition = async function (condFn) {
   return await waitForCondition(wrappedCondFn, {
     waitMs: this.implicitWaitMs, intervalMs: 500, logger: log
   });
+};
+
+helpers.parseTimeoutArgument = function (ms) {
+  let duration = parseInt(ms, 10);
+  if (_.isNaN(duration) || duration < MIN_TIMEOUT) {
+    throw new errors.UnknownError(`Invalid timeout value '${ms}'`);
+  }
+  return duration;
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -49,6 +49,9 @@ class BaseDriver extends MobileJsonWireProtocol {
 
     // keeping track of initial opts
     this.initialOpts = _.cloneDeep(this.opts);
+
+    // allow subclasses to have internal drivers
+    this.managedDrivers = [];
   }
 
   /*
@@ -270,6 +273,14 @@ class BaseDriver extends MobileJsonWireProtocol {
 
   canProxy (/* sessionId */) {
     return false;
+  }
+
+  addManagedDriver (driver) {
+    this.managedDrivers.push(driver);
+  }
+
+  getManagedDrivers () {
+    return this.managedDrivers;
   }
 }
 

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -1,0 +1,119 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import BaseDriver from '../..';
+import sinon from 'sinon';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+
+describe('timeout', () => {
+  let driver = new BaseDriver();
+  let implicitWaitSpy, newCommandTimeoutSpy;
+  before(() => {
+    implicitWaitSpy = sinon.spy(driver, 'setImplicitWait');
+    newCommandTimeoutSpy = sinon.spy(driver, 'setNewCommandTimeout');
+  });
+  beforeEach(() => {
+    driver.implicitWaitMs = 0;
+  });
+  afterEach(() => {
+    implicitWaitSpy.reset();
+    newCommandTimeoutSpy.reset();
+  });
+  describe('timeouts', () => {
+    describe('errors', () => {
+      it('should throw an error if something random is sent', async () => {
+        await driver.timeouts('random timeout', 'howdy').should.eventually.be.rejected;
+      });
+      it('should throw an error if timeout is negative', async () => {
+        await driver.timeouts('random timeout', -42).should.eventually.be.rejected;
+      });
+      it('should throw an errors if timeout type is unknown', async () => {
+        await driver.timeouts('random timeout', 42).should.eventually.be.rejected;
+      });
+    });
+    describe('implicit wait', () => {
+      it('should call setImplicitWait when given an integer', async () => {
+        await driver.timeouts('implicit', 42);
+        implicitWaitSpy.calledOnce.should.be.true;
+        implicitWaitSpy.firstCall.args[0].should.equal(42);
+        driver.implicitWaitMs.should.eql(42);
+      });
+      it('should call setImplicitWait when given a string', async () => {
+        await driver.timeouts('implicit', '42');
+        implicitWaitSpy.calledOnce.should.be.true;
+        implicitWaitSpy.firstCall.args[0].should.equal(42);
+        driver.implicitWaitMs.should.eql(42);
+      });
+    });
+  });
+  describe('implicitWait', () => {
+    it('should call setImplicitWait when given an integer', async () => {
+      driver.implicitWait(42);
+      implicitWaitSpy.calledOnce.should.be.true;
+      implicitWaitSpy.firstCall.args[0].should.equal(42);
+      driver.implicitWaitMs.should.eql(42);
+    });
+    it('should call setImplicitWait when given a string', () => {
+      driver.implicitWait('42');
+      implicitWaitSpy.calledOnce.should.be.true;
+      implicitWaitSpy.firstCall.args[0].should.equal(42);
+      driver.implicitWaitMs.should.eql(42);
+    });
+    it('should throw an error if something random is sent', async () => {
+      await driver.implicitWait('howdy').should.eventually.be.rejected;
+    });
+    it('should throw an error if timeout is negative', async () => {
+      await driver.implicitWait(-42).should.eventually.be.rejected;
+    });
+  });
+
+  describe('set implicit wait', () => {
+    it('should set the implicit wait with an integer', () => {
+      driver.setImplicitWait(42);
+      driver.implicitWaitMs.should.eql(42);
+    });
+    describe('with managed driver', () => {
+      let managedDriver1 = new BaseDriver();
+      let managedDriver2 = new BaseDriver();
+      before(() => {
+        driver.addManagedDriver(managedDriver1);
+        driver.addManagedDriver(managedDriver2);
+      });
+      after(() => {
+        driver.managedDrivers = [];
+      });
+      it('should set the implicit wait on managed drivers', () => {
+        driver.setImplicitWait(42);
+        driver.implicitWaitMs.should.eql(42);
+        managedDriver1.implicitWaitMs.should.eql(42);
+        managedDriver2.implicitWaitMs.should.eql(42);
+      });
+    });
+  });
+  describe('set new command timeout', () => {
+    it('should set the new command timeout with an integer', () => {
+      driver.setNewCommandTimeout(42);
+      driver.newCommandTimeoutMs.should.eql(42);
+    });
+    describe('with managed driver', () => {
+      let managedDriver1 = new BaseDriver();
+      let managedDriver2 = new BaseDriver();
+      before(() => {
+        driver.addManagedDriver(managedDriver1);
+        driver.addManagedDriver(managedDriver2);
+      });
+      after(() => {
+        driver.managedDrivers = [];
+      });
+      it('should set the new command timeout on managed drivers', () => {
+        driver.setNewCommandTimeout(42);
+        driver.newCommandTimeoutMs.should.eql(42);
+        managedDriver1.newCommandTimeoutMs.should.eql(42);
+        managedDriver2.newCommandTimeoutMs.should.eql(42);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are getting in the situation where we need to have drivers that manage other drivers (e.g., `appium-xcuitest-driver` has an instance of `appium-safari-driver` that it delegates webbish stuff too). Rather than _ad hoc_ management of these drivers, let's move it into the base driver. 

At the moment only timeouts need to be handled. 