### PR TITLE
Don't validate 'presence' on firstMatch caps

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -132,9 +132,10 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   // Validate all of the first match capabilities (see spec #5)
   let validatedFirstMatchCaps = allFirstMatchCaps.map((firstMatchCaps) => {
     try {
-      return shouldValidateCaps ? validateCaps(firstMatchCaps, constraints) : firstMatchCaps;
+      // Validate firstMatch caps (don't validate 'presence' though, 'presence' is only validated in alwaysMatch)
+      return shouldValidateCaps ? validateCaps(firstMatchCaps, constraints, true) : firstMatchCaps;
     } catch (e) {
-      throw new Error(`The capabilities.firstMatch argument was not valid for the following reason: ${firstMatchCaps} ${e.message}`);
+      throw new Error(`The capabilities.firstMatch argument was not valid for the following reason: ${JSON.stringify(firstMatchCaps)} ${e.message}`);
     }
   });
 

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -229,5 +229,23 @@ describe('caps', function () {
         firstMatch: [{'appium:browserName': 'Anything'}],
       })).should.throw(/standard capabilities/);
     });
+
+    it('should not throw an exception if presence constraint is not met on a firstMatch capability', function () {
+      const caps = processCapabilities({
+        alwaysMatch: {'platformName': 'Fake', 'appium:fakeCap': 'foobar'},
+        firstMatch: [{'foo': 'bar'}],
+      }, {
+        platformName: {
+          presence: true,
+        },
+        fakeCap: {
+          presence: true
+        },
+      });
+
+      caps.platformName.should.equal('Fake');
+      caps.fakeCap.should.equal('foobar');
+      caps.foo.should.equal('bar');
+    });
   });
 });


### PR DESCRIPTION
* Doesn't make sense to validate 'presence' in the firstMatch caps, because the firstMatch caps extend alwaysMatch and is going to miss necessary capabilities
* Only 'alwaysMatch' should validate 'presence'
* Simply set the 'skipPresenceConstraint' in 'validateCaps' to true for firstMatch caps