### PR TITLE
Handle capabilities prefixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,3 +28,7 @@ export { JWProxy };
 import { codes, getSummaryByCode } from './lib/jsonwp-status/status';
 const statusCodes = codes;
 export { statusCodes, getSummaryByCode };
+
+// W3C capabilities parser
+import { processCapabilities } from './lib/basedriver/capabilities';
+export { processCapabilities };

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { validator } from './desired-caps';
 import { util } from 'appium-support';
+import log from './logger';
 
 // Takes primary caps object and merges it into a secondary caps object.
 // (see https://www.w3.org/TR/webdriver/#dfn-merging-capabilities)
@@ -51,6 +52,47 @@ function validateCaps (caps, constraints = {}, skipPresenceConstraint = false) {
   return caps;
 }
 
+// Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
+const STANDARD_CAPS = ['browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts', 'pageLoadStrategy', 'proxy', 'setWindowRect', 'timeouts', 'unhandledPromptBehavior'];
+
+function isStandardCap (cap) {
+  return !!_.find(STANDARD_CAPS, (standardCap) => standardCap.toLowerCase() === cap.toLowerCase());
+}
+
+// If the 'appium:' prefix was provided and it's a valid capability, strip out the prefix (see https://www.w3.org/TR/webdriver/#dfn-extension-capabilities)
+function stripAppiumPrefixes (caps) {
+  const prefix = 'appium:';
+  const prefixedCaps = _.filter(_.keys(caps), cap => cap.startsWith(prefix));
+  const badPrefixedCaps = [];
+  const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
+    cap.indexOf(':') < 0 && !isStandardCap(cap)
+  ));
+
+  // Strip out the 'appium:' prefix
+  for (let prefixedCap of prefixedCaps) {
+    const strippedCapName = prefixedCap.substr(prefix.length);
+
+    // If it's standard capability that was prefixed, add it to an array of incorrectly prefixed capabilities
+    if (isStandardCap(strippedCapName)) {
+      badPrefixedCaps.push(strippedCapName);
+    }
+
+    // Strip out the prefix
+    caps[strippedCapName] = caps[prefixedCap];
+    delete caps[prefixedCap];
+  }
+
+  // If we found standard caps that were incorrectly prefixed, throw an exception (e.g.: don't accept 'appium:platformName', only accept just 'platformName')
+  if (badPrefixedCaps.length > 0) {
+    throw new Error(`The capabilities ${JSON.stringify(badPrefixedCaps)} are standard capabilities and should not have the "appium:" prefix`);
+  }
+
+  // If client provides non-prefixed, non-standard capabilities, warn them that these should be prefixed
+  if (unprefixedCaps.length > 0) {
+    log.warn(`${JSON.stringify(unprefixedCaps)} are not standard capabilities and should have an extension prefix`);
+  }
+}
+
 // Parse capabilities (based on https://www.w3.org/TR/webdriver/#processing-capabilities)
 function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   if (!_.isObject(caps)) {
@@ -63,12 +105,18 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
     requiredCaps = {};
   }
 
-  requiredCaps = validateCaps(requiredCaps, constraints);
-
   // Reject 'firstMatch' argument if it's not an array (see spec #3.2)
   if (!_.isArray(allFirstMatchCaps)) {
     throw new Error('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must be a JSON array or undefined');
   }
