### PR TITLE
Support pre-W3C element screenshot endpoint

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -507,6 +507,10 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/execute/async': {
     POST: {command: 'executeAsync', payloadParams: {required: ['script', 'args']}}
   },
+  // Pre-W3C endpoint for element screenshot
+  '/wd/hub/session/:sessionId/screenshot/:elementId': {
+    GET: {command: 'getElementScreenshot'}
+  },
   '/wd/hub/session/:sessionId/element/:elementId/screenshot': {
     GET: {command: 'getElementScreenshot'}
   },

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -40,7 +40,7 @@ describe('MJSONWP', () => {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('346c41c1');
+      hash.should.equal('a991dc46');
     });
   });
 


### PR DESCRIPTION
The new W3C-compatible endpoint is only available since Selenium 3.8.0 (which is currently not supported even by beta version of java client), although I think it costs nothing for us to support the legacy endpoint as well.