### PR TITLE
Add printPageSourceOnFindFailure flag to print source when find fails

### DIFF
--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -1,4 +1,7 @@
-let commands = {}, helpers = {}, extensions = {};
+import log from '../logger';
+
+
+const commands = {}, helpers = {}, extensions = {};
 
 // Override the following function for your own driver, and the rest is taken
 // care of!
@@ -12,24 +15,36 @@ let commands = {}, helpers = {}, extensions = {};
 // Returns an object which adheres to the way the JSON Wire Protocol represents elements:
 // { ELEMENT: # }    eg: { ELEMENT: 3 }  or { ELEMENT: 1.023 }
 
-commands.findElement = async function (strategy, selector) {
+helpers.findElOrElsWithProcessing = async function (strategy, selector, mult, context) {
   this.validateLocatorStrategy(strategy);
-  return this.findElOrEls(strategy, selector, false);
+  try {
+    return await this.findElOrEls(strategy, selector, mult, context);
+  } catch (err) {
+    if (this.opts.printPageSourceOnFindFailure) {
+      const src = await this.getPageSource();
+      log.debug(`Error finding element${mult ? 's' : ''}: ${err.message}`);
+      log.debug(`Page source requested through 'printPageSourceOnFindFailure':`);
+      log.debug(src);
+    }
+    // still want the error to occur
+    throw err;
+  }
+};
+
+commands.findElement = async function (strategy, selector) {
+  return await this.findElOrElsWithProcessing(strategy, selector, false);
 };
 
 commands.findElements = async function (strategy, selector) {
-  this.validateLocatorStrategy(strategy);
-  return this.findElOrEls(strategy, selector, true);
+  return await this.findElOrElsWithProcessing(strategy, selector, true);
 };
 
 commands.findElementFromElement = async function (strategy, selector, elementId) {
-  this.validateLocatorStrategy(strategy);
-  return this.findElOrEls(strategy, selector, false, elementId);
+  return await this.findElOrElsWithProcessing(strategy, selector, false, elementId);
 };
 
 commands.findElementsFromElement = async function (strategy, selector, elementId) {
-  this.validateLocatorStrategy(strategy);
-  return this.findElOrEls(strategy, selector, true, elementId);
+  return await this.findElOrElsWithProcessing(strategy, selector, true, elementId);
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/basedriver/desired-caps.js
+++ b/lib/basedriver/desired-caps.js
@@ -62,7 +62,10 @@ let desiredCapabilityConstraints = {
   },
   eventTimings: {
     isBoolean: true
-  }
+  },
+  printPageSourceOnFindFailure: {
+    isBoolean: true
+  },
 };
 
 validator.validators.isString = function (value) {


### PR DESCRIPTION
Add a capability `printPageSourceOnFindFailure` that, when on, makes the server print the page source at the point of find element failure. We find that quite often when people are having problems with finding elements, the first step is to ask them to check the page source to see if the element is there, and if it has the correct id/class/path/whatever. This makes that easier to accomplish.