### PR TITLE
Make different pages and links distinguishable

### DIFF
--- a/static/test/guinea-pig-scrollable.html
+++ b/static/test/guinea-pig-scrollable.html
@@ -62,11 +62,15 @@
 I am some page content
 <div id="i_am_an_id" class="i_am_a_class">I am a div</div>
 <a href="/test/guinea-pig2.html" id="i am a link">i am a link</a><br/>
+<a href="#anchor" id="i am an anchor link">i am an anchor link</a><br/>
 <a href="/test/guinea-pig2.html" id="blanklink" target="_blank">i am a new window link</a>
+<a href="/test/guinea-pig3.html" id="guinea pig 3 link">i am a link to page 3</a><br/>
+<a href="/test/guinea-pig4.html" id="guinea pig 4 blank link" target="_blank">i am a new window link to page 4</a>
 <div>i appear 3 times</div>
 <div>i appear 3 times</div>
 <div>i appear 3 times</div>
 <div id="popuplink" onclick="setTimeout(function() { window.open('/test/guinea-pig2.html', 'popupwin'); }, 500);">i cause a popup window</div>
+<div id="guinea pig 5 popup link" onclick="setTimeout(function() { window.open('/test/guinea-pig5.html', 'popupwin'); }, 500);">i cause a popup window with page 5</div>
 <div id="invisible div" style="display:none;">i am invisible</div>
 <div>
   <a id="alert1" href="javascript:void(0);" onclick="alert('I am an alert')">I cause an alert</a>
@@ -113,13 +117,12 @@ I am some page content
   </form>
   </div>
 
-  <p>Server time: <span id="servertime">{{ serverTime }}</span></p>
-  <p>Client time: <span id="clienttime"></span></p>
+  <p>Server time: <span id="servertime"><%= serverTime %></span></p>
+  <p>Client time: <span id="clienttime"><%= parseInt(new Date().getTime() / 1000, 10) %></span></p>
   <script type="text/javascript">
     var uuid;
     try {uuid = window.location.toString().match(/\?(.*)$/)[1]; } catch (ign) {}
     if (uuid) document.title = document.title + " - " + uuid;
-    $("#clienttime").text(parseInt(new Date().getTime() / 1000));
   </script>
 
   <p id="useragent"><%= userAgent %></p>

--- a/static/test/guinea-pig.html
+++ b/static/test/guinea-pig.html
@@ -14,10 +14,13 @@ I am some page content
 <a href="/test/guinea-pig2.html" id="i am a link">i am a link</a><br/>
 <a href="#anchor" id="i am an anchor link">i am an anchor link</a><br/>
 <a href="/test/guinea-pig2.html" id="blanklink" target="_blank">i am a new window link</a>
+<a href="/test/guinea-pig3.html" id="guinea pig 3 link">i am a link to page 3</a><br/>
+<a href="/test/guinea-pig4.html" id="guinea pig 4 blank link" target="_blank">i am a new window link to page 4</a>
 <div>i appear 3 times</div>
 <div>i appear 3 times</div>
 <div>i appear 3 times</div>
 <div id="popuplink" onclick="setTimeout(function() { window.open('/test/guinea-pig2.html', 'popupwin'); }, 500);">i cause a popup window</div>
+<div id="guinea pig 5 popup link" onclick="setTimeout(function() { window.open('/test/guinea-pig5.html', 'popupwin'); }, 500);">i cause a popup window with page 5</div>
 <div id="invisible div" style="display:none;">i am invisible</div>
 <div>
   <a id="alert1" href="javascript:void(0);" onclick="alert('I am an alert')">I cause an alert</a>
@@ -64,13 +67,12 @@ I am some page content
   </form>
   </div>
 
-  <p>Server time: <span id="servertime">{{ serverTime }}</span></p>
-  <p>Client time: <span id="clienttime"></span></p>
+  <p>Server time: <span id="servertime"><%= serverTime %></span></p>
+  <p>Client time: <span id="clienttime"><%= parseInt(new Date().getTime() / 1000, 10) %></span></p>
   <script type="text/javascript">
     var uuid;
     try {uuid = window.location.toString().match(/\?(.*)$/)[1]; } catch (ign) {}
     if (uuid) document.title = document.title + " - " + uuid;
-    $("#clienttime").text(parseInt(new Date().getTime() / 1000));
   </script>
 
   <p id="useragent"><%= userAgent %></p>

--- a/static/test/guinea-pig3.html
+++ b/static/test/guinea-pig3.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Another Page: page 3</title>
+</head>
+<body>
+  Page 3: I am some other page content
+  <div id="i_am_an_id">I am another div</div>
+  <textarea id="only_on_page_3">lol</textarea>
+</body>
+</html>

--- a/static/test/guinea-pig4.html
+++ b/static/test/guinea-pig4.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Another Page: page 4</title>
+</head>
+<body>
+  Page 4: I am some other page content
+  <div id="i_am_an_id">I am another div</div>
+  <textarea id="only_on_page_4">lol</textarea>
+</body>
+</html>

--- a/static/test/guinea-pig5.html
+++ b/static/test/guinea-pig5.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Another Page: page 5</title>
+</head>
+<body>
+  Page 5: I am some other page content
+  <div id="i_am_an_id">I am another div</div>
+  <textarea id="only_on_page_4">lol</textarea>
+</body>
+</html>


### PR DESCRIPTION
We have tests that rely on distinguishing between what links we tap, but most of the links actually open the same page. So change that, so each link opens a distinct page.

This will be a breaking change, unfortunately, since tests that rely on the old behavior will fail unexpectedly with the text they are searching for having been changed.