### PR TITLE
Consolidate non-prefixed caps warnings

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -79,9 +79,6 @@ function stripAppiumPrefixes (caps) {
   const prefix = 'appium:';
   const prefixedCaps = _.filter(_.keys(caps), cap => `${cap}`.startsWith(prefix));
   const badPrefixedCaps = [];
-  const unprefixedCaps = _.filter(_.keys(caps), (cap) => (
-    !cap.includes(':') && !isStandardCap(cap)
-  ));
 
   // Strip out the 'appium:' prefix
   for (let prefixedCap of prefixedCaps) {
@@ -101,11 +98,20 @@ function stripAppiumPrefixes (caps) {
   if (badPrefixedCaps.length > 0) {
     throw new errors.InvalidArgumentError(`The capabilities ${JSON.stringify(badPrefixedCaps)} are standard capabilities and should not have the "appium:" prefix`);
   }
+}
 
-  // If client provides non-prefixed, non-standard capabilities, warn them that these should be prefixed
-  if (unprefixedCaps.length > 0) {
-    log.warn(`${JSON.stringify(unprefixedCaps)} are not standard capabilities and should have an extension prefix`);
-  }
+/**
+ * Get an array of all the unprefixed caps that are being used in 'alwaysMatch' and all of the 'firstMatch' object
+ * @param {Object} caps A capabilities object
+ */
+function findNonPrefixedCaps ({alwaysMatch={}, firstMatch=[]}) {
+  return _.chain([alwaysMatch, ...firstMatch])
+    .reduce((unprefixedCaps, caps) => [
+      ...unprefixedCaps,
+      ..._(caps).keys().filter((cap) => !cap.includes(':') && !isStandardCap(cap)),
+    ], [])
+    .uniq()
+    .value();
 }
 
 // Parse capabilities (based on https://www.w3.org/TR/webdriver/#processing-capabilities)
@@ -129,6 +135,12 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
   // If an empty array as provided, we'll be forgiving and make it an array of one empty object
   if (allFirstMatchCaps.length === 0) {
     allFirstMatchCaps.push({});
+  }
+
+  // Check for non-prefixed, non-standard capabilities and log warnings if they are found
+  let nonPrefixedCaps = findNonPrefixedCaps(caps);
+  if (!_.isEmpty(nonPrefixedCaps)) {
+    log.warn(`The capabilities ${JSON.stringify(nonPrefixedCaps)} are not standard capabilities and should have an extension prefix`);
   }
 
   // Strip out the 'appium:' prefix from all
@@ -199,4 +211,4 @@ function processCapabilities (caps, constraints = {}, shouldValidateCaps = true)
 }
 
 
-export default { parseCaps, processCapabilities, validateCaps, mergeCaps };
+export default { parseCaps, processCapabilities, validateCaps, mergeCaps, findNonPrefixedCaps };


### PR DESCRIPTION
* Previously, it was going through alwaysMatch and all of the firstMatch caps and individually logging when any of them had unprefixed, non-standard caps
* Now it does them all at once
  * Made a helper function that takes a caps object ({alwaysMatch, firstMatch}) and finds all of the non-prefixed caps in all of them
  * Calls that function and logs warning