+
+  // Strip out the 'appium:' prefix
+  stripAppiumPrefixes(requiredCaps);
+  for (let firstMatchCaps of allFirstMatchCaps) {
+    stripAppiumPrefixes(firstMatchCaps);
+  }
+
+  requiredCaps = validateCaps(requiredCaps, constraints);
 
   // Validate all of the first match capabilities (see spec #5)
   let validatedFirstMatchCaps = allFirstMatchCaps.map((firstMatchCaps) => {

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -53,19 +53,30 @@ function validateCaps (caps, constraints = {}, skipPresenceConstraint = false) {
 }
 
 // Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
-const STANDARD_CAPS = ['browserName', 'browserVersion', 'platformName', 'acceptInsecureCerts', 'pageLoadStrategy', 'proxy', 'setWindowRect', 'timeouts', 'unhandledPromptBehavior'];
+const STANDARD_CAPS = [
+  'browserName',
+  'browserVersion',
+  'platformName',
+  'acceptInsecureCerts',
+  'pageLoadStrategy',
+  'proxy',
+  'setWindowRect',
+  'timeouts',
+  'unhandledPromptBehavior'
+];
 
 function isStandardCap (cap) {
-  return !!_.find(STANDARD_CAPS, (standardCap) => standardCap.toLowerCase() === cap.toLowerCase());
+  return !!_.find(STANDARD_CAPS, (standardCap) => standardCap.toLowerCase() === `${cap}`.toLowerCase());
 }
 
 // If the 'appium:' prefix was provided and it's a valid capability, strip out the prefix (see https://www.w3.org/TR/webdriver/#dfn-extension-capabilities)
+// (NOTE: Method is destructive and mutates contents of caps)
 function stripAppiumPrefixes (caps) {
   const prefix = 'appium:';
   const prefixedCaps = _.filter(_.keys(caps), cap => cap.startsWith(prefix));
   const badPrefixedCaps = [];
   const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
-    cap.indexOf(':') < 0 && !isStandardCap(cap)
+    cap.includes(':') && !isStandardCap(`${cap}`)
   ));
 
   // Strip out the 'appium:' prefix

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -73,10 +73,10 @@ function isStandardCap (cap) {
 // (NOTE: Method is destructive and mutates contents of caps)
 function stripAppiumPrefixes (caps) {
   const prefix = 'appium:';
-  const prefixedCaps = _.filter(_.keys(caps), cap => cap.startsWith(prefix));
+  const prefixedCaps = _.filter(_.keys(caps), cap => `${cap}`.startsWith(prefix));
   const badPrefixedCaps = [];
   const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
-    cap.includes(':') && !isStandardCap(cap)
+    `${cap}`.includes(':') && !isStandardCap(cap)
   ));
 
   // Strip out the 'appium:' prefix

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -76,7 +76,7 @@ function stripAppiumPrefixes (caps) {
   const prefixedCaps = _.filter(_.keys(caps), cap => cap.startsWith(prefix));
   const badPrefixedCaps = [];
   const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
-    cap.includes(':') && !isStandardCap(`${cap}`)
+    cap.includes(':') && !isStandardCap(cap)
   ));
 
   // Strip out the 'appium:' prefix

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -3,6 +3,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
+chai.should();
 
 describe('caps', () => {
 
@@ -213,6 +214,20 @@ describe('caps', () => {
         alwaysMatch: {hello: 'world'},
         firstMatch: [{foo: 'bar'}]
       }).should.deep.equal({hello: 'world', foo: 'bar'});
+    });
+
+    it('should strip out the "appium:" prefix for non-standard capabilities', () => {
+      processCapabilities({
+        alwaysMatch: {'appium:hello': 'world'},
+        firstMatch: [{'appium:foo': 'bar'}]
+      }).should.deep.equal({hello: 'world', foo: 'bar'});
+    });
+
+    it('should throw an exception if a standard capability (https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities) is prefixed', () => {
+      (() => processCapabilities({
+        alwaysMatch: {'appium:platformName': 'Whatevz'},
+        firstMatch: [{'appium:browserName': 'Anything'}],
+      })).should.throw(/standard capabilities/);
     });
   });
 });

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -5,51 +5,51 @@ import chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 chai.should();
 
