### PR TITLE
fixing copyFromWindowsShare on Windows 

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -261,7 +261,19 @@ async function mountWindowsShareOnMac (app, mountRoot, windowsUserName, windowsP
 
 async function copyLocallyFromWindowsShare (app, appExt) {
   let fileInfo = await tempDir.open({prefix: 'appium-app', suffix: appExt});
-  return await fs.copyFile(app, fileInfo.path);
+  return await copyFiles(app, fileInfo);
+}
+
+async function copyFiles (source, target) {
+  let infile = _fs.createReadStream(source);
+  let outfile = _fs.createWriteStream(target.path);
+  return new B((resolve, reject) => {
+    infile.pipe(outfile).on('close', () => {
+      resolve(target.path);
+    }).on('error', (err) => {
+      reject(err);
+    });
+  });
 }
 
 function isPackageOrBundle (app) {
@@ -293,4 +305,4 @@ function getSwipeTouchDuration (waitGesture) {
 
 export default { configureApp, downloadApp, downloadFile, copyLocalZip,
                  unzipApp, unzipFile, testZipArchive, isPackageOrBundle,
-                 getCoordDefault, getSwipeTouchDuration, copyFromWindowsNetworkShare };
+                 getCoordDefault, getSwipeTouchDuration, copyFromWindowsNetworkShare, copyFiles };


### PR DESCRIPTION
fixing copyFromWindowsShare on Windows as fs.copy really doesn't do any copy on windows