### PR TITLE
Begin adding W3C route alternatives

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -175,16 +175,6 @@ const METHOD_MAP = {
     GET: {command: 'getOrientation'},
     POST: {command: 'setOrientation', payloadParams: {required: ['orientation']}}
   },
-  '/wd/hub/session/:sessionId/alert_text': {
-    GET: {command: 'getAlertText'},
-    POST: {command: 'setAlertText', payloadParams: {required: ['text']}}
-  },
-  '/wd/hub/session/:sessionId/accept_alert': {
-    POST: {command: 'postAcceptAlert'}
-  },
-  '/wd/hub/session/:sessionId/dismiss_alert': {
-    POST: {command: 'postDismissAlert'}
-  },
   '/wd/hub/session/:sessionId/moveto': {
     POST: {command: 'moveTo', payloadParams: {optional: ['element', 'xoffset', 'yoffset']}}
   },
@@ -396,7 +386,37 @@ const METHOD_MAP = {
   },
   '/wd/hub/session/:sessionId/appium/receive_async_response': {
     POST: {command: 'receiveAsyncResponse', payloadParams: {required: ['response']}}
-  }
+  },
+
+
+  /*
+   * The W3C spec has some changes to the wire protocol.
+   * https://w3c.github.io/webdriver/webdriver-spec.html
+   * Begin to add those changes here, keeping the old version
+   * since clients still implement them.
+   */
+  // old alerts
+   '/wd/hub/session/:sessionId/alert_text': {
+     GET: {command: 'getAlertText'},
+     POST: {command: 'setAlertText', payloadParams: {required: ['text']}}
+   },
+   '/wd/hub/session/:sessionId/accept_alert': {
+     POST: {command: 'postAcceptAlert'}
+   },
+   '/wd/hub/session/:sessionId/dismiss_alert': {
+     POST: {command: 'postDismissAlert'}
+   },
+   // https://w3c.github.io/webdriver/webdriver-spec.html#user-prompts
+   '/wd/hub/session/:sessionId/alert/text': {
+     GET: {command: 'getAlertText'},
+     POST: {command: 'setAlertText', payloadParams: {required: ['text']}}
+   },
+   '/wd/hub/session/:sessionId/alert/accept': {
+     POST: {command: 'postAcceptAlert'}
+   },
+   '/wd/hub/session/:sessionId/alert/dismiss': {
+     POST: {command: 'postDismissAlert'}
+   },
 };
 
 // driver command names

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('08ccf63a');
+      hash.should.equal('78590b48');
     });
   });
 


### PR DESCRIPTION
We will, eventually, need to support the new spec, while also supporting the old versions until all the clients are updated. Keep track of that here.