### PR TITLE
Add support for optional ‘text’ parameter

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -10,7 +10,7 @@ const METHOD_MAP = {
   },
   '/wd/hub/session': {
     POST: {command: 'createSession', payloadParams: {
-      validate: (jsonObj) => (!jsonObj.capabilities && !jsonObj.desiredCapabilities) && 'we require one of "desiredCapabilities" or "capabilities" object', 
+      validate: (jsonObj) => (!jsonObj.capabilities && !jsonObj.desiredCapabilities) && 'we require one of "desiredCapabilities" or "capabilities" object',
       optional: ['desiredCapabilities', 'requiredCapabilities', 'capabilities']}}
   },
   '/wd/hub/sessions': {
@@ -135,7 +135,7 @@ const METHOD_MAP = {
     GET: {command: 'getText'}
   },
   '/wd/hub/session/:sessionId/element/:elementId/value': {
-    POST: {command: 'setValue', payloadParams: {required: ['value']}}
+    POST: {command: 'setValue', payloadParams: {required: ['value'], optional: ['text']}}
   },
   '/wd/hub/session/:sessionId/keys': {
     POST: {command: 'keys', payloadParams: {required: ['value']}}

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -135,7 +135,9 @@ const METHOD_MAP = {
     GET: {command: 'getText'}
   },
   '/wd/hub/session/:sessionId/element/:elementId/value': {
-    POST: {command: 'setValue', payloadParams: {required: ['value'], optional: ['text']}}
+    POST: {command: 'setValue', payloadParams: {
+      validate: (jsonObj) => (!jsonObj.value && !jsonObj.text) && 'we require one of "text" or "value" object',
+      optional: ['text', 'value']}}
   },
   '/wd/hub/session/:sessionId/keys': {
     POST: {command: 'keys', payloadParams: {required: ['value']}}

--- a/test/mjsonwp/mjsonwp-specs.js
+++ b/test/mjsonwp/mjsonwp-specs.js
@@ -217,18 +217,32 @@ describe('MJSONWP', async () => {
         json: {id: 'baz', sessionId: 'lol', value: ['a']}
       });
 
-      await request({
-        url: 'http://localhost:8181/wd/hub/session/foo/element/bar/value',
-        method: 'POST',
-        json: {id: 'baz'}
-      }).should.eventually.be.rejectedWith("400");
-
       // make sure adding the optional 'id' doesn't clobber a route where we
       // have an actual required 'id'
       await request({
         url: 'http://localhost:8181/wd/hub/session/foo/frame',
         method: 'POST',
         json: {id: 'baz'}
+      });
+    });
+
+    it('should properly handle variable payload for set value call', async () => {
+      await request({
+        url: 'http://localhost:8181/wd/hub/session/foo/element/bar/value',
+        method: 'POST',
+        json: {sessionId: 'lol'}
+      }).should.eventually.be.rejectedWith("400");
+
+      await request({
+        url: 'http://localhost:8181/wd/hub/session/foo/element/bar/value',
+        method: 'POST',
+        json: {sessionId: 'lol', value: ['a'], text: 'bla'}
+      });
+
+      await request({
+        url: 'http://localhost:8181/wd/hub/session/foo/element/bar/value',
+        method: 'POST',
+        json: {sessionId: 'lol', text: 'bla'}
       });
     });
 


### PR DESCRIPTION
This parameter is not a part of W3C spec, although Geckodriver has it implemented and thus webdriver.io as well. I assume it won't hurt us if we just have it here instead of failing on _setValue_ call. Check https://github.com/appium/appium/issues/8253#issuecomment-302482837 for more details.