### PR TITLE
Allow downloaded app urls to have query strings

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -18,7 +18,7 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
   }
 
   let newApp = null;
-  let shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(app));
+  let shouldUnzipApp = false;
 
   // check if we're copying from a windows network share
   if (_.startsWith(app, "\\")) {
@@ -27,19 +27,14 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
 
   if ((app || '').substring(0, 4).toLowerCase() === 'http') {
     logger.info(`Using downloadable app '${app}'`);
-    let downloadedApp = await downloadApp(app, shouldUnzipApp ? '.zip' : appExt);
+    let downloadedApp = await downloadApp(app, appExt);
     newApp = downloadedApp.targetPath;
-    // the filetype may not be obvious for certain urls. so check the mime type
-    if (downloadedApp.contentType === ZIP_MIME_TYPE) {
-      shouldUnzipApp = true;
-    }
+    shouldUnzipApp = downloadedApp.shouldUnzipApp;
     logger.info(`Downloaded app to '${newApp}'`);
   } else {
     logger.info(`Using local app '${app}'`);
-    newApp = app;
-    if (shouldUnzipApp) {
-      newApp = await copyLocalZip(app);
-    }
+    shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(app));
+    newApp = shouldUnzipApp ? await copyLocalZip(app) : app;
   }
 
   if (shouldUnzipApp) {
@@ -62,12 +57,20 @@ async function downloadApp (app, appExt) {
     throw new Error(`Invalid App URL (${app})`);
   }
 
+  // check if this is zipped
+  let shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(appUrl.pathname));
+  appExt = shouldUnzipApp ? '.zip' : appExt;
+
   let downloadedApp;
   try {
     downloadedApp = await downloadFile(url.format(appUrl), appExt);
   } catch (err) {
     throw new Error(`Problem downloading app from url ${app}: ${err}`);
   }
+
+  // note that we need to download, either from the extension
+  // the filetype may not be obvious for certain urls. so check the mime type
+  downloadedApp.shouldUnzipApp = shouldUnzipApp || downloadedApp.contentType === ZIP_MIME_TYPE;
 
   return downloadedApp;
 }

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -27,9 +27,10 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
 
   if ((app || '').substring(0, 4).toLowerCase() === 'http') {
     logger.info(`Using downloadable app '${app}'`);
-    let downloadedApp = await downloadApp(app, appExt);
-    newApp = downloadedApp.targetPath;
-    shouldUnzipApp = downloadedApp.shouldUnzipApp;
+    let {targetPath, contentType} = await downloadApp(app, appExt);
+    newApp = targetPath;
+    // the filetype may not be obvious for certain urls, so check the mime type too
+    shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(newApp)) || contentType === ZIP_MIME_TYPE;
     logger.info(`Downloaded app to '${newApp}'`);
   } else {
     logger.info(`Using local app '${app}'`);
@@ -58,8 +59,8 @@ async function downloadApp (app, appExt) {
   }
 
   // check if this is zipped
-  let shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(appUrl.pathname));
-  appExt = shouldUnzipApp ? '.zip' : appExt;
+  let isZipFile = _.includes(ZIP_EXTS, path.extname(appUrl.pathname));
+  appExt = isZipFile ? '.zip' : appExt;
 
   let downloadedApp;
   try {
@@ -67,10 +68,6 @@ async function downloadApp (app, appExt) {
   } catch (err) {
     throw new Error(`Problem downloading app from url ${app}: ${err}`);
   }
-
-  // note that we need to download, either from the extension
-  // the filetype may not be obvious for certain urls. so check the mime type
-  downloadedApp.shouldUnzipApp = shouldUnzipApp || downloadedApp.contentType === ZIP_MIME_TYPE;
 
   return downloadedApp;
 }

--- a/test/basedriver/helpers-e2e-specs.js
+++ b/test/basedriver/helpers-e2e-specs.js
@@ -94,6 +94,12 @@ describe('app download and configuration', () => {
         let contents = await fs.readFile(newAppPath, 'utf8');
         contents.should.eql('this is not really an app\n');
       });
+      it('should download zip file with query string', async () => {
+        let newAppPath = await h.configureApp('http://localhost:8000/FakeIOSApp.app.zip?sv=abc&sr=def', '.app');
+        newAppPath.should.contain('.app');
+        let contents = await fs.readFile(newAppPath, 'utf8');
+        contents.should.eql('this is not really an app\n');
+      });
       it('should download an app file', async () => {
         let newAppPath = await h.configureApp('http://localhost:8000/FakeIOSApp.app', '.app');
         newAppPath.should.contain('.app');
@@ -112,6 +118,13 @@ describe('app download and configuration', () => {
       });
       it('should recognize zip mime types and unzip the downloaded file', async () => {
         let newAppPath = await h.configureApp('http://localhost:8000/FakeAndroidApp.asd?mime-zip', '.apk');
+        newAppPath.should.contain('FakeAndroidApp.apk');
+        newAppPath.should.not.contain('.asd');
+        let contents = await fs.readFile(newAppPath, 'utf8');
+        contents.should.eql('this is not really an apk\n');
+      });
+      it('should recognize zip mime types and unzip the downloaded file with query string', async () => {
+        let newAppPath = await h.configureApp('http://localhost:8000/FakeAndroidApp.asd?mime-zip&sv=abc&sr=def', '.apk');
         newAppPath.should.contain('FakeAndroidApp.apk');
         newAppPath.should.not.contain('.asd');
         let contents = await fs.readFile(newAppPath, 'utf8');


### PR DESCRIPTION
When downloading an app, use the URL's pathname rather than the whole URL to determine if it needs to be unzipped.

Fixes https://github.com/appium/appium/issues/8793