### PR TITLE
Add routes and docs for device commands

### DIFF
--- a/docs/mjsonwp/protocol-methods.md
+++ b/docs/mjsonwp/protocol-methods.md
@@ -118,6 +118,7 @@ POST        | `/wd/hub/session/{sessionId}/appium/device/install_app`           
 POST        | `/wd/hub/session/{sessionId}/appium/device/remove_app`                 | Remote an app from the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/app_installed`              | Check whether the specified app is installed on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/hide_keyboard`              | Hide the soft keyboard.
+GET         | `/wd/hub/session/{sessionId}/appium/device/is_keyboard_shown`          | Whether or not the soft keyboard is shown.
 POST        | `/wd/hub/session/{sessionId}/appium/device/push_file`                  | Place a file onto the device in a particular place.
 POST        | `/wd/hub/session/{sessionId}/appium/device/pull_file`                  | Retrieve a file from the device's file system.
 POST        | `/wd/hub/session/{sessionId}/appium/device/pull_folder`                | Retrieve a folder from the device's file system.
@@ -127,6 +128,8 @@ POST        | `/wd/hub/session/{sessionId}/appium/device/toggle_wifi`           
 POST        | `/wd/hub/session/{sessionId}/appium/device/toggle_location_services`   | Switch the state of the location service.
 POST        | `/wd/hub/session/{sessionId}/appium/device/open_notifications`         | Open the notifications pane on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/start_activity`             | Start the specified activity on the device.
+GET         | `/wd/hub/session/{sessionId}/appium/device/system_bars`                | Retrieve visibility and bounds information of the status and navigation bars.
+GET         | `/wd/hub/session/{sessionId}/appium/device/display_density`            | Retrieve the display density of the device.
 POST        | `/wd/hub/session/{sessionId}/appium/simulator/touch_id`                | Simulate a successful or failed touch id event on the simulator.
 POST        | `/wd/hub/session/{sessionId}/appium/app/launch`                        | Launch the given application on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/app/close`                         | Close the given application.

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -329,6 +329,9 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/hide_keyboard': {
     POST: {command: 'hideKeyboard', payloadParams: {optional: ['strategy', 'key', 'keyCode', 'keyName']}}
   },
+  '/wd/hub/session/:sessionId/appium/device/is_keyboard_shown': {
+    GET: {command: 'isKeyboardShown'}
+  },
   '/wd/hub/session/:sessionId/appium/device/push_file': {
     POST: {command: 'pushFile', payloadParams: {required: ['path', 'data']}}
   },
@@ -359,6 +362,12 @@ const METHOD_MAP = {
                                                                 'intentAction', 'intentCategory',
                                                                 'intentFlags', 'optionalIntentArguments',
                                                                 'dontStopAppOnReset']}}
+  },
+  '/wd/hub/session/:sessionId/appium/device/system_bars': {
+    GET: {command: 'getSystemBars'}
+  },
+  '/wd/hub/session/:sessionId/appium/device/display_density': {
+    GET: {command: 'getDisplayDensity'}
   },
   '/wd/hub/session/:sessionId/appium/simulator/touch_id': {
     POST: {command: 'touchId', payloadParams: {required: ['match']}}

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('24791855');
+      hash.should.equal('17acd488');
     });
   });
 


### PR DESCRIPTION
For: https://github.com/appium/appium-android-driver/pull/192

It seems a lot of clients have to be updated to support these out of the box. I wasn't able to do `driver.execute('display_density')` in Python because the Appium client uses the Selenium client which does a look up in a table of predefined commands. I assume clients for all the other languages are the same.

Work around to get functionality is to build a URL and make a request without using a client, which is how I tested this.