### PR TITLE
w3c CreateSession response

### DIFF
--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -283,7 +283,13 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // unpack createSession response
       if (spec.command === 'createSession') {
         newSessionId = driverRes[0];
-        driverRes = driverRes[1];
+        if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP) {
+          driverRes = driverRes[1];
+        } else {
+          driverRes = {
+            capabilities: driverRes[1],
+          };
+        }
       }
 
       // convert undefined to null, but leave all other values the same
@@ -334,7 +340,11 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       res.status(httpStatus).send(httpResBody);
     } else {
       if (newSessionId) {
-        httpResBody.sessionId = newSessionId;
+        if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
+          httpResBody.value.sessionId = newSessionId;
+        } else {
+          httpResBody.sessionId = newSessionId;
+        }
       } else {
         httpResBody.sessionId = req.params.sessionId || null;
       }

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -283,9 +283,8 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // unpack createSession response
       if (spec.command === 'createSession') {
         newSessionId = driverRes[0];
-        if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP) {
-          driverRes = driverRes[1];
-        } else {
+        driverRes = driverRes[1];
+        if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
           driverRes = {
             capabilities: driverRes[1],
           };

--- a/test/mjsonwp/mjsonwp-e2e-specs.js
+++ b/test/mjsonwp/mjsonwp-e2e-specs.js
@@ -390,7 +390,7 @@ describe('MJSONWP', async () => {
         res.status.should.equal(0);
         res.value.should.eql(capabilities);
       });
-      it('should fail with code 408 when starting W3C session and then running a command that throws a TimeoutError', async () => {
+      it.only('should fail with code 408 when starting W3C session and then running a command that throws a TimeoutError', async () => {
         let w3cCaps = {
           alwaysMatch: {
             platformName: 'Fake',
@@ -398,13 +398,14 @@ describe('MJSONWP', async () => {
           },
           firstMatch: [{}],
         };
-        let {sessionId} = await request({
+        let {value} = await request({
           url: 'http://localhost:8181/wd/hub/session',
           method: 'POST',
           json: {
             capabilities: w3cCaps,
           }
         });
+        let sessionId = value.sessionId;
         let {statusCode:badStatusCode} = await request({
           url: `http://localhost:8181/wd/hub/session/${sessionId}/url`,
           method: 'POST',

--- a/test/mjsonwp/mjsonwp-e2e-specs.js
+++ b/test/mjsonwp/mjsonwp-e2e-specs.js
@@ -390,7 +390,7 @@ describe('MJSONWP', async () => {
         res.status.should.equal(0);
         res.value.should.eql(capabilities);
       });
-      it.only('should fail with code 408 when starting W3C session and then running a command that throws a TimeoutError', async () => {
+      it('should fail with code 408 when starting W3C session and then running a command that throws a TimeoutError', async () => {
         let w3cCaps = {
           alwaysMatch: {
             platformName: 'Fake',


### PR DESCRIPTION
* Make it return format like this: https://github.com/jlipps/simple-wd-spec#new-session

```javascript
{
  "capabilities": {
    ...
  },
  "sessionId": "<SESSION_ID>"
}
```