### PR TITLE
Add capabilities to create session

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -9,7 +9,7 @@ const METHOD_MAP = {
     GET: {command: 'getStatus'}
   },
   '/wd/hub/session': {
-    POST: {command: 'createSession', payloadParams: {required: ['desiredCapabilities'], optional: ['requiredCapabilities']}}
+    POST: {command: 'createSession', payloadParams: {required: ['desiredCapabilities'], optional: ['requiredCapabilities', 'capabilities']}}
   },
   '/wd/hub/sessions': {
     GET: {command: 'getSessions'}

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('8c54fd6e');
+      hash.should.equal('24791855');
     });
   });
 


### PR DESCRIPTION
There are some third-party libraries that send in "capabilities" (with desired and required capabilities inside) as well as the desired and required capabilities. Appium doesn't like this. None of our drivers use this object, but it should be allowed, 
