### PR TITLE
Fix problems with W3C responses

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { validator } from './desired-caps';
 import { util } from 'appium-support';
 import log from './logger';
+import { errors } from '../mjsonwp/errors';
 
 // Takes primary caps object and merges it into a secondary caps object.
 // (see https://www.w3.org/TR/webdriver/#dfn-merging-capabilities)
@@ -11,7 +12,7 @@ function mergeCaps (primary = {}, secondary = {}) {
   for (let [name, value] of _.toPairs(secondary)) {
     // Overwriting is not allowed. Primary and secondary must have different properties (w3c rule 4.4)
     if (!_.isUndefined(primary[name])) {
-      throw new Error(`property '${name}' should not exist on both primary (${JSON.stringify(primary)}) and secondary (${JSON.stringify(secondary)}) object`);
+      throw new errors.InvalidArgumentError(`property '${name}' should not exist on both primary (${JSON.stringify(primary)}) and secondary (${JSON.stringify(secondary)}) object`);
     }
     result[name] = value;
   }
@@ -25,7 +26,7 @@ function validateCaps (caps, constraints = {}, opts = {}) {
   let  {skipPresenceConstraint} = opts;
 
   if (!_.isObject(caps)) {
-    throw new Error(`must be a JSON object`);
+    throw new errors.InvalidArgumentError(`must be a JSON object`);
   }
 
   constraints = _.cloneDeep(constraints); // Defensive copy
@@ -48,7 +49,7 @@ function validateCaps (caps, constraints = {}, opts = {}) {
         message.push(`'${attribute}' ${reason}`);
       }
     }
-    throw new Error(message.join('; '));
+    throw new errors.InvalidArgumentError(message.join('; '));
   }
 
   // Return caps
@@ -98,7 +99,7 @@ function stripAppiumPrefixes (caps) {
 
   // If we found standard caps that were incorrectly prefixed, throw an exception (e.g.: don't accept 'appium:platformName', only accept just 'platformName')
   if (badPrefixedCaps.length > 0) {
-    throw new Error(`The capabilities ${JSON.stringify(badPrefixedCaps)} are standard capabilities and should not have the "appium:" prefix`);
+    throw new errors.InvalidArgumentError(`The capabilities ${JSON.stringify(badPrefixedCaps)} are standard capabilities and should not have the "appium:" prefix`);
   }
 
   // If client provides non-prefixed, non-standard capabilities, warn them that these should be prefixed
@@ -111,7 +112,7 @@ function stripAppiumPrefixes (caps) {
 function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   // If capabilities request is not an object, return error (#1.1)
   if (!_.isObject(caps)) {
-    throw new Error('The capabilities argument was not valid for the following reason(s): "capabilities" must be a JSON object.');
+    throw new errors.InvalidArgumentError('The capabilities argument was not valid for the following reason(s): "capabilities" must be a JSON object.');
   }
 
   // Let 'requiredCaps' be property named 'alwaysMatch' from capabilities request (#2) and 'allFirstMatchCaps' be property named 'firstMatch from capabilities request (#3)
@@ -122,7 +123,7 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
 
   // Reject 'firstMatch' argument if it's not an array (#3.2)
   if (!_.isArray(allFirstMatchCaps)) {
-    throw new Error('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must be a JSON array or undefined');
+    throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must be a JSON array or undefined');
   }
 
   // If an empty array as provided, we'll be forgiving and make it an array of one empty object
@@ -153,13 +154,13 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   }
 
   // Validate all of the first match capabilities and return an array with only the valid caps (see spec #5)
-  let errors = [];
+  let validationErrors = [];
   let validatedFirstMatchCaps = allFirstMatchCaps.map((firstMatchCaps) => {
     try {
       // Validate firstMatch caps
       return shouldValidateCaps ? validateCaps(firstMatchCaps, filteredConstraints) : firstMatchCaps;
     } catch (e) {
-      errors.push(e.message);
+      validationErrors.push(e.message);
       return null;
     }
   }).filter((caps) => !_.isNull(caps));
@@ -176,21 +177,21 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   }
 
   // Returns variables for testing purposes
