### PR TITLE
Add driverData property to the base driver class

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -64,6 +64,18 @@ class BaseDriver extends MobileJsonWireProtocol {
     };
   }
 
+  /**
+   * This property is used by AppiumDriver to store the data of the
+   * specific driver sessions. This datacan be later used to adjust
+   * properties for driver instances running in parallel.
+   * Override it in inherited driver classes if necessary.
+   *
+   * @return {object} Driver properties mapping
+   */
+  get driverData () {
+    return {};
+  }
+
   /*
    * make eventHistory a property and return a cloned object so a consumer can't
    * inadvertently change data outside of logEvent


### PR DESCRIPTION
It is better to have this property defined in the base class to avoid the exception thrown by `curSessionDataForDriver` AppiumDriver's method. This error prevents parallel driver instances to be created.