### PR TITLE
Add a possibility to execute commands without queueing them

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -66,7 +66,7 @@ class BaseDriver extends MobileJsonWireProtocol {
 
   /**
    * This property is used by AppiumDriver to store the data of the
-   * specific driver sessions. This datacan be later used to adjust
+   * specific driver sessions. This data can be later used to adjust
    * properties for driver instances running in parallel.
    * Override it in inherited driver classes if necessary.
    *
@@ -74,6 +74,21 @@ class BaseDriver extends MobileJsonWireProtocol {
    */
   get driverData () {
     return {};
+  }
+
+  /**
+   * This property controls the way {#executeCommand} method
+   * handles new driver commands received from the client.
+   * Override it for inherited classes only in special cases.
+   *
+   * @return {boolean} If the returned value is true (default) then all the commands
+   *   received by the particular driver instance are going to be put into the queue,
+   *   so each following command will not be executed until the previous command
+   *   execution is completed. False value disables that queue, so each driver command
+   *   is executed independently and does not wait for anything.
+   */
+  get isCommandsQueueEnabled () {
+    return true;
   }
 
   /*
@@ -195,33 +210,41 @@ class BaseDriver extends MobileJsonWireProtocol {
       throw new errors.NotYetImplementedError();
     }
 
-    // What we're doing here is pretty clever. this.curCommand is always
-    // a promise representing the command currently being executed by the
-    // driver, or the last command executed by the driver (it starts off as
-    // essentially a pre-resolved promise). When a command comes in, we tack it
-    // to the end of this.curCommand, essentially saying we want to execute it
-    // whenever this.curCommand is done. We call this new promise nextCommand,
-    // and its resolution is what we ultimately will return to whomever called
-    // us. Meanwhile, we reset this.curCommand to _be_ nextCommand (but
-    // ignoring any rejections), so that if another command comes into the
-    // server, it gets tacked on to the end of nextCommand. Thus we create
-    // a chain of promises that acts as a queue with single concurrency.
-    let nextCommand = this.curCommand.then(() => { // eslint-disable-line promise/prefer-await-to-then
-      // if we unexpectedly shut down, we need to reject every command in
-      // the queue before we actually try to run it
+    let res;
+    if (this.isCommandsQueueEnabled) {
+      // What we're doing here is pretty clever. this.curCommand is always
+      // a promise representing the command currently being executed by the
+      // driver, or the last command executed by the driver (it starts off as
+      // essentially a pre-resolved promise). When a command comes in, we tack it
+      // to the end of this.curCommand, essentially saying we want to execute it
+      // whenever this.curCommand is done. We call this new promise nextCommand,
+      // and its resolution is what we ultimately will return to whomever called
+      // us. Meanwhile, we reset this.curCommand to _be_ nextCommand (but
+      // ignoring any rejections), so that if another command comes into the
+      // server, it gets tacked on to the end of nextCommand. Thus we create
+      // a chain of promises that acts as a queue with single concurrency.
+      let nextCommand = this.curCommand.then(() => { // eslint-disable-line promise/prefer-await-to-then
+        // if we unexpectedly shut down, we need to reject every command in
+        // the queue before we actually try to run it
+        if (this.shutdownUnexpectedly) {
+          return B.reject(new errors.NoSuchDriverError('The driver was unexpectedly shut down!'));
+        }
+        // We also need to turn the command into a cancellable promise so if we
+        // have an unexpected shutdown event, for example, we can cancel it from
+        // outside, rejecting the current command immediately
+        this.curCommandCancellable = new B((r) => { r(); }).then(() => { // eslint-disable-line promise/prefer-await-to-then
+          return this[cmd](...args);
+        }).cancellable();
+        return this.curCommandCancellable;
+      });
+      this.curCommand = nextCommand.catch(() => {});
+      res = await nextCommand;
+    } else {
       if (this.shutdownUnexpectedly) {
-        return B.reject(new errors.NoSuchDriverError('The driver was unexpectedly shut down!'));
+        throw new errors.NoSuchDriverError('The driver was unexpectedly shut down!');
       }
-      // We also need to turn the command into a cancellable promise so if we
-      // have an unexpected shutdown event, for example, we can cancel it from
-      // outside, rejecting the current command immediately
-      this.curCommandCancellable = new B((r) => { r(); }).then(() => { // eslint-disable-line promise/prefer-await-to-then
-        return this[cmd](...args);
-      }).cancellable();
-      return this.curCommandCancellable;
-    });
-    this.curCommand = nextCommand.catch(() => {});
-    let res = await nextCommand;
+      res = await this[cmd](...args);
+    }
 
     // if we have set a new command timeout (which is the default), start a
     // timer once we've finished executing this command. If we don't clear


### PR DESCRIPTION
This is a "blind" implementation of the feature that we discussed before. I didn't test it with a real client, but it's just how I see it should look like. The next step will be to override _isCommandsQueueEnabled_ property in AppiumDriver to make it return false :)