### PR TITLE
Update parameters list for start_recording_screen/stop_recording_screen endpoints

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -343,10 +343,10 @@ const METHOD_MAP = {
     POST: {command: 'isLocked'}
   },
   '/wd/hub/session/:sessionId/appium/start_recording_screen': {
-    POST: {command: 'startRecordingScreen', payloadParams: {required: ['filePath', 'videoSize', 'timeLimit', 'bitRate']}}
+    POST: {command: 'startRecordingScreen', payloadParams: {optional: ['options']}}
   },
   '/wd/hub/session/:sessionId/appium/stop_recording_screen': {
-    POST: {command: 'stopRecordingScreen'}
+    POST: {command: 'stopRecordingScreen', payloadParams: {optional: ['options']}}
   },
   '/wd/hub/session/:sessionId/appium/performanceData/types': {
     POST: {command: 'getPerformanceDataTypes'}

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -40,7 +40,7 @@ describe('MJSONWP', () => {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('94cbb31c');
+      hash.should.equal('21ceab6b');
     });
   });
 


### PR DESCRIPTION
iOS and Android have different of configurable options for screen recording, so that the previous implementation is not cross platform.