### PR TITLE
Allow guinea pig delay to be in query

### DIFF
--- a/lib/express/static.js
+++ b/lib/express/static.js
@@ -13,7 +13,7 @@ if (_.isNull(path.resolve(__dirname).match(/build[\/\\]lib[\/\\]express$/))) {
 }
 
 async function guineaPigTemplate (req, res, page) {
-  let delay = req.params.delay ? parseInt(req.params.delay, 10) : 0;
+  let delay = parseInt(req.params.delay || req.query.delay || 0);
   let params = {
     serverTime: parseInt(Date.now() / 1000, 10),
     userAgent: req.headers['user-agent'],
@@ -23,7 +23,10 @@ async function guineaPigTemplate (req, res, page) {
     params.comment = req.body.comments || params.comment;
   }
   log.debug(`Sending guinea pig response with params: ${JSON.stringify(params)}`);
-  await B.delay(delay);
+  if (delay) {
+    log.debug(`Waiting ${delay}ms before responding`);
+    await B.delay(delay);
+  }
   res.set('Content-Type', 'text/html');
   res.cookie('guineacookie1', 'i am a cookie value', {path: '/'});
   res.cookie('guineacookie2', 'cookié2', {path: '/'});


### PR DESCRIPTION
Allow the delay to be specified in either the body or the query params.