### PR TITLE
Fix implicit wait for w3c

### DIFF
--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -10,6 +10,16 @@ let commands = {}, helpers = {}, extensions = {};
 
 const MIN_TIMEOUT = 0;
 
+commands.timeoutsW3C = async function (type, duration, scriptDuration, pageLoadDuration, implicitDuration) {
+  if (_.isNumber(implicitDuration)) {
+    return this.setImplicitWait(this.parseTimeoutArgument(implicitDuration));
+  } else if (_.isNumber(scriptDuration) || _.isNumber(pageLoadDuration)) {
+    throw new Error(`Not implemented yet for script and pageLoad.`);
+  }
+
+  this.timeouts(type, duration);
+};
+
 commands.timeouts = async function (type, duration) {
   let ms = this.parseTimeoutArgument(duration);
   switch (type) {

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -11,9 +11,15 @@ let commands = {}, helpers = {}, extensions = {};
 
 const MIN_TIMEOUT = 0;
 
-commands.timeoutsW3C = async function (timeoutsObj) {
+// If we define `commands.timeouts` instead of `commands.timeoutsW3C`, the command `timeouts` will be called
+// from other dirver's timeouts. See https://github.com/appium/appium-base-driver/pull/164
+// Arguments will be: [{"protocol":"W3C","implicit":30000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97", ...]
+// eslint-disable-next-line no-unused-vars
+commands.timeoutsW3C = async function (timeoutsObj, ...args) {
   if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
     const {script, pageLoad, implicit} = timeoutsObj;
+    log.debug(`script: ${script}, pageLoad: ${pageLoad}, implicit: ${implicit}`);
+
     if (util.hasValue(script) || util.hasValue(pageLoad)) {
       throw new errors.NotImplementedError('Not implemented yet for script and pageLoad.');
     }
@@ -23,22 +29,19 @@ commands.timeoutsW3C = async function (timeoutsObj) {
     }
   } else {
     const {type, ms} = timeoutsObj;
-    this.timeouts(type, ms);
-  }
-};
+    log.debug(`type: ${type}, ms: ${ms}`);
 
-// TODO: remove and rename timeoutsW3C to timeouts
-commands.timeouts = async function (type, duration) {
-  let ms = this.parseTimeoutArgument(duration);
-  switch (type) {
-    case 'command':
-      this.setNewCommandTimeout(ms);
-      break;
-    case 'implicit':
-      this.setImplicitWait(ms);
-      break;
-    default:
-      throw new Error(`Invalid timeout '${type}'`);
+    let duration = this.parseTimeoutArgument(ms);
+    switch (type) {
+      case 'command':
+        this.setNewCommandTimeout(duration);
+        break;
+      case 'implicit':
+        this.setImplicitWait(duration);
+        break;
+      default:
+        throw new Error(`Invalid timeout '${type}'`);
+    }
   }
 };
 

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -13,18 +13,21 @@ const MIN_TIMEOUT = 0;
 
 commands.timeoutsW3C = async function (timeoutsObj) {
   if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
-    if (util.hasValue(timeoutsObj.script) || util.hasValue(timeoutsObj.pageLoad)) {
+    const {script, pageLoad, implicit} = timeoutsObj;
+    if (util.hasValue(script) || util.hasValue(pageLoad)) {
       throw new errors.NotImplementedError('Not implemented yet for script and pageLoad.');
     }
 
-    if (util.hasValue(timeoutsObj.implicit)) {
-      return this.setImplicitWait(this.parseTimeoutArgument(timeoutsObj.implicit));
+    if (util.hasValue(implicit)) {
+      this.setImplicitWait(this.parseTimeoutArgument(implicit));
     }
+  } else {
+    const {type, ms} = timeoutsObj;
+    this.timeouts(type, ms);
   }
-
-  this.timeouts(timeoutsObj.type, timeoutsObj.ms);
 };
 
+// TODO: remove and rename timeoutsW3C to timeouts
 commands.timeouts = async function (type, duration) {
   let ms = this.parseTimeoutArgument(duration);
   switch (type) {

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -11,10 +11,15 @@ let commands = {}, helpers = {}, extensions = {};
 const MIN_TIMEOUT = 0;
 
 commands.timeoutsW3C = async function (type, duration, scriptDuration, pageLoadDuration, implicitDuration) {
-  if (_.isNumber(implicitDuration)) {
-    return this.setImplicitWait(this.parseTimeoutArgument(implicitDuration));
-  } else if (_.isNumber(scriptDuration) || _.isNumber(pageLoadDuration)) {
-    throw new Error(`Not implemented yet for script and pageLoad.`);
+  if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration) || _.isInteger(implicitDuration)) {
+    if (_.isInteger(implicitDuration)) {
+      this.setImplicitWait(this.parseTimeoutArgument(implicitDuration));
+    }
+
+    if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration)) {
+      throw new Error(`Not implemented yet for script and pageLoad.`);
+    }
+    return;
   }
 
   this.timeouts(type, duration);

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -25,19 +25,18 @@ commands.timeouts = async function (timeoutsObj, ...args) {
     }
 
     if (util.hasValue(implicit)) {
-      this.setImplicitWait(this.parseTimeoutArgument(implicit));
+      this.implicitWait(implicit);
     }
   } else {
     const {type, ms} = timeoutsObj;
     log.debug(`type: ${type}, ms: ${ms}`);
 
-    let duration = this.parseTimeoutArgument(ms);
     switch (type) {
       case 'command':
-        this.setNewCommandTimeout(duration);
+        this.newCommandTimeout(ms);
         break;
       case 'implicit':
-        this.setImplicitWait(duration);
+        this.implicitWait(ms);
         break;
       default:
         throw new Error(`Invalid timeout '${type}'`);
@@ -67,6 +66,10 @@ helpers.setImplicitWait = function (ms) {
       }
     }
   }
+};
+
+commands.newCommandTimeout = async function (ms) {
+  this.setNewCommandTimeout(this.parseTimeoutArgument(ms));
 };
 
 helpers.setNewCommandTimeout = function (ms) {

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -4,22 +4,25 @@ import B from 'bluebird';
 import _ from 'lodash';
 import { util } from 'appium-support';
 import { errors } from '../../mjsonwp';
+import BaseDriver from "../driver";
 
 
 let commands = {}, helpers = {}, extensions = {};
 
 const MIN_TIMEOUT = 0;
 
-commands.timeoutsW3C = async function (type, duration, scriptDuration, pageLoadDuration, implicitDuration) {
-  if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration)) {
-    throw new errors.NotImplementedError('Not implemented yet for script and pageLoad.');
+commands.timeoutsW3C = async function (timeoutsObj) {
+  if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
+    if (util.hasValue(timeoutsObj.script) || util.hasValue(timeoutsObj.pageLoad)) {
+      throw new errors.NotImplementedError('Not implemented yet for script and pageLoad.');
+    }
+
+    if (util.hasValue(timeoutsObj.implicit)) {
+      return this.setImplicitWait(this.parseTimeoutArgument(timeoutsObj.implicit));
+    }
   }
 
-  if (_.isInteger(implicitDuration)) {
-    return this.setImplicitWait(this.parseTimeoutArgument(implicitDuration));
-  }
-
-  this.timeouts(type, duration);
+  this.timeouts(timeoutsObj.type, timeoutsObj.ms);
 };
 
 commands.timeouts = async function (type, duration) {

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -20,12 +20,16 @@ commands.timeouts = async function (timeoutsObj) {
     const {script, pageLoad, implicit} = timeoutsObj;
     log.debug(`script: ${script}, pageLoad: ${pageLoad}, implicit: ${implicit}`);
 
-    if (util.hasValue(script) || util.hasValue(pageLoad)) {
-      throw new errors.NotImplementedError('Not implemented yet for script and pageLoad.');
+    if (util.hasValue(script)) {
+      await this.scriptTimeoutW3C(script);
+    }
+
+    if (util.hasValue(pageLoad)) {
+      await this.pageLoadTimeoutW3C(pageLoad);
     }
 
     if (util.hasValue(implicit)) {
-      this.implicitWait(implicit);
+      await this.implicitWaitW3C(implicit);
     }
   } else {
     const {type, ms} = timeoutsObj;
@@ -33,13 +37,19 @@ commands.timeouts = async function (timeoutsObj) {
 
     switch (type) {
       case 'command':
-        this.newCommandTimeout(ms);
+        await this.newCommandTimeout(ms);
         break;
       case 'implicit':
-        this.implicitWait(ms);
+        await this.implicitWaitMJSONWP(ms);
+        break;
+      case 'page load':
+        await this.pageLoadTimeoutMJSONWP(ms);
+        break;
+      case 'script':
+        await this.scriptTimeoutMJSONWP(ms);
         break;
       default:
-        throw new Error(`Invalid timeout '${type}'`);
+        throw new Error(`'${type}' is not supported`);
     }
   }
 };
@@ -51,8 +61,17 @@ commands.getTimeouts = async function () {
   };
 };
 
+// implicit
+commands.implicitWaitW3C = async function (ms) {
+  await this.implicitWait(ms);
+};
+
+commands.implicitWaitMJSONWP = async function (ms) {
+  await this.implicitWait(ms);
+};
+
 commands.implicitWait = async function (ms) {
-  this.setImplicitWait(this.parseTimeoutArgument(ms));
+  await this.setImplicitWait(this.parseTimeoutArgument(ms));
 };
 
 helpers.setImplicitWait = function (ms) {
@@ -68,6 +87,29 @@ helpers.setImplicitWait = function (ms) {
   }
 };
 
+// pageLoad
+// eslint-disable-next-line no-unused-vars
+commands.pageLoadTimeoutW3C = async function (ms) {
+  throw new errors.NotImplementedError('Not implemented yet for pageLoad.');
+};
+
+// eslint-disable-next-line no-unused-vars
+commands.pageLoadTimeoutMJSONWP = async function (ms) {
+  throw new errors.NotImplementedError('Not implemented yet for pageLoad.');
+};
+
+// script
+// eslint-disable-next-line no-unused-vars
+commands.scriptTimeoutW3C = async function (ms) {
+  throw new errors.NotImplementedError('Not implemented yet for script.');
+};
+
+// eslint-disable-next-line no-unused-vars
+commands.scriptTimeoutMJSONWP = async function (ms) {
+  throw new errors.NotImplementedError('Not implemented yet for script.');
+};
+
+// command
 commands.newCommandTimeout = async function (ms) {
   this.setNewCommandTimeout(this.parseTimeoutArgument(ms));
 };

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -15,7 +15,7 @@ const MIN_TIMEOUT = 0;
 // from other dirver's timeouts. See https://github.com/appium/appium-base-driver/pull/164
 // Arguments will be: [{"protocol":"W3C","implicit":30000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97", ...]
 // eslint-disable-next-line no-unused-vars
-commands.timeouts = async function (timeoutsObj, ...args) {
+commands.timeouts = async function (timeoutsObj) {
   if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
     const {script, pageLoad, implicit} = timeoutsObj;
     log.debug(`script: ${script}, pageLoad: ${pageLoad}, implicit: ${implicit}`);

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -15,7 +15,7 @@ const MIN_TIMEOUT = 0;
 // from other dirver's timeouts. See https://github.com/appium/appium-base-driver/pull/164
 // Arguments will be: [{"protocol":"W3C","implicit":30000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97", ...]
 // eslint-disable-next-line no-unused-vars
-commands.timeoutsW3C = async function (timeoutsObj, ...args) {
+commands.timeouts = async function (timeoutsObj, ...args) {
   if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
     const {script, pageLoad, implicit} = timeoutsObj;
     log.debug(`script: ${script}, pageLoad: ${pageLoad}, implicit: ${implicit}`);

--- a/lib/basedriver/commands/timeout.js
+++ b/lib/basedriver/commands/timeout.js
@@ -11,15 +11,12 @@ let commands = {}, helpers = {}, extensions = {};
 const MIN_TIMEOUT = 0;
 
 commands.timeoutsW3C = async function (type, duration, scriptDuration, pageLoadDuration, implicitDuration) {
-  if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration) || _.isInteger(implicitDuration)) {
-    if (_.isInteger(implicitDuration)) {
-      this.setImplicitWait(this.parseTimeoutArgument(implicitDuration));
-    }
+  if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration)) {
+    throw new errors.NotImplementedError('Not implemented yet for script and pageLoad.');
+  }
 
-    if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration)) {
-      throw new Error(`Not implemented yet for script and pageLoad.`);
-    }
-    return;
+  if (_.isInteger(implicitDuration)) {
+    return this.setImplicitWait(this.parseTimeoutArgument(implicitDuration));
   }
 
   this.timeouts(type, duration);

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -47,7 +47,7 @@ function unwrapParams (paramSets, jsonObj) {
   return res;
 }
 
-function checkParams (paramSets, jsonObj) {
+function checkParams (paramSets, jsonObj, isW3CProtocol) {
   let requiredParams = [];
   let optionalParams = [];
   let receivedParams = _.keys(jsonObj);
@@ -72,7 +72,7 @@ function checkParams (paramSets, jsonObj) {
     // considered to have passed. If it returns something else, that will be the
     // argument to an error which is thrown to the user
     if (paramSets.validate) {
-      let message = paramSets.validate(jsonObj);
+      let message = paramSets.validate(jsonObj, isW3CProtocol);
       if (message) {
         throw new errors.BadParametersError(message, jsonObj);
       }
@@ -259,7 +259,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // ensure that the json payload conforms to the spec
-      checkParams(spec.payloadParams, jsonObj);
+      checkParams(spec.payloadParams, jsonObj, driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C);
       // ensure the session the user is trying to use is valid
 
       // turn the command and json payload into an argument list for

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -47,7 +47,7 @@ function unwrapParams (paramSets, jsonObj) {
   return res;
 }
 
-function checkParams (paramSets, jsonObj, isW3CProtocol) {
+function checkParams (paramSets, jsonObj, protocol) {
   let requiredParams = [];
   let optionalParams = [];
   let receivedParams = _.keys(jsonObj);
@@ -72,7 +72,7 @@ function checkParams (paramSets, jsonObj, isW3CProtocol) {
     // considered to have passed. If it returns something else, that will be the
     // argument to an error which is thrown to the user
     if (paramSets.validate) {
-      let message = paramSets.validate(jsonObj, isW3CProtocol);
+      let message = paramSets.validate(jsonObj, protocol);
       if (message) {
         throw new errors.BadParametersError(message, jsonObj);
       }
@@ -259,7 +259,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // ensure that the json payload conforms to the spec
-      checkParams(spec.payloadParams, jsonObj, driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C);
+      checkParams(spec.payloadParams, jsonObj, driver.protocol);
       // ensure the session the user is trying to use is valid
 
       // turn the command and json payload into an argument list for

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -113,7 +113,7 @@ function checkParams (paramSets, jsonObj, protocol) {
  * on handling parameters. This method returns an array of arguments which will
  * be applied to a command.
  */
-function makeArgs (requestParams, jsonObj, payloadParams) {
+function makeArgs (requestParams, jsonObj, payloadParams, protocol) {
   // We want to pass the "url" parameters to the commands in reverse order
   // since the command will sometimes want to ignore, say, the sessionId.
   // This has the effect of putting sessionId last, which means in JS we can
@@ -148,7 +148,7 @@ function makeArgs (requestParams, jsonObj, payloadParams) {
     // which will be applied to the handling command. For example if it returns
     // [1, 2, 3], we will call `command(1, 2, 3, ...)` (url params are separate
     // from JSON params and get concatenated below).
-    args = payloadParams.makeArgs(jsonObj);
+    args = payloadParams.makeArgs(jsonObj, protocol);
   } else {
     // Otherwise, collect all the required and optional params and flatten them
     // into an argument array
@@ -264,7 +264,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // turn the command and json payload into an argument list for
       // the driver methods
-      let args = makeArgs(req.params, jsonObj, spec.payloadParams || []);
+      let args = makeArgs(req.params, jsonObj, spec.payloadParams || [], driver.protocol);
       let driverRes;
       // validate command args according to MJSONWP
       if (validators[spec.command]) {

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -22,7 +22,23 @@ const METHOD_MAP = {
   },
   '/wd/hub/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
-    POST: {command: 'timeoutsW3C', payloadParams: {optional: ['type', 'ms', 'script', 'pageLoad', 'implicit']}}
+    POST: {command: 'timeoutsW3C', payloadParams: {
+      validate: (jsonObj) => {
+        // W3C requires some of script/pageLoad/implicit like: { "script": 1000, "pageLoad": 7000, "implicit": 5000 }
+        // MJSONWP requires both type and ms like: {"type": "command", "ms": 3000}
+        if (!jsonObj.script && !jsonObj.pageLoad && !jsonObj.implicit) {
+          if (!jsonObj.type && !jsonObj.ms) {
+            return 'We require type and ms for MJSONWP or (script|pageLoad|implicit) for W3C';
+          } else if (!jsonObj.type || !jsonObj.ms) {
+            return 'We require type and ms for MJSONWP';
+          }
+        }
+      },
+      optional: ['type', 'ms', 'script', 'pageLoad', 'implicit']},
+      makeArgs: (jsonObj) => {
+        return [jsonObj.type, jsonObj.ms, jsonObj.script, jsonObj.pageLoad, jsonObj.implicit];
+      }
+    }
   },
   '/wd/hub/session/:sessionId/timeouts/async_script': {
     POST: {command: 'asyncScriptTimeout', payloadParams: {required: ['ms']}}

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -24,7 +24,7 @@ const METHOD_MAP = {
   },
   '/wd/hub/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
-    POST: {command: 'timeoutsW3C', payloadParams: {
+    POST: {command: 'timeouts', payloadParams: {
       validate: (jsonObj, protocolName) => {
         if (protocolName === BaseDriver.DRIVER_PROTOCOL.W3C) {
           if (!util.hasValue(jsonObj.script) && !util.hasValue(jsonObj.pageLoad) && !util.hasValue(jsonObj.implicit)) {

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import BaseDriver from "../basedriver/driver";
+import { util } from 'appium-support';
 
 
 // define the routes, mapping of HTTP methods to particular driver commands,
@@ -23,13 +25,13 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
     POST: {command: 'timeoutsW3C', payloadParams: {
-      validate: (jsonObj, isW3CProtocol) => {
-        if (isW3CProtocol) {
-          if (!jsonObj.script && !jsonObj.pageLoad && !jsonObj.implicit) {
+      validate: (jsonObj, protocol) => {
+        if (protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
+          if (!util.hasValue(jsonObj.script) && !util.hasValue(jsonObj.pageLoad) && !util.hasValue(jsonObj.implicit)) {
             return 'W3C protocol expects one or more of script, pageLoad or implicit';
           }
         } else {
-          if (!jsonObj.type || !jsonObj.ms) {
+          if (!util.hasValue(jsonObj.type) || !util.hasValue(jsonObj.ms)) {
             return 'MJSONWP protocol requires type and ms';
           }
         }

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -22,7 +22,7 @@ const METHOD_MAP = {
   },
   '/wd/hub/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
-    POST: {command: 'timeouts', payloadParams: {required: ['type', 'ms']}}
+    POST: {command: 'timeoutsW3C', payloadParams: {optional: ['type', 'ms', 'script', 'pageLoad', 'implicit']}}
   },
   '/wd/hub/session/:sessionId/timeouts/async_script': {
     POST: {command: 'asyncScriptTimeout', payloadParams: {required: ['ms']}}

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -25,10 +25,10 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
     POST: {command: 'timeoutsW3C', payloadParams: {
-      validate: (jsonObj, protocol) => {
-        if (protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
+      validate: (jsonObj, protocolName) => {
+        if (protocolName === BaseDriver.DRIVER_PROTOCOL.W3C) {
           if (!util.hasValue(jsonObj.script) && !util.hasValue(jsonObj.pageLoad) && !util.hasValue(jsonObj.implicit)) {
-            return 'W3C protocol expects one or more of script, pageLoad or implicit';
+            return 'W3C protocol expects any of script, pageLoad or implicit to be set';
           }
         } else {
           if (!util.hasValue(jsonObj.type) || !util.hasValue(jsonObj.ms)) {
@@ -36,7 +36,7 @@ const METHOD_MAP = {
           }
         }
       },
-      optional: ['type', 'ms', 'script', 'pageLoad', 'implicit']},
+      optional: ['type', 'ms', 'script', 'pageLoad', 'implicit'],
       makeArgs: (jsonObj, protocolName) => {
         if (protocolName === BaseDriver.DRIVER_PROTOCOL.W3C) {
           return [{protocol: protocolName, script: jsonObj.script, pageLoad: jsonObj.pageLoad, implicit: jsonObj.implicit}];
@@ -44,7 +44,7 @@ const METHOD_MAP = {
           return [{protocol: protocolName, type: jsonObj.type, ms: jsonObj.ms}];
         }
       }
-    }
+    }}
   },
   '/wd/hub/session/:sessionId/timeouts/async_script': {
     POST: {command: 'asyncScriptTimeout', payloadParams: {required: ['ms']}}

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -37,8 +37,12 @@ const METHOD_MAP = {
         }
       },
       optional: ['type', 'ms', 'script', 'pageLoad', 'implicit']},
-      makeArgs: (jsonObj) => {
-        return [jsonObj.type, jsonObj.ms, jsonObj.script, jsonObj.pageLoad, jsonObj.implicit];
+      makeArgs: (jsonObj, protocolName) => {
+        if (protocolName === BaseDriver.DRIVER_PROTOCOL.W3C) {
+          return [{protocol: protocolName, script: jsonObj.script, pageLoad: jsonObj.pageLoad, implicit: jsonObj.implicit}];
+        } else {
+          return [{protocol: protocolName, type: jsonObj.type, ms: jsonObj.ms}];
+        }
       }
     }
   },

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -23,14 +23,14 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
     POST: {command: 'timeoutsW3C', payloadParams: {
-      validate: (jsonObj) => {
-        // W3C requires some of script/pageLoad/implicit like: { "script": 1000, "pageLoad": 7000, "implicit": 5000 }
-        // MJSONWP requires both type and ms like: {"type": "command", "ms": 3000}
-        if (!jsonObj.script && !jsonObj.pageLoad && !jsonObj.implicit) {
-          if (!jsonObj.type && !jsonObj.ms) {
-            return 'We require type and ms for MJSONWP or (script|pageLoad|implicit) for W3C';
-          } else if (!jsonObj.type || !jsonObj.ms) {
-            return 'We require type and ms for MJSONWP';
+      validate: (jsonObj, isW3CProtocol) => {
+        if (isW3CProtocol) {
+          if (!jsonObj.script && !jsonObj.pageLoad && !jsonObj.implicit) {
+            return 'W3C protocol expects one or more of script, pageLoad or implicit';
+          }
+        } else {
+          if (!jsonObj.type || !jsonObj.ms) {
+            return 'MJSONWP protocol requires type and ms';
           }
         }
       },

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -24,7 +24,7 @@ const validators = {
   asyncScriptTimeout: (ms) => {
     msValidator(ms);
   },
-  timeouts: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
+  timeoutsW3C: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
     if (isNumber(scriptDuration) || isNumber(pageLoadDuration) || isNumber(implicitDuration)) {
       if (isNumber(scriptDuration)) {
         msValidator(scriptDuration);
@@ -38,6 +38,12 @@ const validators = {
       return;
     }
 
+    msValidator(ms);
+    if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
+      throw new Error(`'${type}' is not a valid timeout type`);
+    }
+  },
+  timeouts: (type, ms) => {
     msValidator(ms);
     if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
       throw new Error(`'${type}' is not a valid timeout type`);

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { util } from 'appium-support';
 
 
 function isNumber (o) {
@@ -27,15 +28,15 @@ const validators = {
   timeoutsW3C: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
     // W3C request to send one or more of the following parameters, script/pageLoad/implicit.
     let hasW3C = false;
-    if (_.isInteger(scriptDuration)) {
+    if (util.hasValue(scriptDuration)) {
       hasW3C = true;
       msValidator(scriptDuration);
     }
-    if (_.isInteger(pageLoadDuration)) {
+    if (util.hasValue(pageLoadDuration)) {
       hasW3C = true;
       msValidator(pageLoadDuration);
     }
-    if (_.isInteger(implicitDuration)) {
+    if (util.hasValue(implicitDuration)) {
       hasW3C = true;
       msValidator(implicitDuration);
     }

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { util } from 'appium-support';
+import BaseDriver from "../basedriver/driver";
 
 
 function isNumber (o) {
@@ -25,30 +26,22 @@ const validators = {
   asyncScriptTimeout: (ms) => {
     msValidator(ms);
   },
-  timeoutsW3C: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
-    // W3C request to send one or more of the following parameters, script/pageLoad/implicit.
-    let hasW3C = false;
-    if (util.hasValue(scriptDuration)) {
-      hasW3C = true;
-      msValidator(scriptDuration);
-    }
-    if (util.hasValue(pageLoadDuration)) {
-      hasW3C = true;
-      msValidator(pageLoadDuration);
-    }
-    if (util.hasValue(implicitDuration)) {
-      hasW3C = true;
-      msValidator(implicitDuration);
-    }
-    if (hasW3C) {
-      return;
-    }
-
-    // For MJSONWP.
-    // If there are no W3C related attribute, we validate values for MJSONWP.
-    msValidator(ms);
-    if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
-      throw new Error(`'${type}' is not a valid timeout type`);
+  timeoutsW3C: (timeoutsObj) => {
+    if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
+      if (util.hasValue(timeoutsObj.script)) {
+        msValidator(timeoutsObj.script);
+      }
+      if (util.hasValue(timeoutsObj.pageLoad)) {
+        msValidator(timeoutsObj.pageLoad);
+      }
+      if (util.hasValue(timeoutsObj.implicit)) {
+        msValidator(timeoutsObj.implicit);
+      }
+    } else {
+      msValidator(timeoutsObj.ms);
+      if (!_.includes(['script', 'implicit', 'page load', 'command'], timeoutsObj.type)) {
+        throw new Error(`'${timeoutsObj.type}' is not a valid timeout type`);
+      }
     }
   },
   timeouts: (type, ms) => {

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { util } from 'appium-support';
 import BaseDriver from "../basedriver/driver";
 
-
 function isNumber (o) {
   return _.isNumber(o) || !_.isNaN(parseInt(o, 10)) || !_.isNaN(parseFloat(o));
 }
@@ -46,13 +45,6 @@ const validators = {
       if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
         throw new Error(`'${type}' is not a valid timeout type`);
       }
-    }
-  },
-  // TODO: remove timtouts and rename timeoutsW3C to timeouts
-  timeouts: (type, ms) => {
-    msValidator(ms);
-    if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
-      throw new Error(`'${type}' is not a valid timeout type`);
     }
   },
   clickCurrent: (button) => {

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -25,19 +25,22 @@ const validators = {
     msValidator(ms);
   },
   timeoutsW3C: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
-    if (isNumber(scriptDuration) || isNumber(pageLoadDuration) || isNumber(implicitDuration)) {
-      if (isNumber(scriptDuration)) {
+    // W3C request to send one or more of the following parameters, script/pageLoad/implicit.
+    if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration) || _.isInteger(implicitDuration)) {
+      if (_.isInteger(scriptDuration)) {
         msValidator(scriptDuration);
       }
-      if (isNumber(pageLoadDuration)) {
+      if (_.isInteger(pageLoadDuration)) {
         msValidator(pageLoadDuration);
       }
-      if (isNumber(implicitDuration)) {
+      if (_.isInteger(implicitDuration)) {
         msValidator(implicitDuration);
       }
       return;
     }
 
+    // For MJSONWP.
+    // If there are no W3C related attribute, we validate values for MJSONWP.
     msValidator(ms);
     if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
       throw new Error(`'${type}' is not a valid timeout type`);

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -28,22 +28,27 @@ const validators = {
   },
   timeoutsW3C: (timeoutsObj) => {
     if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
-      if (util.hasValue(timeoutsObj.script)) {
-        msValidator(timeoutsObj.script);
+      const {script, pageLoad, implicit} = timeoutsObj;
+
+      if (util.hasValue(script)) {
+        msValidator(script);
       }
-      if (util.hasValue(timeoutsObj.pageLoad)) {
-        msValidator(timeoutsObj.pageLoad);
+      if (util.hasValue(pageLoad)) {
+        msValidator(pageLoad);
       }
-      if (util.hasValue(timeoutsObj.implicit)) {
-        msValidator(timeoutsObj.implicit);
+      if (util.hasValue(implicit)) {
+        msValidator(implicit);
       }
     } else {
-      msValidator(timeoutsObj.ms);
-      if (!_.includes(['script', 'implicit', 'page load', 'command'], timeoutsObj.type)) {
-        throw new Error(`'${timeoutsObj.type}' is not a valid timeout type`);
+      const {type, ms} = timeoutsObj;
+
+      msValidator(ms);
+      if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
+        throw new Error(`'${type}' is not a valid timeout type`);
       }
     }
   },
+  // TODO: remove timtouts and rename timeoutsW3C to timeouts
   timeouts: (type, ms) => {
     msValidator(ms);
     if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -25,7 +25,7 @@ const validators = {
   asyncScriptTimeout: (ms) => {
     msValidator(ms);
   },
-  timeoutsW3C: (timeoutsObj) => {
+  timeouts: (timeoutsObj) => {
     if (timeoutsObj.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
       const {script, pageLoad, implicit} = timeoutsObj;
 

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -26,16 +26,20 @@ const validators = {
   },
   timeoutsW3C: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
     // W3C request to send one or more of the following parameters, script/pageLoad/implicit.
-    if (_.isInteger(scriptDuration) || _.isInteger(pageLoadDuration) || _.isInteger(implicitDuration)) {
-      if (_.isInteger(scriptDuration)) {
-        msValidator(scriptDuration);
-      }
-      if (_.isInteger(pageLoadDuration)) {
-        msValidator(pageLoadDuration);
-      }
-      if (_.isInteger(implicitDuration)) {
-        msValidator(implicitDuration);
-      }
+    let hasW3C = false;
+    if (_.isInteger(scriptDuration)) {
+      hasW3C = true;
+      msValidator(scriptDuration);
+    }
+    if (_.isInteger(pageLoadDuration)) {
+      hasW3C = true;
+      msValidator(pageLoadDuration);
+    }
+    if (_.isInteger(implicitDuration)) {
+      hasW3C = true;
+      msValidator(implicitDuration);
+    }
+    if (hasW3C) {
       return;
     }
 

--- a/lib/mjsonwp/validators.js
+++ b/lib/mjsonwp/validators.js
@@ -24,7 +24,20 @@ const validators = {
   asyncScriptTimeout: (ms) => {
     msValidator(ms);
   },
-  timeouts: (type, ms) => {
+  timeouts: (type, ms, scriptDuration, pageLoadDuration, implicitDuration) => {
+    if (isNumber(scriptDuration) || isNumber(pageLoadDuration) || isNumber(implicitDuration)) {
+      if (isNumber(scriptDuration)) {
+        msValidator(scriptDuration);
+      }
+      if (isNumber(pageLoadDuration)) {
+        msValidator(pageLoadDuration);
+      }
+      if (isNumber(implicitDuration)) {
+        msValidator(implicitDuration);
+      }
+      return;
+    }
+
     msValidator(ms);
     if (!_.includes(['script', 'implicit', 'page load', 'command'], type)) {
       throw new Error(`'${type}' is not a valid timeout type`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-base-driver",
-  "version": "2.19.0",
+  "version": "2.18.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3593,6 +3593,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3601,14 +3609,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4472,11 +4472,6 @@
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
-    },
-    "http-status-codes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
-      "integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y="
     },
     "iconv-lite": {
       "version": "0.4.15",
@@ -7108,6 +7103,14 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7117,14 +7120,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringmap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-base-driver",
-  "version": "2.18.4",
+  "version": "2.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3593,14 +3593,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3609,6 +3601,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4472,6 +4472,11 @@
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
+    },
+    "http-status-codes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
+      "integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y="
     },
     "iconv-lite": {
       "version": "0.4.15",
@@ -7103,14 +7108,6 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7120,6 +7117,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringmap": {

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -229,7 +229,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.newCommandTimeoutMs.should.equal(60000);
         });
         it('should be settable through `timeouts`', async () => {
-          await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+          await d.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
           d.newCommandTimeoutMs.should.equal(20);
         });
       });
@@ -238,7 +238,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.implicitWaitMs.should.equal(0);
         });
         it('should be settable through `timeouts`', async () => {
-          await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+          await d.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
           d.implicitWaitMs.should.equal(20);
         });
       });
@@ -252,14 +252,14 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         await d.deleteSession();
       });
       it('should get timeouts that we set', async () => {
-        await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 1000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await d.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 1000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.have.property('implicit', 1000);
-        await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 2000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await d.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 2000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 1000,
           command: 2000,
         });
-        await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await d.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 3000,
           command: 2000,

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -251,14 +251,14 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         await d.deleteSession();
       });
       it('should get timeouts that we set', async () => {
-        await d.timeoutsW3C(null, null, null, null, 1000);
+        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 1000});
         await d.getTimeouts().should.eventually.have.property('implicit', 1000);
-        await d.timeoutsW3C('command', 2000);
+        await d.timeoutsW3C({protocol: 'MJSONWP', type: 'command', ms: 2000});
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 1000,
           command: 2000,
         });
-        await d.timeoutsW3C(null, null, null, null, 3000);
+        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 3000});
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 3000,
           command: 2000,

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -3,6 +3,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { DeviceSettings } from '../..';
+import BaseDriver from "../../lib/basedriver/driver";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -228,7 +229,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.newCommandTimeoutMs.should.equal(60000);
         });
         it('should be settable through `timeouts`', async () => {
-          await d.timeoutsW3C({protocol: 'MJSONWP', type: 'command', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+          await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
           d.newCommandTimeoutMs.should.equal(20);
         });
       });
@@ -237,7 +238,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.implicitWaitMs.should.equal(0);
         });
         it('should be settable through `timeouts`', async () => {
-          await d.timeoutsW3C({protocol: 'MJSONWP', type: 'implicit', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+          await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
           d.implicitWaitMs.should.equal(20);
         });
       });
@@ -251,14 +252,14 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         await d.deleteSession();
       });
       it('should get timeouts that we set', async () => {
-        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 1000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 1000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.have.property('implicit', 1000);
-        await d.timeoutsW3C({protocol: 'MJSONWP', type: 'command', ms: 2000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'command', ms: 2000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 1000,
           command: 2000,
         });
-        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await d.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 3000,
           command: 2000,

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -251,14 +251,14 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         await d.deleteSession();
       });
       it('should get timeouts that we set', async () => {
-        await d.timeouts('implicit', 1000);
+        await d.timeoutsW3C(null, null, null, null, 1000);
         await d.getTimeouts().should.eventually.have.property('implicit', 1000);
-        await d.timeouts('command', 2000);
+        await d.timeoutsW3C('command', 2000);
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 1000,
           command: 2000,
         });
-        await d.timeouts('implicit', 3000);
+        await d.timeoutsW3C(null, null, null, null, 3000);
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 3000,
           command: 2000,

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -228,7 +228,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.newCommandTimeoutMs.should.equal(60000);
         });
         it('should be settable through `timeouts`', async () => {
-          await d.timeouts('command', 20);
+          await d.timeoutsW3C({protocol: 'MJSONWP', type: 'command', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
           d.newCommandTimeoutMs.should.equal(20);
         });
       });
@@ -237,7 +237,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.implicitWaitMs.should.equal(0);
         });
         it('should be settable through `timeouts`', async () => {
-          await d.timeouts('implicit', 20);
+          await d.timeoutsW3C({protocol: 'MJSONWP', type: 'implicit', ms: 20}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
           d.implicitWaitMs.should.equal(20);
         });
       });
@@ -251,14 +251,14 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         await d.deleteSession();
       });
       it('should get timeouts that we set', async () => {
-        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 1000});
+        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 1000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.have.property('implicit', 1000);
-        await d.timeoutsW3C({protocol: 'MJSONWP', type: 'command', ms: 2000});
+        await d.timeoutsW3C({protocol: 'MJSONWP', type: 'command', ms: 2000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 1000,
           command: 2000,
         });
-        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 3000});
+        await d.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 3000}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         await d.getTimeouts().should.eventually.deep.equal({
           implicit: 3000,
           command: 2000,

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -25,21 +25,21 @@ describe('timeout', () => {
   describe('timeoutsW3C', () => {
     describe('errors', () => {
       it('should throw an error if something random is sent to scriptDuration', async () => {
-        await driver.timeoutsW3C(null, null, 123, null, null).should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: 'W3C', script: 123, pageLoad: null, implicit: null}).should.eventually.be.rejected;
       });
       it('should throw an error if something random is sent to pageLoadDuration', async () => {
-        await driver.timeoutsW3C(null, null, null, 123, null).should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 123, implicit: null}).should.eventually.be.rejected;
       });
     });
     describe('implicit wait', () => {
       it('should call setImplicitWait when given an integer to implicitDuration', async () => {
-        await driver.timeoutsW3C(null, null, null, null, 42);
+        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 42});
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
       it('should call setImplicitWait when given a string to implicitDuration', async () => {
-        await driver.timeoutsW3C(null, null, null, null, 42);
+        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: '42'});
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -22,46 +22,46 @@ describe('timeout', () => {
     implicitWaitSpy.reset();
     newCommandTimeoutSpy.reset();
   });
-  describe('timeoutsW3C', () => {
+  describe('timeouts', () => {
     describe('errors', () => {
       it('should throw an error if something random is sent', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: 'howdy'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: 'howdy'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if timeout is negative', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: -42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: -42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an errors if timeout type is unknown', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if something random is sent to scriptDuration', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 123, pageLoad: undefined, implicit: undefined}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 123, pageLoad: undefined, implicit: undefined}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if something random is sent to pageLoadDuration', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 123, implicit: undefined}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 123, implicit: undefined}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
     });
     describe('implicit wait', () => {
       it('should call setImplicitWait when given an integer', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
       it('should call setImplicitWait when given a string', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
 
       it('should call setImplicitWait when given an integer to implicitDuration', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
       it('should call setImplicitWait when given a string to implicitDuration', async () => {
-        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -22,6 +22,31 @@ describe('timeout', () => {
     implicitWaitSpy.reset();
     newCommandTimeoutSpy.reset();
   });
+  describe('timeoutsW3C', () => {
+    describe('errors', () => {
+      it('should throw an error if something random is sent to scriptDuration', async () => {
+        await driver.timeoutsW3C(null, null, 123, null, null).should.eventually.be.rejected;
+      });
+      it('should throw an error if something random is sent to pageLoadDuration', async () => {
+        await driver.timeoutsW3C(null, null, null, 123, null).should.eventually.be.rejected;
+      });
+    });
+    describe('implicit wait', () => {
+      it('should call setImplicitWait when given an integer to implicitDuration', async () => {
+        await driver.timeoutsW3C(null, null, null, null, 42);
+        implicitWaitSpy.calledOnce.should.be.true;
+        implicitWaitSpy.firstCall.args[0].should.equal(42);
+        driver.implicitWaitMs.should.eql(42);
+      });
+      it('should call setImplicitWait when given a string to implicitDuration', async () => {
+        await driver.timeoutsW3C(null, null, null, null, 42);
+        implicitWaitSpy.calledOnce.should.be.true;
+        implicitWaitSpy.firstCall.args[0].should.equal(42);
+        driver.implicitWaitMs.should.eql(42);
+      });
+    });
+  });
+
   describe('timeouts', () => {
     describe('errors', () => {
       it('should throw an error if something random is sent', async () => {

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -70,7 +70,7 @@ describe('timeout', () => {
   });
   describe('implicitWait', () => {
     it('should call setImplicitWait when given an integer', async () => {
-      driver.implicitWait(42);
+      driver.setImplicitWait(42);
       implicitWaitSpy.calledOnce.should.be.true;
       implicitWaitSpy.firstCall.args[0].should.equal(42);
       driver.implicitWaitMs.should.eql(42);

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -25,43 +25,43 @@ describe('timeout', () => {
   describe('timeoutsW3C', () => {
     describe('errors', () => {
       it('should throw an error if something random is sent', async () => {
-        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'random timeout', ms: 'howdy'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: 'howdy'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if timeout is negative', async () => {
-        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'random timeout', ms: -42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: -42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an errors if timeout type is unknown', async () => {
-        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'random timeout', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'random timeout', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if something random is sent to scriptDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: 123, pageLoad: null, implicit: null}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 123, pageLoad: undefined, implicit: undefined}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if something random is sent to pageLoadDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 123, implicit: null}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 123, implicit: undefined}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
     });
     describe('implicit wait', () => {
       it('should call setImplicitWait when given an integer', async () => {
-        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'implicit', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
       it('should call setImplicitWait when given a string', async () => {
-        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'implicit', ms: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'implicit', ms: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
 
       it('should call setImplicitWait when given an integer to implicitDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
       it('should call setImplicitWait when given a string to implicitDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        await driver.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);

--- a/test/basedriver/timeout-specs.js
+++ b/test/basedriver/timeout-specs.js
@@ -24,50 +24,44 @@ describe('timeout', () => {
   });
   describe('timeoutsW3C', () => {
     describe('errors', () => {
-      it('should throw an error if something random is sent to scriptDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: 123, pageLoad: null, implicit: null}).should.eventually.be.rejected;
-      });
-      it('should throw an error if something random is sent to pageLoadDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 123, implicit: null}).should.eventually.be.rejected;
-      });
-    });
-    describe('implicit wait', () => {
-      it('should call setImplicitWait when given an integer to implicitDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 42});
-        implicitWaitSpy.calledOnce.should.be.true;
-        implicitWaitSpy.firstCall.args[0].should.equal(42);
-        driver.implicitWaitMs.should.eql(42);
-      });
-      it('should call setImplicitWait when given a string to implicitDuration', async () => {
-        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: '42'});
-        implicitWaitSpy.calledOnce.should.be.true;
-        implicitWaitSpy.firstCall.args[0].should.equal(42);
-        driver.implicitWaitMs.should.eql(42);
-      });
-    });
-  });
-
-  describe('timeouts', () => {
-    describe('errors', () => {
       it('should throw an error if something random is sent', async () => {
-        await driver.timeouts('random timeout', 'howdy').should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'random timeout', ms: 'howdy'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an error if timeout is negative', async () => {
-        await driver.timeouts('random timeout', -42).should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'random timeout', ms: -42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
       it('should throw an errors if timeout type is unknown', async () => {
-        await driver.timeouts('random timeout', 42).should.eventually.be.rejected;
+        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'random timeout', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+      });
+      it('should throw an error if something random is sent to scriptDuration', async () => {
+        await driver.timeoutsW3C({protocol: 'W3C', script: 123, pageLoad: null, implicit: null}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
+      });
+      it('should throw an error if something random is sent to pageLoadDuration', async () => {
+        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 123, implicit: null}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97").should.eventually.be.rejected;
       });
     });
     describe('implicit wait', () => {
       it('should call setImplicitWait when given an integer', async () => {
-        await driver.timeouts('implicit', 42);
+        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'implicit', ms: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);
       });
       it('should call setImplicitWait when given a string', async () => {
-        await driver.timeouts('implicit', '42');
+        await driver.timeoutsW3C({protocol: 'MJSONWP', type: 'implicit', ms: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        implicitWaitSpy.calledOnce.should.be.true;
+        implicitWaitSpy.firstCall.args[0].should.equal(42);
+        driver.implicitWaitMs.should.eql(42);
+      });
+
+      it('should call setImplicitWait when given an integer to implicitDuration', async () => {
+        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 42}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
+        implicitWaitSpy.calledOnce.should.be.true;
+        implicitWaitSpy.firstCall.args[0].should.equal(42);
+        driver.implicitWaitMs.should.eql(42);
+      });
+      it('should call setImplicitWait when given a string to implicitDuration', async () => {
+        await driver.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: '42'}, "1dcfe021-8fc8-49bd-8dac-e986d3091b97");
         implicitWaitSpy.calledOnce.should.be.true;
         implicitWaitSpy.firstCall.args[0].should.equal(42);
         driver.implicitWaitMs.should.eql(42);

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -46,6 +46,11 @@ describe('MJSONWP', () => {
 
   describe('check route to command name conversion', () => {
     it('should properly lookup correct command name for endpoint with session', () => {
+      const cmdName = routeToCommandName('/timeouts', 'POST');
+      cmdName.should.equal('timeoutsW3C');
+    });
+
+    it('should properly lookup correct command name for endpoint with session', () => {
       const cmdName = routeToCommandName('/timeouts/implicit_wait', 'POST');
       cmdName.should.equal('implicitWait');
     });

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -40,7 +40,7 @@ describe('MJSONWP', () => {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('6b555735');
+      hash.should.equal('a7f869cd');
     });
   });
 

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -40,14 +40,14 @@ describe('MJSONWP', () => {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('a7f869cd');
+      hash.should.equal('94cbb31c');
     });
   });
 
   describe('check route to command name conversion', () => {
     it('should properly lookup correct command name for endpoint with session', () => {
       const cmdName = routeToCommandName('/timeouts', 'POST');
-      cmdName.should.equal('timeoutsW3C');
+      cmdName.should.equal('timeouts');
     });
 
     it('should properly lookup correct command name for endpoint with session', () => {

--- a/test/mjsonwp/validator-specs.js
+++ b/test/mjsonwp/validator-specs.js
@@ -67,63 +67,63 @@ describe('MJSONWP', () => {
         (() => {validators.asyncScriptTimeout(100);}).should.not.throw();
       });
     });
-    describe('timeoutsW3C', () => {
+    describe('timeouts', () => {
       it('should fail when given no ms', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: undefined});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric ms', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 'five'});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 'five'});}).should.throw(/ms/i);
       });
       it('should fail when given a negative ms', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: -1});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: -1});}).should.throw(/ms/i);
       });
       it('should succeed when given an ms of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 0});}).should.not.throw();
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 0});}).should.not.throw();
       });
       it('should succeed when given an ms greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 100});}).should.not.throw();
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 100});}).should.not.throw();
       });
       it('should not allow an invalid timeout type', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'foofoo', ms: 100});}).should.throw(/'foofoo'/);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'foofoo', ms: 100});}).should.throw(/'foofoo'/);
       });
       it('should fail when given a non-numeric scriptDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 'one', pageLoad: undefined, implicit: undefined});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 'one', pageLoad: undefined, implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric pageLoadDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 'one', implicit: undefined});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 'one', implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric implicitDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 'one'});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 'one'});}).should.throw(/ms/i);
       });
       it('should fail when given a negative scriptDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: -1, pageLoad: undefined, implicit: undefined});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: -1, pageLoad: undefined, implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a negative pageLoadDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: -1, implicit: undefined});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: -1, implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a negative implicitDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: -1});}).should.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: -1});}).should.throw(/ms/i);
       });
       it('should succeed when given scriptDuration of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 0, pageLoad: undefined, implicit: undefined});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 0, pageLoad: undefined, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given pageLoadDuration of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 0, implicit: undefined});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 0, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given implicitDuration of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 0});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 0});}).should.not.throw(/ms/i);
       });
       it('should succeed when given scriptDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 1, pageLoad: undefined, implicit: undefined});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 1, pageLoad: undefined, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given pageLoadDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 1, implicit: undefined});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 1, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given implicitDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 1});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 1});}).should.not.throw(/ms/i);
       });
       it('should succeed when given scriptDuration, pageLoadDuration and implicitDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 1, pageLoad: 1, implicit: 1});}).should.not.throw(/ms/i);
+        (() => {validators.timeouts({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 1, pageLoad: 1, implicit: 1});}).should.not.throw(/ms/i);
       });
     });
     describe('clickCurrent', () => {

--- a/test/mjsonwp/validator-specs.js
+++ b/test/mjsonwp/validator-specs.js
@@ -66,26 +66,6 @@ describe('MJSONWP', () => {
         (() => {validators.asyncScriptTimeout(100);}).should.not.throw();
       });
     });
-    describe('other timeouts', () => {
-      it('should fail when given no ms', async () => {
-        (() => {validators.timeouts('page load');}).should.throw(/ms/i);
-      });
-      it('should fail when given a non-numeric ms', async () => {
-        (() => {validators.timeouts('page load', "five");}).should.throw(/ms/i);
-      });
-      it('should fail when given a negative ms', async () => {
-        (() => {validators.timeouts('page load', -1);}).should.throw(/ms/i);
-      });
-      it('should succeed when given an ms of 0', async () => {
-        (() => {validators.timeouts('page load', 0);}).should.not.throw();
-      });
-      it('should succeed when given an ms greater than 0', async () => {
-        (() => {validators.timeouts('page load', 100);}).should.not.throw();
-      });
-      it('should not allow an invalid timeout type', async () => {
-        (() => {validators.timeouts('foofoo', 100);}).should.throw(/'foofoo'/);
-      });
-    });
     describe('timeoutsW3C', () => {
       it('should fail when given no ms', async () => {
         (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: null});}).should.throw(/ms/i);

--- a/test/mjsonwp/validator-specs.js
+++ b/test/mjsonwp/validator-specs.js
@@ -2,6 +2,7 @@
 
 import { validators } from '../../lib/mjsonwp/validators';
 import chai from 'chai';
+import BaseDriver from "../../lib/basedriver/driver";
 
 
 chai.should();
@@ -68,61 +69,61 @@ describe('MJSONWP', () => {
     });
     describe('timeoutsW3C', () => {
       it('should fail when given no ms', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: null});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric ms', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: 'five'});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 'five'});}).should.throw(/ms/i);
       });
       it('should fail when given a negative ms', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: -1});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: -1});}).should.throw(/ms/i);
       });
       it('should succeed when given an ms of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: 0});}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 0});}).should.not.throw();
       });
       it('should succeed when given an ms greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: 100});}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'page load', ms: 100});}).should.not.throw();
       });
       it('should not allow an invalid timeout type', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'foofoo', ms: 100});}).should.throw(/'foofoo'/);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.MJSONWP, type: 'foofoo', ms: 100});}).should.throw(/'foofoo'/);
       });
       it('should fail when given a non-numeric scriptDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 'one', pageLoad: null, implicit: null});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 'one', pageLoad: undefined, implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric pageLoadDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 'one', implicit: null});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 'one', implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric implicitDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 'one'});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 'one'});}).should.throw(/ms/i);
       });
       it('should fail when given a negative scriptDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: -1, pageLoad: null, implicit: null});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: -1, pageLoad: undefined, implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a negative pageLoadDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: -1, implicit: null});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: -1, implicit: undefined});}).should.throw(/ms/i);
       });
       it('should fail when given a negative implicitDuration', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: -1});}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: -1});}).should.throw(/ms/i);
       });
       it('should succeed when given scriptDuration of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 0, pageLoad: null, implicit: null});}).should.not.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 0, pageLoad: undefined, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given pageLoadDuration of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 0, implicit: null});}).should.not.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 0, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given implicitDuration of 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 0});}).should.not.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 0});}).should.not.throw(/ms/i);
       });
       it('should succeed when given scriptDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 1, pageLoad: null, implicit: null});}).should.not.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 1, pageLoad: undefined, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given pageLoadDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 1, implicit: null});}).should.not.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: 1, implicit: undefined});}).should.not.throw(/ms/i);
       });
       it('should succeed when given implicitDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 1});}).should.not.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: undefined, pageLoad: undefined, implicit: 1});}).should.not.throw(/ms/i);
       });
