### PR TITLE
W3C Error Formatting

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -98,9 +98,9 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
 }
 
 // Calls parseCaps and just returns the matchedCaps variable
-function processCaps (caps, constraints = {}, shouldValidateCaps = true) {
+function processCapabilities (caps, constraints = {}, shouldValidateCaps = true) {
   return parseCaps(caps, constraints, shouldValidateCaps).matchedCaps;
 }
 
 
-export default { parseCaps, processCaps, validateCaps, mergeCaps };
+export default { parseCaps, processCapabilities, validateCaps, mergeCaps };

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -191,11 +191,11 @@ class BaseDriver extends MobileJsonWireProtocol {
   /**
    * Test createSession inputs to see if this is a W3C Session or a MJSONWP Session
    */
-  getProtocolFromCaps (desiredCapabilities, requiredCapabilities, capabilities) {
+  determineProtocol (desiredCapabilities, requiredCapabilities, capabilities) {
     if (_.isObject(capabilities) && _.isObject(capabilities.alwaysMatch)) {
-      return 'W3C';
+      return this.protocol = 'W3C';
     }
-    return 'MJSONWP';
+    this.protocol = 'MJSONWP';
   }
 
   // This is the main command handler for the driver. It wraps command
@@ -207,7 +207,7 @@ class BaseDriver extends MobileJsonWireProtocol {
     let startTime = Date.now();
     if (cmd === 'createSession') {
       // If creating a session determine if W3C or MJSONWP protocol was requested and remember the choice
-      this.protocol = this.getProtocolFromCaps(...args);
+      this.determineProtocol(...args);
       this.logEvent(EVENT_SESSION_INIT);
     } else if (cmd === 'deleteSession') {
       this.logEvent(EVENT_SESSION_QUIT_START);

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -188,6 +188,16 @@ class BaseDriver extends MobileJsonWireProtocol {
     return true;
   }
 
+  /**
+   * Test createSession inputs to see if this is a W3C Session or a MJSONWP Session
+   */
+  getProtocolFromCaps (desiredCapabilities, requiredCapabilities, capabilities) {
+    if (_.isObject(capabilities) && _.isObject(capabilities.alwaysMatch)) {
+      return 'W3C';
+    }
+    return 'MJSONWP';
+  }
+
   // This is the main command handler for the driver. It wraps command
   // execution with timeout logic, checking that we have a valid session,
   // and ensuring that we execute commands one at a time. This method is called
@@ -196,6 +206,8 @@ class BaseDriver extends MobileJsonWireProtocol {
     // get start time for this command, and log in special cases
     let startTime = Date.now();
     if (cmd === 'createSession') {
+      // If creating a session determine if W3C or MJSONWP protocol was requested and remember the choice
+      this.protocol = this.getProtocolFromCaps(...args);
       this.logEvent(EVENT_SESSION_INIT);
     } else if (cmd === 'deleteSession') {
       this.logEvent(EVENT_SESSION_QUIT_START);

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -62,6 +62,8 @@ class BaseDriver extends MobileJsonWireProtocol {
     this._eventHistory = {
       commands: [] // commands get a special place
     };
+
+    this.protocol = null;
   }
 
   /**
@@ -188,14 +190,18 @@ class BaseDriver extends MobileJsonWireProtocol {
     return true;
   }
 
+  static DRIVER_PROTOCOL = {
+    W3C: 'W3C',
+    MJSONWP: 'MJSONWP',
+  };
+
   /**
    * Test createSession inputs to see if this is a W3C Session or a MJSONWP Session
    */
-  determineProtocol (desiredCapabilities, requiredCapabilities, capabilities) {
-    if (_.isObject(capabilities) && _.isObject(capabilities.alwaysMatch)) {
-      return this.protocol = 'W3C';
-    }
-    this.protocol = 'MJSONWP';
+  static determineProtocol (desiredCapabilities, requiredCapabilities, capabilities) {
+    return (_.isPlainObject(capabilities) && _.isPlainObject(capabilities.alwaysMatch)) ?
+      BaseDriver.DRIVER_PROTOCOL.W3C :
+      BaseDriver.DRIVER_PROTOCOL.MJSONWP;
   }
 
   // This is the main command handler for the driver. It wraps command
@@ -207,7 +213,7 @@ class BaseDriver extends MobileJsonWireProtocol {
     let startTime = Date.now();
     if (cmd === 'createSession') {
       // If creating a session determine if W3C or MJSONWP protocol was requested and remember the choice
-      this.determineProtocol(...args);
+      this.protocol = BaseDriver.determineProtocol(...args);
       this.logEvent(EVENT_SESSION_INIT);
     } else if (cmd === 'deleteSession') {
       this.logEvent(EVENT_SESSION_QUIT_START);

--- a/lib/mjsonwp/errors.js
+++ b/lib/mjsonwp/errors.js
@@ -5,10 +5,13 @@ import HTTPStatusCodes from 'http-status-codes';
 
 // base error class for all of our errors
 class MJSONWPError extends ES6Error {
-  constructor (msg, jsonwpCode, w3cStatus) {
+  constructor (msg, jsonwpCode, w3cStatus = 400) {
     super(msg);
     this.jsonwpCode = jsonwpCode;
-    this.w3cStatus = w3cStatus || 400; // Most w3c errors are 400 error so make that the default
+    if (this.jsonwpCode === null) {
+      this.jsonwpCode = 13;
+    }
+    this.w3cStatus = w3cStatus;
   }
 }
 
@@ -385,6 +388,7 @@ class BadParametersError extends ES6Error {
       message = `Parameters were incorrect. You sent ${JSON.stringify(actualParams)}, ${errMessage}`;
     }
     super(message);
+    this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
   }
 }
 
@@ -398,6 +402,7 @@ class ProxyRequestError extends ES6Error {
   constructor (err, jsonwp) {
     let message = `Proxy request unsuccessful. ${util.hasValue(jsonwp) ? jsonwp.value : ''}`;
     super(err || message);
+    this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
     if (typeof jsonwp === 'string') {
       this.jsonwp = JSON.parse(jsonwp);
     } else {

--- a/lib/mjsonwp/errors.js
+++ b/lib/mjsonwp/errors.js
@@ -1,12 +1,14 @@
 import ES6Error from 'es6-error';
 import _ from 'lodash';
 import { util } from 'appium-support';
+import HTTPStatusCodes from 'http-status-codes';
 
 // base error class for all of our errors
 class MJSONWPError extends ES6Error {
-  constructor (msg, jsonwpCode) {
+  constructor (msg, jsonwpCode, w3cStatus) {
     super(msg);
     this.jsonwpCode = jsonwpCode;
+    this.w3cStatus = w3cStatus || 400; // Most w3c errors are 400 error so make that the default
   }
 }
 
@@ -14,8 +16,12 @@ class NoSuchDriverError extends MJSONWPError {
   static code () {
     return 6;
   }
+  // W3C Error is called InvalidSessionID
+  static w3cStatus () {
+    return HTTPStatusCodes.NOT_FOUND;
+  }
   constructor (err) {
-    super(err || 'A session is either terminated or not started', NoSuchDriverError.code());
+    super(err || 'A session is either terminated or not started', NoSuchDriverError.code(), NoSuchDriverError.w3cStatus());
   }
 }
 
@@ -23,9 +29,12 @@ class NoSuchElementError extends MJSONWPError {
   static code () {
     return 7;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.NOT_FOUND;
+  }
   constructor (err) {
     super(err || 'An element could not be located on the page using the given ' +
-          'search parameters.', NoSuchElementError.code());
+          'search parameters.', NoSuchElementError.code(), NoSuchElementError.w3cStatus());
   }
 }
 
@@ -43,10 +52,13 @@ class UnknownCommandError extends MJSONWPError {
   static code () {
     return 9;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.NOT_FOUND;
+  }
   constructor (err) {
     super(err || 'The requested resource could not be found, or a request was ' +
           'received using an HTTP method that is not supported by the mapped ' +
-          'resource.', UnknownCommandError.code());
+          'resource.', UnknownCommandError.code(), UnknownCommandError.w3cStatus());
   }
 }
 
@@ -85,6 +97,9 @@ class UnknownError extends MJSONWPError {
   static code () {
     return 13;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
+  }
   constructor (originalError) {
     let origMessage = originalError;
     if (originalError instanceof Error) {
@@ -96,7 +111,25 @@ class UnknownError extends MJSONWPError {
       message = `${message} Original error: ${origMessage}`;
     }
 
-    super(message, UnknownError.code());
+    super(message, UnknownError.code(), UnknownError.w3cStatus());
+  }
+}
+
+class UnknownMethodError extends MJSONWPError {
+  static w3cStatus () {
+    return HTTPStatusCodes.METHOD_NOT_ALLOWED;
+  }
+  constructor (err) {
+    super(err || 'Unknown method.', null, UnknownMethodError.w3cStatus());
+  }
+}
+
+class UnsupportedOperationError extends MJSONWPError {
+  static w3cStatus () {
+    return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
+  }
+  constructor (err) {
+    super(err || 'A server-side error occurred. Command cannot be supported.', null, UnsupportedOperationError.w3cStatus());
   }
 }
 
@@ -114,9 +147,12 @@ class JavaScriptError extends MJSONWPError {
   static code () {
     return 17;
   }
+  static w3cStatus () {
+    return 500;
+  }
   constructor (err) {
     super(err || 'An error occurred while executing user supplied JavaScript.',
-          JavaScriptError.code());
+          JavaScriptError.code(), JavaScriptError.w3cStatus());
   }
 }
 
@@ -134,9 +170,12 @@ class TimeoutError extends MJSONWPError {
   static code () {
     return 21;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.REQUEST_TIMEOUT;
+  }
   constructor (err) {
     super(err || 'An operation did not complete before its timeout expired.',
-          TimeoutError.code());
+          TimeoutError.code(), TimeoutError.w3cStatus());
   }
 }
 
@@ -160,13 +199,25 @@ class InvalidCookieDomainError extends MJSONWPError {
   }
 }
 
+class NoSuchCookieError extends MJSONWPError {
+  static w3cStatus () {
+    return HTTPStatusCodes.NOT_FOUND;
+  }
+  constructor (err) {
+    super(err || 'Could not find cookie', null, NoSuchCookieError.w3cStatus());
+  }
+}
+
 class UnableToSetCookieError extends MJSONWPError {
   static code () {
     return 25;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
+  }
   constructor (err) {
     super(err || 'A request to set a cookie\'s value could not be satisfied.',
-          UnableToSetCookieError.code());
+          UnableToSetCookieError.code(), UnableToSetCookieError.w3cStatus());
   }
 }
 
@@ -174,9 +225,12 @@ class UnexpectedAlertOpenError extends MJSONWPError {
   static code () {
     return 26;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
+  }
   constructor (err) {
     super(err || 'A modal dialog was open, blocking this operation',
-          UnexpectedAlertOpenError.code());
+          UnexpectedAlertOpenError.code(), UnexpectedAlertOpenError.w3cStatus());
   }
 }
 
@@ -194,9 +248,12 @@ class ScriptTimeoutError extends MJSONWPError {
   static code () {
     return 28;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.REQUEST_TIMEOUT;
+  }
   constructor (err) {
     super(err || 'A script did not complete before its timeout expired.',
-          ScriptTimeoutError.code());
+          ScriptTimeoutError.code(), ScriptTimeoutError.w3cStatus());
   }
 }
 
@@ -243,13 +300,16 @@ class SessionNotCreatedError extends MJSONWPError {
   static code () {
     return 33;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
+  }
   constructor (details) {
     let message = 'A new session could not be created.';
     if (details) {
       message += ` Details: ${details}`;
     }
 
-    super(message, SessionNotCreatedError.code());
+    super(message, SessionNotCreatedError.code(), SessionNotCreatedError.w3cStatus());
   }
 }
 
@@ -257,9 +317,12 @@ class MoveTargetOutOfBoundsError extends MJSONWPError {
   static code () {
     return 34;
   }
+  static w3cStatus () {
+    return 500;
+  }
   constructor (err) {
     super(err || 'Target provided for a move action is out of bounds.',
-          MoveTargetOutOfBoundsError.code());
+          MoveTargetOutOfBoundsError.code(), MoveTargetOutOfBoundsError.w3cStatus());
   }
 }
 
@@ -299,6 +362,17 @@ class NotImplementedError extends MJSONWPError {
     super(err || 'Method is not implemented', NotImplementedError.code());
   }
 }
+
+class UnableToCaptureScreen extends MJSONWPError {
+  static w3cStatus () {
+    return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
+  }
+  constructor (err) {
+    super(err || 'Unable to capture screen', null, UnableToCaptureScreen.w3cStatus());
+  }
+}
+
+
 
 class BadParametersError extends ES6Error {
   constructor (requiredParams, actualParams, errMessage) {
@@ -355,6 +429,7 @@ const errors = {NotYetImplementedError,
                 XPathLookupError,
                 TimeoutError,
                 NoSuchWindowError,
+                NoSuchCookieError,
                 InvalidCookieDomainError,
                 UnableToSetCookieError,
                 UnexpectedAlertOpenError,
@@ -369,6 +444,9 @@ const errors = {NotYetImplementedError,
                 NoSuchContextError,
                 InvalidContextError,
                 NoSuchFrameError,
+                UnableToCaptureScreen,
+                UnknownMethodError,
+                UnsupportedOperationError,
                 ProxyRequestError};
 
 // map of error code to error class

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -189,6 +189,14 @@ function getResponseForJsonwpError (err) {
   return [httpStatus, httpResBody];
 }
 
+function getResponseForW3CError (err) {
+  let httpStatus = err.w3cStatus || 400;
+  let httpResBody = err.message;
+  return [httpStatus, httpResBody];
+}
+
+
+
 function routeConfiguringFunction (driver) {
   if (!driver.sessionExists) {
     throw new Error('Drivers used with MJSONWP must implement `sessionExists`');
@@ -311,7 +319,11 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
       // if anything goes wrong, figure out what our response should be
       // based on the type of error that we encountered
-      [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);
+      if (driver.protocol === 'W3C') {
+        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
+      } else {
+        [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);
+      }
     }
 
     // decode the response, which is either a string or json

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -3,6 +3,7 @@ import { logger, util } from 'appium-support';
 import { validators } from './validators';
 import { errors, isErrorType, MJSONWPError, errorFromCode } from './errors';
 import { METHOD_MAP, NO_SESSION_ID_COMMANDS } from './routes';
+import BaseDriver from '../basedriver/driver';
 import B from 'bluebird';
 
 
@@ -190,7 +191,7 @@ function getResponseForJsonwpError (err) {
 }
 
 function getResponseForW3CError (err) {
-  let httpStatus = err.w3cStatus || 400;
+  let httpStatus = err.w3cStatus;
   let httpResBody = err.message;
   return [httpStatus, httpResBody];
 }
@@ -319,7 +320,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
       // if anything goes wrong, figure out what our response should be
       // based on the type of error that we encountered
-      if (driver.protocol === 'W3C') {
+      if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
         [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
       } else {
         [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "colors": "^1.1.2",
     "es6-error": "^2.0.2",
     "express": "^4.13.3",
+    "http-status-codes": "^1.3.0",
     "lodash": "^4.0.0",
     "method-override": "^2.3.5",
     "morgan": "^1.6.1",

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -1,4 +1,4 @@
-import { parseCaps, validateCaps, mergeCaps, processCaps } from '../../lib/basedriver/capabilities';
+import { parseCaps, validateCaps, mergeCaps, processCapabilities } from '../../lib/basedriver/capabilities';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -205,11 +205,11 @@ describe('caps', () => {
 
   describe('#processCaps', () => {
     it('should return "alwaysMatch" if "firstMatch" and "constraints" were not provided', () => {
-      processCaps({}).should.deep.equal({});
+      processCapabilities({}).should.deep.equal({});
     });
 
     it('should return merged caps', () => {
-      processCaps({
+      processCapabilities({
         alwaysMatch: {hello: 'world'},
         firstMatch: [{foo: 'bar'}]
       }).should.deep.equal({hello: 'world', foo: 'bar'});

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -108,6 +108,28 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       await d.deleteSession();
     });
 
+    it('should distinguish between W3C and JSONWP session', async () => {
+      // Test JSONWP// Test W3C (leave first 2 args null because those are the JSONWP args)
+      await d.executeCommand('createSession', {
+        platformName: 'Fake',
+        deviceName: 'Commodore 64',
+      });
+
+      d.protocol.should.equal('MJSONWP');
+      await d.executeCommand('deleteSession');
+
+      // Test W3C (leave first 2 args null because those are the JSONWP args)
+      await d.executeCommand('createSession', null, null, {
+        alwaysMatch: {
+          platformName: 'Fake',
+          deviceName: 'Commodore 64',
+        },
+        firstMatch: [],
+      });
+
+      d.protocol.should.equal('W3C');
+    });
+
     it('should have a method to get driver for a session', async () => {
       let [sessId] = await d.createSession(defaultCaps);
       d.driverForSession(sessId).should.eql(d);

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -109,7 +109,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
     });
 
     it('should distinguish between W3C and JSONWP session', async () => {
-      // Test JSONWP// Test W3C (leave first 2 args null because those are the JSONWP args)
+      // Test JSONWP
       await d.executeCommand('createSession', {
         platformName: 'Fake',
         deviceName: 'Commodore 64',

--- a/test/mjsonwp/errors-specs.js
+++ b/test/mjsonwp/errors-specs.js
@@ -4,6 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
 
 chai.use(chaiAsPromised);
+chai.should();
 
 // Error codes and messages have been added according to JsonWireProtocol see
 // https://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_Codes
@@ -144,5 +145,35 @@ describe('errorFromCode', () => {
     errorFromCode(99)
       .should.have.property('message', 'An unknown server-side error occurred ' +
                                        'while processing the command.');
+  });
+});
+describe('w3c Status Codes', () => {
+  it('should match the correct error codes', function () {
+    let non400Errors = [
+      ['NoSuchDriverError', 404],
+      ['JavaScriptError', 500],
+      ['MoveTargetOutOfBoundsError', 500],
+      ['NoSuchCookieError', 404],
+      ['NoSuchElementError', 404],
+      ['ScriptTimeoutError', 408],
+      ['SessionNotCreatedError', 500],
+      ['TimeoutError', 408],
+      ['UnableToSetCookieError', 500],
+      ['UnableToCaptureScreen', 500],
+      ['UnexpectedAlertOpenError', 500],
+      ['UnknownCommandError', 404],
+      ['UnknownError', 500],
+      ['UnknownMethodError', 405],
+      ['UnsupportedOperationError', 500],
+    ];
+
+    // Test the errors that we don't expect to return 400 code
+    for (let [errorName, expectedErrorCode] of non400Errors) {
+      errors[errorName].should.exist;
+      (new errors[errorName]()).should.have.property('w3cStatus', expectedErrorCode);
+    }
+
+    // Test an error that we expect to return 400 code
+    (new errors.NoSuchFrameError()).should.have.property('w3cStatus', 400);
   });
 });

--- a/test/mjsonwp/fake-driver.js
+++ b/test/mjsonwp/fake-driver.js
@@ -1,4 +1,4 @@
-import { errors, MobileJsonWireProtocol } from '../..';
+import { errors, MobileJsonWireProtocol, BaseDriver } from '../..';
 import _ from 'lodash';
 
 class FakeDriver extends MobileJsonWireProtocol {
@@ -34,6 +34,9 @@ class FakeDriver extends MobileJsonWireProtocol {
   async executeCommand (cmd, ...args) {
     if (!this[cmd]) {
       throw new errors.NotYetImplementedError();
+    }
+    if (cmd === 'createSession') {
+      BaseDriver.prototype.determineProtocol.apply(this, args);
     }
     return await this[cmd](...args);
   }

--- a/test/mjsonwp/fake-driver.js
+++ b/test/mjsonwp/fake-driver.js
@@ -36,7 +36,7 @@ class FakeDriver extends MobileJsonWireProtocol {
       throw new errors.NotYetImplementedError();
     }
     if (cmd === 'createSession') {
-      BaseDriver.prototype.determineProtocol.apply(this, args);
+      this.protocol = BaseDriver.determineProtocol.apply(null, args);
     }
     return await this[cmd](...args);
   }


### PR DESCRIPTION
* Remembers protocol requested in createSession
    * Checks the parameters in 'createSession' and determines if it's W3C or MJSONWP
    * MJSONWP expects `{desiredCapabilities: {...}`; W3C expects `{capabilities: {alwaysMatch: {...}, firstMatch: [{...}, ...]}`
    * Also renamed 'processCaps' to 'processCapabilities'
* Add W3C error format
    * Add W3C status codes to errors
    * When deciding error format to return in mjsonwp.js, check format and then return eitherJSONWP or W3C format

(related to https://github.com/appium/appium/issues/9574)