### PR TITLE
Do not keep adding sessionId and id to optional parameters

### DIFF
--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -74,10 +74,14 @@ function checkParams (paramSets, jsonObj) {
   }
 
   // some clients pass in the session id in the params
-  optionalParams.push('sessionId');
+  if (optionalParams.indexOf('sessionId') === -1) {
+    optionalParams.push('sessionId');
+  }
 
   // some clients pass in an element id in the params
-  optionalParams.push('id');
+  if (optionalParams.indexOf('id') === -1) {
+    optionalParams.push('id');
+  }
 
   // go through the required parameters and check against our arguments
   for (let params of requiredParams) {
@@ -110,7 +114,6 @@ function makeArgs (reqParams, jsonObj, payloadParams) {
     }
   }
   let args = _.flatten(realRequiredParams).map((p) => jsonObj[p]);
-
   if (payloadParams.optional) {
     args = args.concat(_.flatten(payloadParams.optional).map((p) => jsonObj[p]));
   }
@@ -158,10 +161,8 @@ function routeConfiguringFunction (driver) {
   return function (app) {
     for (let [path, methods] of _.toPairs(METHOD_MAP)) {
       for (let [method, spec] of _.toPairs(methods)) {
-        let isSessCmd = isSessionCommand(spec.command);
-
         // set up the express route handler
-        buildHandler(app, method, path, spec, driver, isSessCmd);
+        buildHandler(app, method, path, spec, driver, isSessionCommand(spec.command));
       }
     }
   };

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('5b035b99');
+      hash.should.equal('f5aec588');
     });
   });
 


### PR DESCRIPTION
Check before adding `sessionId` and `id` to the optional parameters. Otherwise, after a number of sessions, we end up with things like:

```
dbug MJSONWP Calling XCUITestDriver.createSession() with args: [{"safariIgnoreFraudWarning":false,"safariInitialUrl":"http://0.0.0.0:4994/test/guinea-pig","safariAllowPopups":true,"nativeWebTap":true,"browserName":"Safari","platformName":"iOS","platformVersion":"9.3","deviceName":"iPhone 6","automationName":"XCUITest","noReset":true},null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]
```