### PR TITLE
Add basic getStatus method

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -55,6 +55,14 @@ class BaseDriver extends MobileJsonWireProtocol {
   }
 
   /*
+   * Overridden in appium driver, but here so that individual drivers can be
+   * tested with clients that poll
+   */
+  async getStatus () {
+    return {};
+  }
+
+  /*
    * Initialize a new onUnexpectedShutdown promise, cancelling existing one.
    */
   resetOnUnexpectedShutdown() {

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -16,6 +16,11 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       d = new DriverClass();
     });
 
+    it('should return an empty status object', async () => {
+      let status = await d.getStatus();
+      status.should.eql({});
+    });
+
     it('should return a sessionId from createSession', async () => {
       let [sessId] = await d.createSession(defaultCaps);
       should.exist(sessId);


### PR DESCRIPTION
Certain clients (like the java client) poll the server to make sure things are ok. The main Appium driver implements a `getStatus` method that returns build information, but if someone is testing against a specific driver their tests cannot even get past the client trying to connect.