### PR TITLE
Removing _truncate for requests for better debugging

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -8,9 +8,8 @@ import { errors } from '../mjsonwp/errors';
 
 
 const log = getLogger('JSONWP Proxy');
-// set a reasonable log length for proxy output, so we can see what is being sent.
-// in the future maybe make this configurable?
-const LOG_LENGTH = 1000;
+// TODO: Make this value configurable as a server side capability
+const LOG_OBJ_LENGTH = 1024; // MAX LENGTH Logged to file / console
 
 class JWProxy {
   constructor (opts = {}) {
@@ -108,13 +107,14 @@ class JWProxy {
       reqOpts.json = null;
     }
 
-    log.info(`Proxying [${method} ${url || "/"}] to [${method} ${newUrl}] ` +
-             (body ? `with body: ${_.truncate(JSON.stringify(body), {length: LOG_LENGTH})}` : 'with no body'));
+    log.debug(`Proxying [${method} ${url || "/"}] to [${method} ${newUrl}] ` +
+             (body ? `with body: ${_.truncate(JSON.stringify(body), {length: LOG_OBJ_LENGTH})}` : 'with no body'));
+
     let res, resBody;
     try {
       res = await this.request(reqOpts);
       resBody = res.body;
-      log.info(`Got response with status ${res.statusCode}: ${_.truncate(JSON.stringify(resBody), {length: LOG_LENGTH})}`);
+      log.debug(`Got response with status ${res.statusCode}: ${_.truncate(JSON.stringify(resBody), {length: LOG_OBJ_LENGTH})}`);
       if (/\/session$/.test(url) && method === 'POST') {
         if (res.statusCode === 200) {
           this.sessionId = resBody.sessionId;

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -9,7 +9,8 @@ import { util } from 'appium-support';
 
 const log = getLogger('MJSONWP');
 const JSONWP_SUCCESS_STATUS_CODE = 0;
-const LOG_OBJ_LENGTH = 250;
+// TODO: Make this value configurable as a server side capability
+const LOG_OBJ_LENGTH = 1024; // MAX LENGTH Logged to file / console
 
 class MJSONWP {}
 
@@ -219,7 +220,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         validators[spec.command](...args);
       }
       // run the driver command wrapped inside the argument validators
-      log.info(`Calling ${driver.constructor.name}.${spec.command}() with args: ` +
+      log.debug(`Calling ${driver.constructor.name}.${spec.command}() with args: ` +
                 _.truncate(JSON.stringify(args), {length: LOG_OBJ_LENGTH}));
 
       if (driver.executeCommand) {
@@ -254,7 +255,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // Response status should be the status set by the driver response.
       httpResBody.status = (_.isNil(driverRes) || _.isUndefined(driverRes.status)) ? JSONWP_SUCCESS_STATUS_CODE : driverRes.status;
       httpResBody.value = driverRes;
-      log.info(`Responding to client with driver.${spec.command}() ` +
+      log.debug(`Responding to client with driver.${spec.command}() ` +
                `result: ${_.truncate(JSON.stringify(driverRes), {length: LOG_OBJ_LENGTH})}`);
     } catch (err) {
       let actualErr = err;


### PR DESCRIPTION
Removing _truncate for requests for better debugging
All the proxied requests are logged truncated in log files. It's hard to identify what was the original request which failed. 
