### PR TITLE
Make use of os.tmpdir instead of os.tmpDir

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -35,7 +35,7 @@ class BaseDriver extends MobileJsonWireProtocol {
     // restarted
     this.opts.tmpDir = this.opts.tmpDir ||
                        process.env.APPIUM_TMP_DIR ||
-                       os.tmpDir();
+                       os.tmpdir();
 
     // base-driver internals
     this.curCommand = new B((r) => { r(); }); // see note in execute


### PR DESCRIPTION
`os.tmpDir` is deprecated in Node 7. 