### PR TITLE
Handle zip files from URLs

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -11,6 +11,7 @@ import request from 'request';
 
 
 const ZIP_EXTS = ['.zip', '.ipa'];
+const ZIP_MIME_TYPE = 'application/zip';
 
 async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserName="", windowsSharePassword="") {
   if (_.isNull(app) || _.isUndefined(app)) {
@@ -28,7 +29,9 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
 
   if ((app || '').substring(0, 4).toLowerCase() === 'http') {
     logger.info(`Using downloadable app '${app}'`);
-    newApp = await downloadApp(app, shouldUnzipApp ? '.zip' : appExt);
+    let downloadedApp = await downloadApp(app);
+    newApp = downloadedApp.targetPath;
+    shouldUnzipApp = downloadedApp.contentType === ZIP_MIME_TYPE;
     logger.info(`Downloaded app to '${newApp}'`);
   } else {
     logger.info(`Using local app '${app}'`);
@@ -50,7 +53,7 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
   return newApp;
 }
 
-async function downloadApp (app, appExt) {
+async function downloadApp (app) {
   let appUrl;
   try {
     appUrl = url.parse(app);
@@ -58,20 +61,21 @@ async function downloadApp (app, appExt) {
     throw new Error(`Invalid App URL (${app})`);
   }
 
-  let appPath;
+  let downloadedApp;
   try {
-    appPath = await downloadFile(url.format(appUrl), appExt);
+    downloadedApp = await downloadFile(url.format(appUrl));
   } catch (err) {
     throw new Error(`Problem downloading app from url ${app}: ${err}`);
   }
 
-  return appPath;
+  return downloadedApp;
 }
 
-async function downloadFile (sourceUrl, suffix) {
+async function downloadFile (sourceUrl) {
   // We will be downloading the files to a directory, so make sure it's there
   // This step is not required if you have manually created the directory
-  let targetPath = await tempDir.path({prefix: 'appium-app', suffix});
+  let targetPath = await tempDir.path({prefix: 'appium-app'});
+  let contentType;
 
   // don't use request-promise here, we need streams
   await new B((resolve, reject) => {
@@ -82,13 +86,15 @@ async function downloadFile (sourceUrl, suffix) {
         if (res.statusCode >= 400) {
           reject(`Error downloading file: ${res.statusCode}`);
         }
+        contentType = res.headers['content-type'];
       })
       .pipe(_fs.createWriteStream(targetPath))
       .on('error', reject)
       .on('close', resolve);
   });
   logger.debug(`${sourceUrl} downloaded to ${targetPath}`);
-  return targetPath;
+  logger.debug(`Downloaded file type '${contentType}'`);
+  return {targetPath, contentType};
 }
 
 async function copyLocalZip (localZipPath) {


### PR DESCRIPTION
Addresses https://github.com/appium/appium-base-driver/issues/79

Sometimes you can't tell the file type from a URL. Like URL minimizers or if there are parameters, etc. So just check the content type of the response. If it's a zip file, ensure it gets unzipped in subsequent logic. Otherwise, assume it's an app file.

Works on:
- URL pointing to an APK file
- URL pointing to a ZIP file
- URL pointing to a ZIP file but with parameters in the URL

Note: The `downloadApp` and `downloadFile` functions are exported in helpers. Their signatures have changed. But I did a full grep on all the code from a fresh Appium node install (including node_modules) and saw the only users were inside `helpers.js` so I don't think this is would break anyone.