### PR TITLE
Check that W3C capabilities is a plain object

### DIFF
--- a/lib/basedriver/commands/session.js
+++ b/lib/basedriver/commands/session.js
@@ -6,16 +6,35 @@ import { processCapabilities } from '../capabilities';
 
 let commands = {};
 
-commands.createSession = async function (desiredCapabilities, requiredCaps, capabilities) {
+commands.createSession = async function (jsonwpDesiredCapabilities, jsonwpRequiredCaps, w3cCapabilities) {
   if (this.sessionId !== null) {
     throw new errors.SessionNotCreatedError('Cannot create a new session ' +
                                             'while one is in progress');
   }
 
-  // If we were provided with W3C capabilities, parse those. Otherwise, fall back to MJSONWP.
-  let caps = capabilities ?
-    processCapabilities(capabilities, this.desiredCapConstraints, this.shouldValidateCaps) :
-    desiredCapabilities;
+  log.debug();
+
+  // Determine weather we should use jsonwpDesiredCapabilities or w3cCapabilities to get caps from
+  let caps;
+  if (w3cCapabilities) {
+    if (jsonwpDesiredCapabilities) {
+      log.debug(`W3C capabilities ${_.truncate(JSON.stringify(w3cCapabilities))} and MJSONWP desired capabilities ${_.truncate(w3cCapabilities)} were provided`);
+    }
+
+    if (jsonwpDesiredCapabilities && !_.isPlainObject(w3cCapabilities)) {
+      // If W3C Capabilities and MJSONWP Capabilities were provided and W3C caps aren't a plain object,
+      // log a warning and fall back to MJSONWP
+      log.warn(`Expected W3C "capabilities" to be a JSON Object but was provided with: ${JSON.stringify(w3cCapabilities)}`);
+      log.warn(`Falling back to MJSONWP desired capabilities`);
+      caps = jsonwpDesiredCapabilities;
+    } else {
+      log.debug(`Creating session with W3C capabilities: ${_.truncate(JSON.stringify(w3cCapabilities))}`);
+      caps = processCapabilities(w3cCapabilities, this.desiredCapConstraints, this.shouldValidateCaps);
+    }
+  } else {
+    log.debug(`Creating session with MJSONWP desired capabilities: ${_.truncate(JSON.stringify(jsonwpDesiredCapabilities))}`);
+    caps = jsonwpDesiredCapabilities;
+  }
 
   caps = fixCaps(caps, this.desiredCapConstraints);
   this.validateDesiredCaps(caps);

--- a/test/basedriver/capability-specs.js
+++ b/test/basedriver/capability-specs.js
@@ -339,4 +339,36 @@ describe('Desired Capabilities', () => {
     }).should.eventually.be.rejectedWith(/blank/);
 
   });
+
+  describe('w3c', async () => {
+    it('should accept w3c capabilities', async () => {
+      const [sessionId, caps] = await d.createSession(null, null, {
+        alwaysMatch: {
+          'platformName': 'iOS',
+          'deviceName': 'Delorean'
+        }, firstMatch: [{}],
+      });
+      sessionId.should.exist;
+      caps.should.eql({
+        platformName: 'iOS',
+        deviceName: 'Delorean',
+      });
+      await d.deleteSession();
+    });
+
+    it('should ignore w3c capabilities if it is not a plain JSON object', async () => {
+      for (let val of [true, "string", [], 100]) {
+        const [sessionId, caps] = await d.createSession({
+          platformName: 'iOS',
+          deviceName: 'Delorean'
+        }, null, val);
+        sessionId.should.exist;
+        caps.should.eql({
+          platformName: 'iOS',
+          deviceName: 'Delorean',
+        });
+        await d.deleteSession();
+      }
+    });
+  });
 });

--- a/test/basedriver/capability-specs.js
+++ b/test/basedriver/capability-specs.js
@@ -344,8 +344,8 @@ describe('Desired Capabilities', () => {
     it('should accept w3c capabilities', async () => {
       const [sessionId, caps] = await d.createSession(null, null, {
         alwaysMatch: {
-          'platformName': 'iOS',
-          'deviceName': 'Delorean'
+          platformName: 'iOS',
+          deviceName: 'Delorean'
         }, firstMatch: [{}],
       });
       sessionId.should.exist;


### PR DESCRIPTION
* If 'capabilities' and 'desiredCapabilities' were provided, and 'capabilities' is NOT a plain object, fall back to 'desiredCapabilities'
* Added more logging to the W3C vs. MJSONWP determination logic
* Rename `createSession` args to be more descriptive
* Added basic W3C unit tests for above fix