### PR TITLE
Fix broken Proxy logic for W3C

### DIFF
--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -324,19 +324,17 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // if anything goes wrong, figure out what our response should be
       // based on the type of error that we encountered
       let actualErr = err;
-      if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP) {
-        if (isErrorType(err, errors.ProxyRequestError)) {
-          log.error(`Encountered internal error running command:  ${JSON.stringify(err)} ${err.stack}`);
-          actualErr = err.getActualError();
-        } else if (!(isErrorType(err, MJSONWPError) ||
-          isErrorType(err, errors.BadParametersError))) {
-          log.error(`Encountered internal error running command: ${err.stack}`);
-          actualErr = new errors.UnknownError(err);
-        }
-        [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);
-      } else {
-        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
+
+      // If it's a JWProxy error, translate it to a MJSONWPError exception
+      if (isErrorType(err, errors.ProxyRequestError)) {
+        log.error(`Encountered internal error running command:  ${JSON.stringify(err)} ${err.stack}`);
+        actualErr = err.getActualError(driver.protocol);
+      } else if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP && (!(isErrorType(err, MJSONWPError) || isErrorType(err, errors.BadParametersError)))) {
+        log.error(`Encountered internal error running command: ${err.stack}`);
+        actualErr = new errors.UnknownError(err);
       }
+
+      [httpStatus, httpResBody] = driver.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP ? getResponseForJsonwpError(actualErr) : getResponseForW3CError(actualErr);
     }
 
     // decode the response, which is either a string or json
@@ -351,6 +349,11 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         }
       } else {
         httpResBody.sessionId = req.params.sessionId || null;
+      }
+
+      // Don't include sessionId in W3C responses
+      if (driver.protocol === BaseDriver.DRIVER_PROTOCOL.W3C) {
+        delete httpResBody.sessionId;
       }
 
       res.status(httpStatus).json(httpResBody);

--- a/test/mjsonwp/helpers.js
+++ b/test/mjsonwp/helpers.js
@@ -1,0 +1,25 @@
+import Express from 'express';
+import bodyParser from 'body-parser';
+
+export function createProxyServer (sessionId, port) {
+  // Start an express server for proxying
+  let app = new Express();
+  app.use(bodyParser.json());
+  let server = app.listen(port);
+  return {app, server};
+}
+
+let handlers = {
+  'post': {},
+  'get': {},
+  'delete': {},
+  'put': {},
+};
+
+export function addHandler (app, method, url, handler) {
+  method = method.toLowerCase();
+  if (!handlers[method][url]) {
+    app[method](url, (req, res) => handlers[method][url].call(this, req, res));
+  }
+  handlers[method][url] = handler;
+}


### PR DESCRIPTION
* Moved 'ProxyRequestError' handling outside of the MJSONWP block.
  * When it's a proxy error, Appium translates the error (based on statusCode) to it's proper Error
  * W3C sessions weren't doing this when ProxyRequestError was being used
  * Moved conditionals so that W3C translates Proxy errors too
* Added tests in `mjsonwp-e2e-specs` that test JWProxy
  * Made a dummy express server that is used as a jwproxy server that binds routes dynamically
  * Test successful 200 proxies (this test passed _without_ coding fix)
  * Tested unsuccessful responses to see that a JSONWP response with status = 6 would return the correct 'NoSuchDriverError' with statusCode = 404