### PR TITLE
Use keep-alive connection for proxying

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -83,9 +83,14 @@ class JWProxy {
     const reqOpts = {
       url: newUrl,
       method,
-      headers: {'Content-type': 'application/json;charset=UTF-8'},
+      headers: {
+        'Content-type': 'application/json',
+        'user-agent': 'appium',
+        accept: '*/*',
+      },
       resolveWithFullResponse: true,
-      timeout: 240000
+      timeout: 240000,
+      forever: true,
     };
     if (body !== null) {
       if (typeof body !== 'object') {


### PR DESCRIPTION
xcuitest real devices work significantly better if the connection is not closed on each request. Other systems seem to work fine in keep-alive mode, too.