-describe('caps', () => {
+describe('caps', function () {
 
   // Tests based on: https://www.w3.org/TR/webdriver/#dfn-validate-caps
-  describe('#validateCaps', () => {
-    it('returns invalid argument error if "capability" is not a JSON object (1)', () => {
+  describe('#validateCaps', function () {
+    it('returns invalid argument error if "capability" is not a JSON object (1)', function () {
       for (let arg of [undefined, null, 1, true, 'string']) {
         (function () { validateCaps(arg); }).should.throw(/must be a JSON object/);
       }
     });
 
-    it('returns result {} by default if caps is empty object and no constraints provided (2)', () => {
+    it('returns result {} by default if caps is empty object and no constraints provided (2)', function () {
       validateCaps({}).should.deep.equal({});
     });
 
-    describe('throws errors if constraints are not met', () => {
-      it('returns invalid argument error if "present" constraint not met on property', () => {
+    describe('throws errors if constraints are not met', function () {
+      it('returns invalid argument error if "present" constraint not met on property', function () {
         (() => validateCaps({}, {foo: {presence: true}})).should.throw(/foo can't be blank/);
       });
 
-      it('returns the capability that was passed in if "skipPresenceConstraint" is false', () => {
+      it('returns the capability that was passed in if "skipPresenceConstraint" is false', function () {
         validateCaps({}, {foo: {presence: true}}, true).should.deep.equal({});
       });
 
-      it('returns invalid argument error if "isString" constraint not met on property', () => {
+      it('returns invalid argument error if "isString" constraint not met on property', function () {
         (() => validateCaps({foo: 1}, {foo: {isString: true}})).should.throw(/foo must be of type string/);
       });
 
-      it('returns invalid argument error if "isNumber" constraint not met on property', () => {
+      it('returns invalid argument error if "isNumber" constraint not met on property', function () {
         (() => validateCaps({foo: 'bar'}, {foo: {isNumber: true}})).should.throw(/foo must be of type number/);
       });
 
-      it('returns invalid argument error if "isBoolean" constraint not met on property', () => {
+      it('returns invalid argument error if "isBoolean" constraint not met on property', function () {
         (() => validateCaps({foo: 'bar'}, {foo: {isBoolean: true}})).should.throw(/foo must be of type boolean/);
       });
 
-      it('returns invalid argument error if "inclusion" constraint not met on property', () => {
+      it('returns invalid argument error if "inclusion" constraint not met on property', function () {
         (() => validateCaps({foo: '3'}, {foo: {inclusionCaseInsensitive: ['1', '2']}})).should.throw(/foo 3 not part of 1,2./);
       });
 
-      it('returns invalid argument error if "inclusionCaseInsensitive" constraint not met on property', () => {
+      it('returns invalid argument error if "inclusionCaseInsensitive" constraint not met on property', function () {
         (() => validateCaps({foo: 'a'}, {foo: {inclusion: ['A', 'B', 'C']}})).should.throw(/foo a is not included in the list/);
       });
     });
 
-    it('should not throw errors if constraints are met', () => {
+    it('should not throw errors if constraints are met', function () {
       let caps = {
         number: 1,
         string: 'string',
@@ -69,20 +69,20 @@ describe('caps', () => {
   });
 
   // Tests based on: https://www.w3.org/TR/webdriver/#dfn-merging-caps
-  describe('#mergeCaps', () => {
-    it('returns a result that is {} by default (1)', () => {
+  describe('#mergeCaps', function () {
+    it('returns a result that is {} by default (1)', function () {
       mergeCaps().should.deep.equal({});
     });
 
-    it('returns a result that matches primary by default (2, 3)', () => {
+    it('returns a result that matches primary by default (2, 3)', function () {
       mergeCaps({hello: 'world'}).should.deep.equal({hello: 'world'});
     });
 
-    it('returns invalid argument error if primary and secondary have matching properties (4)', () => {
+    it('returns invalid argument error if primary and secondary have matching properties (4)', function () {
       (() => mergeCaps({hello: 'world'}, {hello: 'whirl'})).should.throw(/property hello should not exist on both primary and secondary/);
     });
 
-    it('returns a result with keys from primary and secondary together', () => {
+    it('returns a result with keys from primary and secondary together', function () {
       let primary = {
         a: 'a',
         b: 'b',
@@ -98,67 +98,67 @@ describe('caps', () => {
   });
 
   // Tests based on: https://www.w3.org/TR/webdriver/#dfn-matching-caps
-  describe('#matchCaps', () => {
+  describe('#matchCaps', function () {
     // TODO: Do we need this?
   });
 
   // Tests based on: https://www.w3.org/TR/webdriver/#processing-caps
-  describe('#parseCaps', () => {
+  describe('#parseCaps', function () {
     let caps;
 
     beforeEach(() => {
       caps = {};
     });
 
-    it('should return invalid argument if no caps object provided', () => {
+    it('should return invalid argument if no caps object provided', function () {
       (() => parseCaps()).should.throw(/must be a JSON object/);
     });
 
-    it('sets "requiredCaps" to property named "alwaysMatch" (2)', () => {
+    it('sets "requiredCaps" to property named "alwaysMatch" (2)', function () {
       caps.alwaysMatch = {hello: 'world'};
       parseCaps(caps).requiredCaps.should.deep.equal(caps.alwaysMatch);
     });
 
-    it('sets "requiredCaps" to empty JSON object if "alwaysMatch" is not an object (2.1)', () => {
+    it('sets "requiredCaps" to empty JSON object if "alwaysMatch" is not an object (2.1)', function () {
       parseCaps(caps).requiredCaps.should.deep.equal({});
     });
 
-    it('returns invalid argument error if "requiredCaps" don\'t match "constraints" (2.2)', () => {
+    it('returns invalid argument error if "requiredCaps" don\'t match "constraints" (2.2)', function () {
       caps.alwaysMatch = {foo: 1};
       (() => parseCaps(caps, {foo: {isString: true}})).should.throw(/foo must be of type string/);
     });
 
-    it('sets "allFirstMatchCaps" to property named "firstMatch" (3)', () => {
+    it('sets "allFirstMatchCaps" to property named "firstMatch" (3)', function () {
       parseCaps({}, []).allFirstMatchCaps.should.deep.equal([]);
     });
 
-    it('sets "allFirstMatchCaps" to [] if "firstMatch" is undefined (3.1)', () => {
+    it('sets "allFirstMatchCaps" to [] if "firstMatch" is undefined (3.1)', function () {
       parseCaps({}).allFirstMatchCaps.should.deep.equal([]);
     });
 
-    it('returns invalid argument error if "firstMatch" is not an array and is not undefined (3.2)', () => {
+    it('returns invalid argument error if "firstMatch" is not an array and is not undefined (3.2)', function () {
       for (let arg of [null, 1, true, 'string']) {
         caps.firstMatch = arg;
         (function () { parseCaps(caps); }).should.throw(/must be a JSON array or undefined/);
       }
     });
 
-    it('has "validatedFirstMatchCaps" property that is [] by default (4)', () => {
+    it('has "validatedFirstMatchCaps" property that is [] by default (4)', function () {
       parseCaps(caps).validatedFirstMatchCaps.should.deep.equal([]);
     });
 
-    describe('returns a "validatedFirstMatchCaps" array (5)', () => {
-      it('that equals "firstMatch" if firstMatch is one empty object and there are no constraints', () => {
+    describe('returns a "validatedFirstMatchCaps" array (5)', function () {
+      it('that equals "firstMatch" if firstMatch is one empty object and there are no constraints', function () {
         caps.firstMatch = [{}];
         parseCaps(caps).validatedFirstMatchCaps.should.deep.equal(caps.firstMatch);
       });
 
-      it('returns invalid argument error if firstMatch array\'s first argument fails constraints', () => {
+      it('returns invalid argument error if firstMatch array\'s first argument fails constraints', function () {
         caps.firstMatch = [{}];
         (() => parseCaps(caps, {foo: {presence: true}})).should.throw(/foo can't be blank/);
       });
 
-      it('that equals firstMatch if firstMatch contains two objects that pass the provided constraints', () => {
+      it('that equals firstMatch if firstMatch contains two objects that pass the provided constraints', function () {
         caps.alwaysMatch = {
           foo: 'bar'
         };
@@ -177,53 +177,53 @@ describe('caps', () => {
         parseCaps(caps, constraints).validatedFirstMatchCaps.should.deep.equal(caps.firstMatch);
       });
 
-      it('returns invalid argument error if the firstMatch[2] is not an object', () => {
+      it('returns invalid argument error if the firstMatch[2] is not an object', function () {
         caps.firstMatch = [{foo: 'bar'}, 'foo'];
         (() => parseCaps(caps, {})).should.throw(/must be a JSON object/);
       });
     });
 
-    describe('returns a matchedCaps object (6)', () => {
+    describe('returns a matchedCaps object (6)', function () {
       beforeEach(() => {
         caps.alwaysMatch = {hello: 'world'};
       });
 
-      it('which is same as alwaysMatch if firstMatch array is not provided', () => {
+      it('which is same as alwaysMatch if firstMatch array is not provided', function () {
         parseCaps(caps).matchedCaps.should.deep.equal({hello: 'world'});
       });
 
-      it('merges caps together', () => {
+      it('merges caps together', function () {
         caps.firstMatch = [{foo: 'bar'}];
         parseCaps(caps).matchedCaps.should.deep.equal({hello: 'world', foo: 'bar'});
       });
 
-      it('with merged caps', () => {
+      it('with merged caps', function () {
         caps.firstMatch = [{hello: 'bar', foo: 'foo'}, {foo: 'bar'}];
         parseCaps(caps).matchedCaps.should.deep.equal({hello: 'world', foo: 'bar'});
       });
     });
   });
 
-  describe('#processCaps', () => {
-    it('should return "alwaysMatch" if "firstMatch" and "constraints" were not provided', () => {
+  describe('#processCaps', function () {
+    it('should return "alwaysMatch" if "firstMatch" and "constraints" were not provided', function () {
       processCapabilities({}).should.deep.equal({});
     });
 
-    it('should return merged caps', () => {
+    it('should return merged caps', function () {
       processCapabilities({
         alwaysMatch: {hello: 'world'},
         firstMatch: [{foo: 'bar'}]
       }).should.deep.equal({hello: 'world', foo: 'bar'});
     });
 
-    it('should strip out the "appium:" prefix for non-standard capabilities', () => {
+    it('should strip out the "appium:" prefix for non-standard capabilities', function () {
       processCapabilities({
         alwaysMatch: {'appium:hello': 'world'},
         firstMatch: [{'appium:foo': 'bar'}]
       }).should.deep.equal({hello: 'world', foo: 'bar'});
     });
 
-    it('should throw an exception if a standard capability (https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities) is prefixed', () => {
+    it('should throw an exception if a standard capability (https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities) is prefixed', function () {
       (() => processCapabilities({
         alwaysMatch: {'appium:platformName': 'Whatevz'},
         firstMatch: [{'appium:browserName': 'Anything'}],


### PR DESCRIPTION
* Strip out 'appium:' prefixes
* Reject standard capabilities that contain the 'appium:' prefix
* Expose 'processCapabilities' as API method

(see https://www.w3.org/TR/webdriver/#dfn-extension-capabilities for reference)

(related to https://github.com/appium/appium/issues/9785)