### PR TITLE
Added routes for instrumentation tests running

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -394,8 +394,8 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/receive_async_response': {
     POST: {command: 'receiveAsyncResponse', payloadParams: {required: ['response']}}
   },
-  '/wd/hub/session/:sessionId/appium/instrumentation/test': {
-    POST: {command: 'instrumentationClassTest', payloadParams: {required: ['testClass', 'packageName']}}
+  '/wd/hub/session/:sessionId/appium/instrumentation/testcase': {
+    POST: {command: 'instrumentationClassTest', payloadParams: {required: ['class', 'packageName']}}
   },
   '/wd/hub/session/:sessionId/appium/instrumentation/tests': {
     POST: {command: 'instrumentationPackageTest', payloadParams: {required: ['packageName']}}
@@ -403,6 +403,7 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/instrumentation/install': {
     POST: {command: 'instrumentationInstallTest', payloadParams: {required: ['path']}}
   },
+
 
   /*
    * The W3C spec has some changes to the wire protocol.

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -394,7 +394,15 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/receive_async_response': {
     POST: {command: 'receiveAsyncResponse', payloadParams: {required: ['response']}}
   },
-
+  '/wd/hub/session/:sessionId/appium/instrumentation/test': {
+    POST: {command: 'instrumentationClassTest', payloadParams: {required: ['testClass', 'packageName']}}
+  },
+  '/wd/hub/session/:sessionId/appium/instrumentation/tests': {
+    POST: {command: 'instrumentationPackageTest', payloadParams: {required: ['packageName']}}
+  },
+  '/wd/hub/session/:sessionId/appium/instrumentation/install': {
+    POST: {command: 'instrumentationInstallTest', payloadParams: {required: ['path']}}
+  },
 
   /*
    * The W3C spec has some changes to the wire protocol.


### PR DESCRIPTION
I am want to use Appium as infrastructure for running instrumentation tests on multiple devices or emulators by Selenium Grid. This new approach require new routes.

For running instrumentation test in apk 
'/wd/hub/session/:sessionId/appium/instrumentation/test'

For running all instrumentation tests in apk 
'/wd/hub/session/:sessionId/appium/instrumentation/tests'

For installing apk without activity (apk with test)
/wd/hub/session/:sessionId/appium/instrumentation/install