### PR TITLE
Add homescreen endpoint

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -26,7 +26,7 @@ class JWProxy {
   }
 
   endpointRequiresSessionId (endpoint) {
-    return !_.includes(['/session', '/sessions', '/status'], endpoint);
+    return !_.includes(['/session', '/sessions', '/status', '/homescreen'], endpoint);
   }
 
   getUrlForProxy (url) {
@@ -34,7 +34,7 @@ class JWProxy {
       url = '/';
     }
     const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
-    const endpointRe = '(/(session|status))';
+    const endpointRe = '(/(session|status|homescreen))';
     let remainingUrl = '';
     if (/^http/.test(url)) {
       const first = (new RegExp(`(https?://.+)${endpointRe}`)).exec(url);

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -297,6 +297,9 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/is_locked': {
     POST: {command: 'isLocked'}
   },
+  '/wd/hub/session/:sessionId/appium/device/homescreen': {
+    POST: {command: 'homeScreen'}
+  },
   '/wd/hub/session/:sessionId/appium/device/press_keycode': {
     POST: {command: 'pressKeyCode', payloadParams: {required: ['keycode'], optional: ['metastate']}}
   },

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('4ea1ffc6');
+      hash.should.equal('81187725');
     });
   });
 


### PR DESCRIPTION
This is a new endpoint provided by https://github.com/facebook/WebDriverAgent

It can be used to simulate tapping on the home button on an iOS device

```
curl -X POST $JSON_HEADER -d "" $DEVICE_URL/homescreen
```
