### PR TITLE
Add route to get current package

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -345,6 +345,9 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/current_activity': {
     GET: {command: 'getCurrentActivity'}
   },
+  '/wd/hub/session/:sessionId/appium/device/current_package': {
+    GET: {command: 'getCurrentPackage'}
+  },
   '/wd/hub/session/:sessionId/appium/device/install_app': {
     POST: {command: 'installApp', payloadParams: {required: ['appPath']}}
   },

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('5165c012');
+      hash.should.equal('354f9c79');
     });
   });
 


### PR DESCRIPTION
`appium` vendor route for getting the current package, mirroring the getting of the current activity, which is already available.

First step in https://github.com/appium/appium/issues/5493