### PR TITLE
Make it so that 'status' is only returned for MJSONWP

### DIFF
--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -304,7 +304,9 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // Response status should be the status set by the driver response.
-      httpResBody.status = (_.isNil(driverRes) || _.isUndefined(driverRes.status)) ? JSONWP_SUCCESS_STATUS_CODE : driverRes.status;
+      if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP) {
+        httpResBody.status = (_.isNil(driverRes) || _.isUndefined(driverRes.status)) ? JSONWP_SUCCESS_STATUS_CODE : driverRes.status;
+      }
       httpResBody.value = driverRes;
       log.debug(`Responding to client with driver.${spec.command}() ` +
                `result: ${_.truncate(JSON.stringify(driverRes), {length: LOG_OBJ_LENGTH})}`);

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -7,17 +7,17 @@ import { DeviceSettings } from '../..';
 const should = chai.should();
 chai.use(chaiAsPromised);
 
-const w3cCaps = {
-  alwaysMatch: {
-    platformName: 'Fake',
-    deviceName: 'Commodore 64',
-  },
-  firstMatch: [],
-};
-
 // wrap these tests in a function so we can export the tests and re-use them
 // for actual driver implementations
 function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
+  const w3cCaps = {
+    alwaysMatch: Object.assign({}, defaultCaps, {
+      platformName: 'Fake',
+      deviceName: 'Commodore 64',
+    }),
+    firstMatch: [],
+  };
+
   describe('BaseDriver', () => {
 
     let d;
@@ -118,20 +118,20 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
 
     it('should distinguish between W3C and JSONWP session', async () => {
       // Test JSONWP
-      await d.executeCommand('createSession', {
+      await d.executeCommand('createSession', Object.assign({}, defaultCaps, {
         platformName: 'Fake',
         deviceName: 'Commodore 64',
-      });
+      }));
 
       d.protocol.should.equal('MJSONWP');
       await d.executeCommand('deleteSession');
 
       // Test W3C (leave first 2 args null because those are the JSONWP args)
       await d.executeCommand('createSession', null, null, {
-        alwaysMatch: {
+        alwaysMatch: Object.assign({}, defaultCaps, {
           platformName: 'Fake',
           deviceName: 'Commodore 64',
-        },
+        }),
         firstMatch: [],
       });
 
@@ -324,7 +324,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       beforeEach(async () => {
         beforeStartTime = Date.now();
         d.shouldValidateCaps = false;
-        await d.executeCommand('createSession', [defaultCaps]);
+        await d.executeCommand('createSession', defaultCaps);
       });
       describe('#eventHistory', () => {
         it('should have an eventHistory property', () => {

--- a/test/mjsonwp/fake-driver.js
+++ b/test/mjsonwp/fake-driver.js
@@ -5,6 +5,7 @@ class FakeDriver extends MobileJsonWireProtocol {
 
   constructor () {
     super();
+    this.protocol = BaseDriver.DRIVER_PROTOCOL.MJSONWP;
     this.sessionId = null;
     this.jwpProxyActive = false;
   }


### PR DESCRIPTION
Also:
* Make the 'fake-driver' a MJSONWP driver
* Fix unit tests that were broken when being called in 'appium-fake-driver'