### PR TITLE
Make sure that temporary files are cleaned up properly while configuring the app

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -21,25 +21,25 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
   let shouldUnzipApp = false;
 
   // check if we're copying from a windows network share
-  if (app.startsWith("\\")) {
-    app = await copyFromWindowsNetworkShare(app, appExt,
+  if (newApp.startsWith("\\")) {
+    newApp = await copyFromWindowsNetworkShare(newApp, appExt,
       mountRoot, windowsShareUserName, windowsSharePassword);
   }
 
-  if (app.startsWith('http') && app.includes('://')) {
-    logger.info(`Using downloadable app '${app}'`);
-    let {targetPath, contentType} = await downloadApp(app, appExt);
+  if (newApp.startsWith('http') && newApp.includes('://')) {
+    logger.info(`Using downloadable app '${newApp}'`);
+    let {targetPath, contentType} = await downloadApp(newApp, appExt);
     newApp = targetPath;
     // the filetype may not be obvious for certain urls, so check the mime type too
     shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(newApp)) || contentType === ZIP_MIME_TYPE;
     logger.info(`Downloaded app to '${newApp}'`);
   } else {
-    logger.info(`Using local app '${app}'`);
-    if (!await fs.exists(app)) {
-      throw new Error(`The application at '${app}' does not exist or is not accessible`);
+    logger.info(`Using local app '${newApp}'`);
+    if (!await fs.exists(newApp)) {
+      throw new Error(`The application at '${newApp}' does not exist or is not accessible`);
     }
-    shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(app));
-    newApp = shouldUnzipApp ? await copyLocalZip(app) : app;
+    shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(newApp));
+    newApp = shouldUnzipApp ? await copyLocalZip(newApp) : newApp;
   }
 
   if (shouldUnzipApp) {

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -12,20 +12,21 @@ const ZIP_EXTS = ['.zip', '.ipa'];
 const ZIP_MIME_TYPE = 'application/zip';
 
 async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserName="", windowsSharePassword="") {
-  if (_.isNull(app) || _.isUndefined(app)) {
+  if (!_.isString(app)) {
     // immediately shortcircuit if not given an app
     return;
   }
 
-  let newApp = null;
+  let newApp = app;
   let shouldUnzipApp = false;
 
   // check if we're copying from a windows network share
-  if (_.startsWith(app, "\\")) {
-    app = await copyFromWindowsNetworkShare(app, appExt, mountRoot, windowsShareUserName, windowsSharePassword);
+  if (app.startsWith("\\")) {
+    app = await copyFromWindowsNetworkShare(app, appExt,
+      mountRoot, windowsShareUserName, windowsSharePassword);
   }
 
-  if ((app || '').substring(0, 4).toLowerCase() === 'http') {
+  if (app.startsWith('http') && app.includes('://')) {
     logger.info(`Using downloadable app '${app}'`);
     let {targetPath, contentType} = await downloadApp(app, appExt);
     newApp = targetPath;
@@ -34,16 +35,28 @@ async function configureApp (app, appExt, mountRoot="Volumes", windowsShareUserN
     logger.info(`Downloaded app to '${newApp}'`);
   } else {
     logger.info(`Using local app '${app}'`);
+    if (!await fs.exists(app)) {
+      throw new Error(`The application at '${app}' does not exist or is not accessible`);
+    }
     shouldUnzipApp = _.includes(ZIP_EXTS, path.extname(app));
     newApp = shouldUnzipApp ? await copyLocalZip(app) : app;
   }
 
   if (shouldUnzipApp) {
-    newApp = await unzipApp(newApp, appExt);
+    logger.info(`Unzipping local app '${newApp}'...`);
+    const archivePath = newApp;
+    try {
+      newApp = await unzipApp(archivePath, appExt);
+    } finally {
+      await fs.rimraf(archivePath);
+    }
     logger.info(`Unzipped local app to '${newApp}'`);
   }
 
   if (path.extname(newApp) !== appExt) {
+    if (newApp !== app) {
+      await fs.rimraf(newApp);
+    }
     throw new Error(`New app path ${newApp} did not have extension ${appExt}`);
   }
 


### PR DESCRIPTION
The current code leaves too many file leftovers behind if the downloaded stuff requires unzipping or some failure happens during the extraction process.