### PR TITLE
add apis to read the performance data

### DIFF
--- a/docs/mjsonwp/protocol-methods.md
+++ b/docs/mjsonwp/protocol-methods.md
@@ -109,6 +109,8 @@ POST        | `/wd/hub/session/{sessionId}/appium/device/shake`                 
 POST        | `/wd/hub/session/{sessionId}/appium/device/lock`                       | Lock the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/unlock`                     | Unlock the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/is_locked`                  | Check whether the device is locked or not.
+POST        | `/wd/hub/session/{sessionId}/appium/performanceData/types`             | returns the information types of the system state which is supported to read as like cpu, memory, network traffic, and battery.
+POST        | `/wd/hub/session/{sessionId}/appium/getPerformanceData`				 | returns the information of the system state which is supported to read as like cpu, memory, network traffic, and battery.
 POST        | `/wd/hub/session/{sessionId}/appium/device/press_keycode`              | Press a particular key code on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/long_press_keycode`         | Press and hold a particular key code on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/keyevent`                   | Send a key code to the device.

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -297,10 +297,10 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/is_locked': {
     POST: {command: 'isLocked'}
   },
-  '/wd/hub/session/:sessionId/performanceData/types': {
+  '/wd/hub/session/:sessionId/appium/performanceData/types': {
     POST: {command: 'getPerformanceDataTypes'}
   },
-  '/wd/hub/session/:sessionId/getPerformanceData': {
+  '/wd/hub/session/:sessionId/appium/getPerformanceData': {
     POST: {command: 'getPerformanceData', payloadParams: {required: ['applicationPackageName', 'performanceDataType']}}
   },
   '/wd/hub/session/:sessionId/appium/device/press_keycode': {

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -297,6 +297,12 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/is_locked': {
     POST: {command: 'isLocked'}
   },
+  '/wd/hub/session/:sessionId/performanceData/types': {
+    POST: {command: 'getPerformanceDataTypes'}
+  },
+  '/wd/hub/session/:sessionId/getPerformanceData': {
+    POST: {command: 'getPerformanceData', payloadParams: {required: ['applicationPackageName', 'performanceDataType']}}
+  },
   '/wd/hub/session/:sessionId/appium/device/press_keycode': {
     POST: {command: 'pressKeyCode', payloadParams: {required: ['keycode'], optional: ['metastate']}}
   },

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('84202c41');
+      hash.should.equal('38fde8e1');
     });
   });
 

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('8c54fd6e');
+      hash.should.equal('84202c41');
     });
   });
 


### PR DESCRIPTION
the appium already has a way to gather the performance data by log.
but If the resulting data format is set to a log file, the user should conduct another parsing to show the data on the screen.
also I think user wants to decide the moment to read the data and associate the performance data and other information.
so I’d like to add apis to gather the performance data.
