### PR TITLE
Default to application/json when no Content-Type is supplied

### DIFF
--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -30,6 +30,13 @@ function fixPythonContentType (req, res, next) {
   next();
 }
 
+function defaultToJSONContentType (req, res, next) {
+  if (!req.headers['content-type']) {
+    req.headers['content-type'] = 'application/json';
+  }
+  next();
+}
+
 function catchAllHandler (err, req, res, next) {
   log.error(`Uncaught error: ${err.message}`);
   log.error('Sending generic error response');
@@ -64,4 +71,4 @@ function catch404Handler (req, res) {
   res.status(404).send(`The URL '${req.originalUrl}' did not map to a valid resource`);
 }
 
-export { allowCrossDomain, fixPythonContentType, catchAllHandler, catch404Handler, catch4XXHandler };
+export { allowCrossDomain, fixPythonContentType, defaultToJSONContentType, catchAllHandler, catch404Handler, catch4XXHandler };

--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -6,8 +6,8 @@ import bodyParser from 'body-parser';
 import methodOverride from 'method-override';
 import log from './logger';
 import { startLogFormatter, endLogFormatter } from './express-logging';
-import { allowCrossDomain, fixPythonContentType, catchAllHandler,
-         catch404Handler, catch4XXHandler } from './middleware';
+import { allowCrossDomain, fixPythonContentType, defaultToJSONContentType,
+         catchAllHandler, catch404Handler, catch4XXHandler } from './middleware';
 import { guineaPig, guineaPigScrollable, welcome, STATIC_DIR } from './static';
 import { produceError, produceCrash } from './crash';
 
@@ -75,6 +75,7 @@ function configureServer (app, configureRoutes) {
   // add middlewares
   app.use(allowCrossDomain);
   app.use(fixPythonContentType);
+  app.use(defaultToJSONContentType);
   app.use(bodyParser.urlencoded({extended: true}));
   app.use(methodOverride());
   app.use(catch4XXHandler);

--- a/test/express/server-specs.js
+++ b/test/express/server-specs.js
@@ -18,7 +18,7 @@ describe('server configuration', () => {
     let app = {use: sinon.spy(), all: sinon.spy()};
     let configureRoutes = () => {};
     configureServer(app, configureRoutes);
-    app.use.callCount.should.equal(14);
+    app.use.callCount.should.equal(15);
     app.all.callCount.should.equal(3);
   });
 

--- a/test/mjsonwp/mjsonwp-specs.js
+++ b/test/mjsonwp/mjsonwp-specs.js
@@ -49,6 +49,19 @@ describe('MJSONWP', async () => {
       });
     });
 
+    it('should assume requests without a Content-Type are json requests', async () => {
+      let res = await request({
+        url: 'http://localhost:8181/wd/hub/session/foo/url',
+        method: 'POST',
+        body: JSON.stringify({url: 'http://google.com'}),
+      });
+      JSON.parse(res).should.eql({
+        status: 0,
+        value: "Navigated to: http://google.com",
+        sessionId: "foo"
+      });
+    });
+
     it('should respond to x-www-form-urlencoded as well as json requests', async () => {
       let res = await request({
         url: 'http://localhost:8181/wd/hub/session/foo/url',


### PR DESCRIPTION
The webdriver spec specifies that requests where the method is POST
should be parsed as JSON (see https://www.w3.org/TR/webdriver/#processing-model step 6).

Appium is too restrictive. It only parses as JSON if the application/json
Content-Type is provided, making it incompatible with some Webdriver clients
that follow the spec but don't send a Content-Type header.

This commit makes Appium less restrictive by defaulting to the application/json
Content-Type if none is provided.