### PR TITLE
Added route for setDeviceTime

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -302,7 +302,8 @@ const METHOD_MAP = {
     POST: {command: 'mobileShake'}
   },
   '/wd/hub/session/:sessionId/appium/device/system_time': {
-    GET: {command: 'getDeviceTime'}
+    GET: {command: 'getDeviceTime'},
+    POST: {command: 'setDeviceTime', payloadParams: {required: ['datetime']}}
   },
   '/wd/hub/session/:sessionId/appium/device/lock': {
     POST: {command: 'lock', payloadParams: {optional: ['seconds']}}


### PR DESCRIPTION
Implementing setting device time for the Android platform across this repo, appium-android-driver and python-client