### PR TITLE
Add warning message for erroneous responses to make debugging easier

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -141,8 +141,17 @@ class JWProxy {
         }
       }
     } catch (e) {
+      let responseError;
+      try {
+        responseError = JSON.parse(e.error);
+      } catch (e1) {
+        if (_.isString(e.error) && e.error.length) {
+          log.warn(`Got unexpected response: ${_.truncate(e.error, 300)}`);
+        }
+        responseError = _.isPlainObject(e.error) ? e.error : null;
+      }
       throw new errors.ProxyRequestError(`Could not proxy command to remote server. `  +
-                        `Original error: ${e.message}`, e.error);
+                          `Original error: ${e.message}`, responseError);
     }
     return [res, resBody];
   }

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -146,7 +146,7 @@ class JWProxy {
         responseError = JSON.parse(e.error);
       } catch (e1) {
         if (_.isString(e.error) && e.error.length) {
-          log.warn(`Got unexpected response: ${_.truncate(e.error, 300)}`);
+          log.warn(`Got unexpected response: ${_.truncate(e.error, {length: 300})}`);
         }
         responseError = _.isPlainObject(e.error) ? e.error : null;
       }


### PR DESCRIPTION
This PR has the same reason as https://github.com/appium/appium-xcuitest-driver/pull/432
After further investigation I realised that only this place of code could throw such type of errors.