### PR TITLE
update required an optional parameters for getting performance

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -301,7 +301,7 @@ const METHOD_MAP = {
     POST: {command: 'getPerformanceDataTypes'}
   },
   '/wd/hub/session/:sessionId/appium/getPerformanceData': {
-    POST: {command: 'getPerformanceData', payloadParams: {required: ['applicationPackageName', 'performanceDataType']}}
+    POST: {command: 'getPerformanceData', payloadParams: {required: ['packageName', 'dataType'], optional: ['dataReadTimeout']}}
   },
   '/wd/hub/session/:sessionId/appium/device/press_keycode': {
     POST: {command: 'pressKeyCode', payloadParams: {required: ['keycode'], optional: ['metastate']}}

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('f5aec588');
+      hash.should.equal('e2fcfcad');
     });
   });
 


### PR DESCRIPTION
To get performance data via https://github.com/appium/java-client/pull/562 , this driver should apply parameters `packageName`, `dataType` and `dataReadTimeout `, not `applicationPackageName` and  `performanceDataType`, I think.

The following log is sending parameters with  `packageName`, `dataType` and `dataReadTimeout`. If I sent parameters with `applicationPackageName` and `performanceDataType`, then Appium return `{}` as the result.

What do you think? @heeseon 

```
[HTTP] --> POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData {"packageName":"io.appium.android.apis","dataType":"cpuinfo","dataReadTimeout":1000}
[debug] [MJSONWP] Calling AppiumDriver.getPerformanceData() with args: ["io.appium.android.apis","cpuinfo",1000,null,null,"b3250db7-4d90-4e52-b0bb-989940cb08ae"]
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running 'adb' with args: ["-P",5037,"shell","dumpsys","cpuinfo","|","grep","'io.appium.android.apis'"]
[debug] [MJSONWP] Responding to client with driver.getPerformanceData() result: [["user","kernel"],["0","0"]]
[HTTP] <-- POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData 200 140 ms - 101 
[HTTP] --> POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData {"packageName":"io.appium.android.apis","dataType":"cpuinfo","dataReadTimeout":1000}
[debug] [MJSONWP] Calling AppiumDriver.getPerformanceData() with args: ["io.appium.android.apis","cpuinfo",1000,null,null,"b3250db7-4d90-4e52-b0bb-989940cb08ae"]
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running 'adb' with args: ["-P",5037,"shell","dumpsys","cpuinfo","|","grep","'io.appium.android.apis'"]
[debug] [MJSONWP] Responding to client with driver.getPerformanceData() result: [["user","kernel"],["0","0"]]
[HTTP] <-- POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData 200 173 ms - 101 
[HTTP] --> POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData {"packageName":"io.appium.android.apis","dataType":"batteryinfo","dataReadTimeout":1000}
[debug] [MJSONWP] Calling AppiumDriver.getPerformanceData() with args: ["io.appium.android.apis","batteryinfo",1000,null,null,"b3250db7-4d90-4e52-b0bb-989940cb08ae"]
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running 'adb' with args: ["-P",5037,"shell","dumpsys","battery","|","grep","'level'"]
[debug] [MJSONWP] Responding to client with driver.getPerformanceData() result: [["power"],["64"]]
[HTTP] <-- POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData 200 106 ms - 90 
[HTTP] --> POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData {"packageName":"io.appium.android.apis","dataType":"memoryinfo","dataReadTimeout":1000}
[debug] [MJSONWP] Calling AppiumDriver.getPerformanceData() with args: ["io.appium.android.apis","memoryinfo",1000,null,null,"b3250db7-4d90-4e52-b0bb-989940cb08ae"]
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running 'adb' with args: ["-P",5037,"shell","dumpsys","meminfo","'io.appium.android.apis'","|","grep","-E","'Native|Dalvik|EGL|GL|TOTAL'"]
[debug] [MJSONWP] Responding to client with driver.getPerformanceData() result: [["totalPrivateDirty","nativePrivateDirty","dalvikPrivateDirty","eglPrivateDirty","glPrivateDirty","totalPss","nativePss","dalvikPss","eglPss","glPss","nativeHeapAllocatedSize","nativeHeapSize"],["35564","3100","2632","27360",null,"37609","3107","2666","27360",null,"7168","1742"]]
[HTTP] <-- POST /wd/hub/session/b3250db7-4d90-4e52-b0bb-989940cb08ae/appium/getPerformanceData 200 392 ms - 353 
```

---

I also try to implement in [ruby_lib](https://github.com/appium/ruby_lib/pull/480)