### PR TITLE
Add web context check to validate locators

### DIFF
--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -13,22 +13,22 @@ let commands = {}, helpers = {}, extensions = {};
 // { ELEMENT: # }    eg: { ELEMENT: 3 }  or { ELEMENT: 1.023 }
 
 commands.findElement = async function (strategy, selector) {
-  this.validateLocatorStrategy(strategy);
+  this.validateLocatorStrategy(strategy, this.isWebContext());
   return this.findElOrEls(strategy, selector, false);
 };
 
 commands.findElements = async function (strategy, selector) {
-  this.validateLocatorStrategy(strategy);
+  this.validateLocatorStrategy(strategy, this.isWebContext());
   return this.findElOrEls(strategy, selector, true);
 };
 
 commands.findElementFromElement = async function (strategy, selector, elementId) {
-  this.validateLocatorStrategy(strategy);
+  this.validateLocatorStrategy(strategy, this.isWebContext());
   return this.findElOrEls(strategy, selector, false, elementId);
 };
 
 commands.findElementsFromElement = async function (strategy, selector, elementId) {
-  this.validateLocatorStrategy(strategy);
+  this.validateLocatorStrategy(strategy, this.isWebContext());
   return this.findElOrEls(strategy, selector, true, elementId);
 };
 

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -290,6 +290,10 @@ class BaseDriver extends MobileJsonWireProtocol {
   getManagedDrivers () {
     return this.managedDrivers;
   }
+
+  isWebContext () {
+    return false;
+  }
 }
 
 for (let [cmd, fn] of _.toPairs(commands)) {


### PR DESCRIPTION
Add check for web context within the generic find methods. This way sub-classes can implement a `isWebContext` method in order to get the correct checks, rather than needing to implement their own `validateLocatorStrategy` method that is boilerplate.