-  return {requiredCaps, allFirstMatchCaps, validatedFirstMatchCaps, matchedCaps, errors};
+  return {requiredCaps, allFirstMatchCaps, validatedFirstMatchCaps, matchedCaps, validationErrors};
 }
 
 // Calls parseCaps and just returns the matchedCaps variable
 function processCapabilities (caps, constraints = {}, shouldValidateCaps = true) {
-  const {matchedCaps, errors} = parseCaps(caps, constraints, shouldValidateCaps);
+  const {matchedCaps, validationErrors} = parseCaps(caps, constraints, shouldValidateCaps);
 
   // If we found an error throw an exception
   if (_.isNull(matchedCaps)) {
     if (_.isArray(caps.firstMatch) && caps.firstMatch.length > 1) {
       // If there was more than one 'firstMatch' cap, indicate that we couldn't find a matching capabilities set and show all the errors
-      throw new Error(`Could not find matching capabilities from ${JSON.stringify(caps)}:\n ${errors.join('\n')}`);
+      throw new errors.InvalidArgumentError(`Could not find matching capabilities from ${JSON.stringify(caps)}:\n ${validationErrors.join('\n')}`);
     } else {
       // Otherwise, just show the singular error message
-      throw new Error(errors[0]);
+      throw new errors.InvalidArgumentError(validationErrors[0]);
     }
   }
 

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -25,7 +25,7 @@ function validateCaps (caps, constraints = {}, opts = {}) {
 
   let  {skipPresenceConstraint} = opts;
 
-  if (!_.isObject(caps)) {
+  if (!_.isPlainObject(caps)) {
     throw new errors.InvalidArgumentError(`must be a JSON object`);
   }
 
@@ -111,7 +111,7 @@ function stripAppiumPrefixes (caps) {
 // Parse capabilities (based on https://www.w3.org/TR/webdriver/#processing-capabilities)
 function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   // If capabilities request is not an object, return error (#1.1)
-  if (!_.isObject(caps)) {
+  if (!_.isPlainObject(caps)) {
     throw new errors.InvalidArgumentError('The capabilities argument was not valid for the following reason(s): "capabilities" must be a JSON object.');
   }
 

--- a/lib/mjsonwp/errors.js
+++ b/lib/mjsonwp/errors.js
@@ -192,6 +192,12 @@ class NoSuchWindowError extends MJSONWPError {
   }
 }
 
+class InvalidArgumentError extends MJSONWPError {
+  constructor (err) {
+    super(err || 'The arguments passed to the command are either invalid or malformed');
+  }
+}
+
 class InvalidCookieDomainError extends MJSONWPError {
   static code () {
     return 24;
@@ -352,8 +358,11 @@ class NotYetImplementedError extends MJSONWPError {
   static code () {
     return 13;
   }
+  static w3cStatus () {
+    return HTTPStatusCodes.METHOD_NOT_ALLOWED;
+  }
   constructor (err) {
-    super(err || 'Method has not yet been implemented', NotYetImplementedError.code());
+    super(err || 'Method has not yet been implemented', NotYetImplementedError.code(), NotYetImplementedError.w3cStatus());
   }
 }
 
@@ -429,6 +438,7 @@ const errors = {NotYetImplementedError,
                 ElementNotVisibleError,
                 InvalidElementStateError,
                 UnknownError,
+                InvalidArgumentError,
                 ElementIsNotSelectableError,
                 JavaScriptError,
                 XPathLookupError,

--- a/lib/mjsonwp/errors.js
+++ b/lib/mjsonwp/errors.js
@@ -359,7 +359,7 @@ class NotYetImplementedError extends MJSONWPError {
     return 13;
   }
   static w3cStatus () {
-    return HTTPStatusCodes.METHOD_NOT_ALLOWED;
+    return HTTPStatusCodes.NOT_FOUND; // W3C equivalent is called 'Unknown Command' (A command could not be executed because the remote end is not aware of it)
   }
   constructor (err) {
     super(err || 'Method has not yet been implemented', NotYetImplementedError.code(), NotYetImplementedError.w3cStatus());
@@ -369,6 +369,9 @@ class NotYetImplementedError extends MJSONWPError {
 class NotImplementedError extends MJSONWPError {
   static code () {
     return 13;
+  }
+  static w3cStatus () {
+    return HTTPStatusCodes.METHOD_NOT_ALLOWED; // W3C equivalent is 'Unknown Method' (The requested command matched a known URL but did not match an method for that URL)
   }
   constructor (err) {
     super(err || 'Method is not implemented', NotImplementedError.code());

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -191,7 +191,12 @@ function getResponseForJsonwpError (err) {
 }
 
 function getResponseForW3CError (err) {
-  let httpStatus = err.w3cStatus;
+  let httpStatus;
+  if (!(err.w3cStatus)) {
+    log.error(`Encountered internal error running command: ${err.stack}`);
+    err = new errors.UnknownError(err.message);
+  }
+  httpStatus = err.w3cStatus;
   let httpResBody = err.message;
   return [httpStatus, httpResBody];
 }
@@ -316,21 +321,21 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       log.debug(`Responding to client with driver.${spec.command}() ` +
                `result: ${_.truncate(JSON.stringify(driverRes), {length: LOG_OBJ_LENGTH})}`);
     } catch (err) {
-      let actualErr = err;
-      if (isErrorType(err, errors.ProxyRequestError)) {
-        log.error(`Encountered internal error running command:  ${JSON.stringify(err)} ${err.stack}`);
-        actualErr = err.getActualError();
-      } else if (!(isErrorType(err, MJSONWPError) ||
-            isErrorType(err, errors.BadParametersError))) {
-        log.error(`Encountered internal error running command: ${err.stack}`);
-        actualErr = new errors.UnknownError(err);
-      }
       // if anything goes wrong, figure out what our response should be
       // based on the type of error that we encountered
-      if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
-        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
-      } else {
+      let actualErr = err;
+      if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP) {
+        if (isErrorType(err, errors.ProxyRequestError)) {
+          log.error(`Encountered internal error running command:  ${JSON.stringify(err)} ${err.stack}`);
+          actualErr = err.getActualError();
+        } else if (!(isErrorType(err, MJSONWPError) ||
+          isErrorType(err, errors.BadParametersError))) {
+          log.error(`Encountered internal error running command: ${err.stack}`);
+          actualErr = new errors.UnknownError(err);
+        }
         [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);
+      } else {
+        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
       }
     }
 

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -192,7 +192,7 @@ function getResponseForJsonwpError (err) {
 
 function getResponseForW3CError (err) {
   let httpStatus;
-  if (!(err.w3cStatus)) {
+  if (!err.w3cStatus) {
     log.error(`Encountered internal error running command: ${err.stack}`);
     err = new errors.UnknownError(err.message);
   }


### PR DESCRIPTION
* Make malformed caps return 400 error  
* Add InvalidArgumentTypeError to errors
* Made 'NotYetImplementedError' a 405 (Method Not Allowed) status code
* Made errors in 'createSession' return InvalidArgumentTypeError when capabilities are invalid or malformed
* Fix incorrect W3C responses 
    * Add w3c status for NotImplemented and NotYetImplemented
    * Changed `getResponseForW3CStatusError` so that it throws an unknown error if the exception isn't a w3c exception
      * Checks for property `.w3cStatus` on the Error to confirm if it's a proper W3C protocol-blessed exception (@jlipps do you think this is adequate?)
    * Moved logic that reassigned errors into MJSONWP conditional blocks; W3C shouldn't reassign errors because they all have their own specific HTTP status codes
    * Added endpoint tests that check that you can create sessions in W3C and that subsequent calls to the session return the correct responses