-      it('should succeed when given scriptDuration,  pageLoadDuration and implicitDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 1, pageLoad: 1, implicit: 1});}).should.not.throw(/ms/i);
+      it('should succeed when given scriptDuration, pageLoadDuration and implicitDuration greater than 0', async () => {
+        (() => {validators.timeoutsW3C({protocol: BaseDriver.DRIVER_PROTOCOL.W3C, script: 1, pageLoad: 1, implicit: 1});}).should.not.throw(/ms/i);
       });
     });
     describe('clickCurrent', () => {

--- a/test/mjsonwp/validator-specs.js
+++ b/test/mjsonwp/validator-specs.js
@@ -88,61 +88,61 @@ describe('MJSONWP', () => {
     });
     describe('timeoutsW3C', () => {
       it('should fail when given no ms', async () => {
-        (() => {validators.timeoutsW3C('page load', null, null, null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: null});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric ms', async () => {
-        (() => {validators.timeoutsW3C('page load', "five", null, null, null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: 'five'});}).should.throw(/ms/i);
       });
       it('should fail when given a negative ms', async () => {
-        (() => {validators.timeoutsW3C('page load', -1, null, null, null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: -1});}).should.throw(/ms/i);
       });
       it('should succeed when given an ms of 0', async () => {
-        (() => {validators.timeoutsW3C('page load', 0, null, null, null);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: 0});}).should.not.throw();
       });
       it('should succeed when given an ms greater than 0', async () => {
-        (() => {validators.timeoutsW3C('page load', 100, null, null, null);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'page load', ms: 100});}).should.not.throw();
       });
       it('should not allow an invalid timeout type', async () => {
-        (() => {validators.timeoutsW3C('foofoo', 100, null, null, null);}).should.throw(/'foofoo'/);
+        (() => {validators.timeoutsW3C({protocol: 'MJSONWP', type: 'foofoo', ms: 100});}).should.throw(/'foofoo'/);
       });
       it('should fail when given a non-numeric scriptDuration', async () => {
-        (() => {validators.timeoutsW3C(null, null, 'one', null, null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 'one', pageLoad: null, implicit: null});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric pageLoadDuration', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, 'one', null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 'one', implicit: null});}).should.throw(/ms/i);
       });
       it('should fail when given a non-numeric implicitDuration', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, null, 'one');}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 'one'});}).should.throw(/ms/i);
       });
       it('should fail when given a negative scriptDuration', async () => {
-        (() => {validators.timeoutsW3C(null, null, -1, null, null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: -1, pageLoad: null, implicit: null});}).should.throw(/ms/i);
       });
       it('should fail when given a negative pageLoadDuration', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, -1, null);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: -1, implicit: null});}).should.throw(/ms/i);
       });
       it('should fail when given a negative implicitDuration', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, null -1);}).should.throw(/ms/i);
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: -1});}).should.throw(/ms/i);
       });
       it('should succeed when given scriptDuration of 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, 0, null, null);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 0, pageLoad: null, implicit: null});}).should.not.throw(/ms/i);
       });
       it('should succeed when given pageLoadDuration of 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, 0, null);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 0, implicit: null});}).should.not.throw(/ms/i);
       });
       it('should succeed when given implicitDuration of 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, null, 0);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 0});}).should.not.throw(/ms/i);
       });
       it('should succeed when given scriptDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, 1, null, null);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 1, pageLoad: null, implicit: null});}).should.not.throw(/ms/i);
       });
       it('should succeed when given pageLoadDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, 1, null);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: 1, implicit: null});}).should.not.throw(/ms/i);
       });
       it('should succeed when given implicitDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, null, null, 1);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: null, pageLoad: null, implicit: 1});}).should.not.throw(/ms/i);
       });
       it('should succeed when given scriptDuration,  pageLoadDuration and implicitDuration greater than 0', async () => {
-        (() => {validators.timeoutsW3C(null, null, 1, 1, 1);}).should.not.throw();
+        (() => {validators.timeoutsW3C({protocol: 'W3C', script: 1, pageLoad: 1, implicit: 1});}).should.not.throw(/ms/i);
       });
     });
     describe('clickCurrent', () => {

--- a/test/mjsonwp/validator-specs.js
+++ b/test/mjsonwp/validator-specs.js
@@ -86,6 +86,65 @@ describe('MJSONWP', () => {
         (() => {validators.timeouts('foofoo', 100);}).should.throw(/'foofoo'/);
       });
     });
