### PR TITLE
Refactored mjsonwp with respect to UiAutomator2Driver functionality

### DIFF
--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import { getLogger } from 'appium-logger';
 import { validators } from './validators';
-import { errors, isErrorType, MJSONWPError } from './errors';
+import { errors, isErrorType, MJSONWPError, errorFromCode } from './errors';
 import { METHOD_MAP, NO_SESSION_ID_COMMANDS } from './routes';
 import B from 'bluebird';
-
+import { util } from 'appium-support';
 
 const log = getLogger('MJSONWP');
 const JSONWP_SUCCESS_STATUS_CODE = 0;
@@ -243,6 +243,11 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         log.debug(`Received response: ${_.truncate(JSON.stringify(driverRes), LOG_OBJ_LENGTH)}`);
         log.debug('But deleting session, so not returning');
         driverRes = null;
+      }
+
+      // if the status is not 0,  throw the appropriate error for status code.
+      if (util.hasValue(driverRes) && util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0) {
+        throw errorFromCode(driverRes.status, driverRes.value);
       }
 
       // Response status should be the status set by the driver response.


### PR DESCRIPTION

Added condition in [`mjsonwp.js`](https://github.com/sravanmedarapu/appium-base-driver/blob/master/lib/mjsonwp/mjsonwp.js#L257) to return executed command status (i.e. [`driverRes`](https://github.com/sravanmedarapu/appium-base-driver/blob/master/lib/mjsonwp/mjsonwp.js#L267)) as response if driver is [`UiAutomator2Driver`](https://github.com/sravanmedarapu/appium-base-driver/blob/master/lib/mjsonwp/mjsonwp.js#L249) type.

Issue: https://github.com/appium/appium-uiautomator2-driver/issues/27
