### PR TITLE
Fix for flick not working on uiautomator2

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -162,6 +162,10 @@ class JWProxy {
   }
 
   async proxyReqRes (req, res) {
+    // req.body has elementId under keyname "element". Uiauotomator2 expects it with keyname "elementId" 
+    // in case of HTTP proxy. Creating a new field with key elementId. 
+    // If field element is not used anywhere else, it can be deleted from body here.
+    req.body['elementId'] = req.body['element'];    
     let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
     res.headers = response.headers;
     res.set('Content-type', response.headers['content-type']);


### PR DESCRIPTION
[Problem]
Flick command on any element does not work with uiautomator2.

[Cause]
Flick command is proxied to Uiautomator2 server running on device.
The server expects command body to have element identifier with keyname "elementId".
But the command is proxied with body having element identifier with key "element".
This was causing uiautomator to not identify element and hence the failure of command.

[Solution]
Added code to replace text "element" with "elementId:" for proxyReqRes commands
before sending command to the proxy server.

[Test]
Verified that flick works after the fix