+    describe('timeoutsW3C', () => {
+      it('should fail when given no ms', async () => {
+        (() => {validators.timeoutsW3C('page load', null, null, null);}).should.throw(/ms/i);
+      });
+      it('should fail when given a non-numeric ms', async () => {
+        (() => {validators.timeoutsW3C('page load', "five", null, null, null);}).should.throw(/ms/i);
+      });
+      it('should fail when given a negative ms', async () => {
+        (() => {validators.timeoutsW3C('page load', -1, null, null, null);}).should.throw(/ms/i);
+      });
+      it('should succeed when given an ms of 0', async () => {
+        (() => {validators.timeoutsW3C('page load', 0, null, null, null);}).should.not.throw();
+      });
+      it('should succeed when given an ms greater than 0', async () => {
+        (() => {validators.timeoutsW3C('page load', 100, null, null, null);}).should.not.throw();
+      });
+      it('should not allow an invalid timeout type', async () => {
+        (() => {validators.timeoutsW3C('foofoo', 100, null, null, null);}).should.throw(/'foofoo'/);
+      });
+      it('should fail when given a non-numeric scriptDuration', async () => {
+        (() => {validators.timeoutsW3C(null, null, 'one', null, null);}).should.throw(/ms/i);
+      });
+      it('should fail when given a non-numeric pageLoadDuration', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, 'one', null);}).should.throw(/ms/i);
+      });
+      it('should fail when given a non-numeric implicitDuration', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, null, 'one');}).should.throw(/ms/i);
+      });
+      it('should fail when given a negative scriptDuration', async () => {
+        (() => {validators.timeoutsW3C(null, null, -1, null, null);}).should.throw(/ms/i);
+      });
+      it('should fail when given a negative pageLoadDuration', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, -1, null);}).should.throw(/ms/i);
+      });
+      it('should fail when given a negative implicitDuration', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, null -1);}).should.throw(/ms/i);
+      });
+      it('should succeed when given scriptDuration of 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, 0, null, null);}).should.not.throw();
+      });
+      it('should succeed when given pageLoadDuration of 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, 0, null);}).should.not.throw();
+      });
+      it('should succeed when given implicitDuration of 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, null, 0);}).should.not.throw();
+      });
+      it('should succeed when given scriptDuration greater than 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, 1, null, null);}).should.not.throw();
+      });
+      it('should succeed when given pageLoadDuration greater than 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, 1, null);}).should.not.throw();
+      });
+      it('should succeed when given implicitDuration greater than 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, null, null, 1);}).should.not.throw();
+      });
+      it('should succeed when given scriptDuration,  pageLoadDuration and implicitDuration greater than 0', async () => {
+        (() => {validators.timeoutsW3C(null, null, 1, 1, 1);}).should.not.throw();
+      });
+    });
     describe('clickCurrent', () => {
       it('should fail when given an invalid button', async () => {
         (() => {validators.clickCurrent(4);}).should.throw(/0, 1, or 2/i);


### PR DESCRIPTION
According to [the W3C spec](https://github.com/jlipps/simple-wd-spec#set-timeouts), clients send `{implicit: 3000}` as request body to the server. But current implementation expects `{type: implicit, ms: 3000}` for both W3C and MJSONWP.

I've changed to `optional` parameter because of supporting both W3C format and MJSONWP one.
https://github.com/appium/appium-base-driver/compare/master...KazuCocoa:fix_timeout_for_w3c?expand=1#diff-28707e6fe74fc702b56e27eaff233df0R25

Ideally, I'd like to remain `required: ['type', 'ms']}` for MJSONWP and set `optional: ['script', 'pageLoad', 'implicit']` for W3C, but I didn't come up with good idea... Do you have any good way to implement this?

# Server log when  Ruby client sends set-implicit-wait-time requests to the server
## W3C format
```
[debug] [JSONWP Proxy] Proxying [POST /session] to [POST http://localhost:8100/session] with body: {"desiredCapabilities":{"bundleId":"com.example.apple-samplecode.UICatalog","arguments":[],"environment":{},"shouldWaitForQuiescence":true,"shouldUseTestManagerForVisibilityDetection":false,"maxTypingFrequency":60,"shouldUseSingletonTestManager":true}}
[debug] [JSONWP Proxy] Got response with status 200: {"value":{"sessionId":"94BC124C-0414-43F8-A94A-AF633EBE48F0","capabilities":{"device":"iphone","browserName":"UICatalog","sdkVersion":"10.3.1","CFBundleIdentifier":"com.example.apple-samplecode.UICatalog"}},"sessionId":"94BC124C-0414-43F8-A94A-AF633EBE48F0","status":0}
[debug] [BaseDriver] Event 'wdaSessionStarted' logged at 1515329565137 (21:52:45 GMT+0900 (JST))
[debug] [BaseDriver] Event 'wdaStarted' logged at 1515329565138 (21:52:45 GMT+0900 (JST))
[XCUITest] Skipping setting of the initial display orientation. Set the "orientation" capability to either "LANDSCAPE" or "PORTRAIT", if this is an undesired behavior.
[debug] [BaseDriver] Event 'orientationSet' logged at 1515329565138 (21:52:45 GMT+0900 (JST))
[Appium] New XCUITestDriver session created successfully, session 70e94037-b9e6-494b-afdf-0fe99c3d9f54 added to master session list
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1515329565139 (21:52:45 GMT+0900 (JST))
[debug] [MJSONWP] Responding to client with driver.createSession() result: {"capabilities":{"webStorageEnabled":false,"locationContextEnabled":false,"browserName":"","platform":"MAC","javascriptEnabled":true,"databaseEnabled":false,"takesScreenshot":true,"networkConnectionEnabled":false,"platformName":"ios","automationName":"XCUITest","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","platformVersion":"10.3","deviceName":"iPhone Simulator","useNewWDA":true,"useJSONSource":true,"someCapability":"some_capability","some_capability":"some_capability","udid":"DED4DBAD-8E5E-4AD6-BDC4-E75CF9AD84D8"}}
[HTTP] <-- POST /wd/hub/session 200 22193 ms - 614 
[HTTP] --> POST /wd/hub/session/70e94037-b9e6-494b-afdf-0fe99c3d9f54/timeouts {"implicit":30000}
[debug] [MJSONWP] Calling AppiumDriver.timeoutsW3C() with args: [null,null,null,null,30000,"70e94037-b9e6-494b-afdf-0fe99c3d9f54"]
[debug] [XCUITest] Executing command 'timeoutsW3C'
[debug] [BaseDriver] Set implicit wait to 30000ms
[debug] [MJSONWP] Responding to client with driver.timeoutsW3C() result: null
[HTTP] <-- POST /wd/hub/session/70e94037-b9e6-494b-afdf-0fe99c3d9f54/timeouts 200 3 ms - 65 
[HTTP] --> POST /wd/hub/session/70e94037-b9e6-494b-afdf-0fe99c3d9f54/timeouts {"implicit":60000}
[debug] [MJSONWP] Calling AppiumDriver.timeoutsW3C() with args: [null,null,null,null,60000,"70e94037-b9e6-494b-afdf-0fe99c3d9f54"]
[debug] [XCUITest] Executing command 'timeoutsW3C'
[debug] [BaseDriver] Set implicit wait to 60000ms
[debug] [MJSONWP] Responding to client with driver.timeoutsW3C() result: null
[HTTP] <-- POST /wd/hub/session/70e94037-b9e6-494b-afdf-0fe99c3d9f54/timeouts 200 4 ms - 65 
[BaseDriver] Shutting down because we waited 60 seconds for a command
[Appium] Closing session, cause was 'New Command Timeout of 60 seconds expired. Try customizing the timeout using the 'newCommandTimeout' desired capability'
[Appium] Removing session 70e94037-b9e6-494b-afdf-0fe99c3d9f54 from our master session list
[XCUITest] Shutting down sub-processes
```

## MJSONWP
```
[debug] [MJSONWP] Responding to client with driver.createSession() result: {"webStorageEnabled":false,"locationContextEnabled":false,"browserName":"","platform":"MAC","javascriptEnabled":true,"databaseEnabled":false,"takesScreenshot":true,"networkConnectionEnabled":false,"platformName":"ios","automationName":"XCUITest","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","platformVersion":"10.3","deviceName":"iPhone Simulator","useNewWDA":true,"useJSONSource":true,"someCapability":"some_capability","udid":"DED4DBAD-8E5E-4AD6-BDC4-E75CF9AD84D8"}
[HTTP] <-- POST /wd/hub/session 200 21775 ms - 572 
[HTTP] --> POST /wd/hub/session/1635485c-b845-4f6b-9d73-f2f7c0d3ca06/timeouts/implicit_wait {"ms":30000}
[debug] [MJSONWP] Calling AppiumDriver.implicitWait() with args: [30000,"1635485c-b845-4f6b-9d73-f2f7c0d3ca06"]
[debug] [XCUITest] Executing command 'implicitWait'
[debug] [BaseDriver] Set implicit wait to 30000ms
[debug] [MJSONWP] Responding to client with driver.implicitWait() result: null
[HTTP] <-- POST /wd/hub/session/1635485c-b845-4f6b-9d73-f2f7c0d3ca06/timeouts/implicit_wait 200 3 ms - 76 
[HTTP] --> POST /wd/hub/session/1635485c-b845-4f6b-9d73-f2f7c0d3ca06/timeouts/implicit_wait {"ms":60000}
[debug] [MJSONWP] Calling AppiumDriver.implicitWait() with args: [60000,"1635485c-b845-4f6b-9d73-f2f7c0d3ca06"]
[debug] [XCUITest] Executing command 'implicitWait'
[debug] [BaseDriver] Set implicit wait to 60000ms
[debug] [MJSONWP] Responding to client with driver.implicitWait() result: null
[HTTP] <-- POST /wd/hub/session/1635485c-b845-4f6b-9d73-f2f7c0d3ca06/timeouts/implicit_wait 200 2 ms - 76 
```

## Response
### Ruby
```
[5] pry(#<AppiumLibCoreTest::DriverTest>)> @@driver.t_wrong_param
Selenium::WebDriver::Error::WebDriverError: unexpected response, code=400, content-type="text/html"
Parameters were incorrect. We wanted "We require type and ms for MJSONWP or (script|pageLoad|implicit) for W3C" and you sent {"no":30000}
from /Users/kazuaki/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/http/common.rb:88:in `create_response'
[6] pry(#<AppiumLibCoreTest::DriverTest>)> @@driver.t_mjsonwp_lack_no_ms
Selenium::WebDriver::Error::WebDriverError: unexpected response, code=400, content-type="text/html"
Parameters were incorrect. We wanted "We require type and ms for MJSONWP" and you sent {"type":"command"}
from /Users/kazuaki/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/http/common.rb:88:in `create_response'
```

### Appium server
```
Session() result: {"capabilities":{"webStorageEnabled":false,"locationContextEnabled":false,"browserName":"","platform":"MAC","javascriptEnabled":true,"databaseEnabled":false,"takesScreenshot":true,"networkConnectionEnabled":false,"platformName":"ios","automationName":"XCUITest","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","platformVersion":"10.3","deviceName":"iPhone Simulator","useNewWDA":true,"useJSONSource":true,"someCapability":"some_capability","some_capability":"some_capability","udid":"DED4DBAD-8E5E-4AD6-BDC4-E75CF9AD84D8"}}
[HTTP] <-- POST /wd/hub/session 200 20088 ms - 614
[HTTP] --> POST /wd/hub/session/d30d0c78-eaff-49af-a592-3a43ca367383/timeouts {"implicit":30000}
[debug] [MJSONWP] Calling AppiumDriver.timeoutsW3C() with args: [null,null,null,null,30000,"d30d0c78-eaff-49af-a592-3a43ca367383"]
[debug] [XCUITest] Executing command 'timeoutsW3C'
[debug] [BaseDriver] Set implicit wait to 30000ms
[debug] [MJSONWP] Responding to client with driver.timeoutsW3C() result: null
[HTTP] <-- POST /wd/hub/session/d30d0c78-eaff-49af-a592-3a43ca367383/timeouts 200 9 ms - 65
[HTTP] --> POST /wd/hub/session/d30d0c78-eaff-49af-a592-3a43ca367383/timeouts {"no":30000}
[HTTP] <-- POST /wd/hub/session/d30d0c78-eaff-49af-a592-3a43ca367383/timeouts 400 2 ms - 137
[HTTP] --> POST /wd/hub/session/d30d0c78-eaff-49af-a592-3a43ca367383/timeouts {"type":"command"}
[HTTP] <-- POST /wd/hub/session/d30d0c78-eaff-49af-a592-3a43ca367383/timeouts 400 1 ms - 105
[BaseDriver] Shutting down because we waited 60 seconds for a command
[Appium] Closing session, cause was 'New Command Time
```


## related
- w3c routes #147
- https://github.com/appium/ruby_lib/issues/739
  
  