### PR TITLE
Support `pageLoadStrategy` capability (now supported by chromedriver).

### DIFF
--- a/lib/basedriver/desired-caps.js
+++ b/lib/basedriver/desired-caps.js
@@ -58,7 +58,10 @@ let desiredCapabilityConstraints = {
   },
   locale: {
     isString: true
-  }
+  },
+  pageLoadStrategy: {
+    isString: true
+  },
 };
 
 validator.validators.isString = function (value) {


### PR DESCRIPTION
Chromedriver now supports the `pageLoadStrategy` capability (though they're not desperately keen to tell anyone; it's not in the docs: https://sites.google.com/a/chromium.org/chromedriver/capabilities). It's specified here: https://www.w3.org/TR/webdriver/#dfn-page-load-strategy.

So we'd like to be able to pass it through appium, which requires it to be added to the validation constraints.