### PR TITLE
Fix incorrect identifying of unprefixed caps

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -76,7 +76,7 @@ function stripAppiumPrefixes (caps) {
   const prefixedCaps = _.filter(_.keys(caps), cap => `${cap}`.startsWith(prefix));
   const badPrefixedCaps = [];
   const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
-    !`${cap}`.includes(':') && !isStandardCap(cap)
+    !cap.includes(':') && !isStandardCap(cap)
   ));
 
   // Strip out the 'appium:' prefix

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -76,7 +76,7 @@ function stripAppiumPrefixes (caps) {
   const prefixedCaps = _.filter(_.keys(caps), cap => `${cap}`.startsWith(prefix));
   const badPrefixedCaps = [];
   const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
-    `${cap}`.includes(':') && !isStandardCap(cap)
+    !`${cap}`.includes(':') && !isStandardCap(cap)
   ));
 
   // Strip out the 'appium:' prefix


### PR DESCRIPTION
* Appium logs warnings about W3C caps that aren't prefixed with `appium:`
* Was incorrectly warning about prefixed caps.
* Fix makes it so it warns about unprefixed, non-standard caps.