### PR TITLE
Rename ELEMENT key to W3C format

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -306,21 +306,21 @@ function getSwipeTouchDuration (waitGesture) {
 
 /**
  * Recursively find all instances of the key 'inKey' and rename them 'outKey'
- * @param {*} inp Any type of input
+ * @param {*} input Any type of input
  * @param {String} inKey The key name to replace
  * @param {String} outKey The key name to replace it with
  */
-function renameKey (inp, inKey, outKey) {
-  if (_.isArray(inp)) {
-    return inp.map((item) => renameKey(item, inKey, outKey));
-  } else if (_.isObject(inp)) {
-    return _.reduce(inp, (resultObj, value, key) => ({
+function renameKey (input, inKey, outKey) {
+  if (_.isArray(input)) {
+    return input.map((item) => renameKey(item, inKey, outKey));
+  } else if (_.isPlainObject(input)) {
+    return _.reduce(input, (resultObj, value, key) => ({
       ...resultObj,
       [key === inKey ? outKey : key]: renameKey(value, inKey, outKey),
     }), {});
   }
 
-  return inp;
+  return input;
 }
 
 export default { configureApp, downloadApp, downloadFile, copyLocalZip,

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -318,9 +318,9 @@ function renameKey (inp, inKey, outKey) {
       ...resultObj,
       [key === inKey ? outKey : key]: renameKey(value, inKey, outKey),
     }), {});
-  } else {
-    return inp;
   }
+
+  return inp;
 }
 
 export default { configureApp, downloadApp, downloadFile, copyLocalZip,

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -314,13 +314,10 @@ function renameKey (inp, inKey, outKey) {
   if (_.isArray(inp)) {
     return inp.map((item) => renameKey(item, inKey, outKey));
   } else if (_.isObject(inp)) {
-    return _.chain(inp)
-      .reduce((resultObj, value, key) => ({
-        ...resultObj,
-        [key === inKey ? outKey : key]: renameKey(value, inKey, outKey),
-      }), {})
-      //.omit(inKey)
-      .value();
+    return _.reduce(inp, (resultObj, value, key) => ({
+      ...resultObj,
+      [key === inKey ? outKey : key]: renameKey(value, inKey, outKey),
+    }), {});
   } else {
     return inp;
   }

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -303,6 +303,29 @@ function getSwipeTouchDuration (waitGesture) {
   return duration;
 }
 
+
+/**
+ * Recursively find all instances of the key 'inKey' and rename them 'outKey'
+ * @param {*} inp Any type of input
+ * @param {String} inKey The key name to replace
+ * @param {String} outKey The key name to replace it with
+ */
+function renameKey (inp, inKey, outKey) {
+  if (_.isArray(inp)) {
+    return inp.map((item) => renameKey(item, inKey, outKey));
+  } else if (_.isObject(inp)) {
+    return _.chain(inp)
+      .reduce((resultObj, value, key) => ({
+        ...resultObj,
+        [key === inKey ? outKey : key]: renameKey(value, inKey, outKey),
+      }), {})
+      //.omit(inKey)
+      .value();
+  } else {
+    return inp;
+  }
+}
+
 export default { configureApp, downloadApp, downloadFile, copyLocalZip,
                  unzipApp, unzipFile, testZipArchive, isPackageOrBundle,
-                 getCoordDefault, getSwipeTouchDuration, copyFromWindowsNetworkShare };
+                 getCoordDefault, getSwipeTouchDuration, copyFromWindowsNetworkShare, renameKey };

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -3,6 +3,7 @@ import { logger, util } from 'appium-support';
 import { validators } from './validators';
 import { errors, isErrorType, MJSONWPError, errorFromCode } from './errors';
 import { METHOD_MAP, NO_SESSION_ID_COMMANDS } from './routes';
+import { renameKey } from '../basedriver/helpers';
 import B from 'bluebird';
 
 
@@ -295,6 +296,20 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
           };
         }
       }
+
+      // If the MJSONWP element key format (ELEMENT) was provided translate it to W3C element key format (element-6066-11e4-a52e-4f735466cecf)
+      // and vice-versa
+      if (driverRes) {
+        const MJSONWP_ELEMENT_KEY = 'ELEMENT';
+        const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
+        if (driver.isW3CProtocol()) {
+          driverRes = renameKey(driverRes, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY);
+        } else {
+          driverRes = renameKey(driverRes, W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY);
+        }
+      }
+
+
       // convert undefined to null, but leave all other values the same
       if (_.isUndefined(driverRes)) {
         driverRes = null;

--- a/lib/mjsonwp/mjsonwp.js
+++ b/lib/mjsonwp/mjsonwp.js
@@ -12,6 +12,9 @@ const JSONWP_SUCCESS_STATUS_CODE = 0;
 // TODO: Make this value configurable as a server side capability
 const LOG_OBJ_LENGTH = 1024; // MAX LENGTH Logged to file / console
 
+const MJSONWP_ELEMENT_KEY = 'ELEMENT';
+const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
+
 class MJSONWP {}
 
 function isSessionCommand (command) {
@@ -300,8 +303,6 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // If the MJSONWP element key format (ELEMENT) was provided translate it to W3C element key format (element-6066-11e4-a52e-4f735466cecf)
       // and vice-versa
       if (driverRes) {
-        const MJSONWP_ELEMENT_KEY = 'ELEMENT';
-        const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
         if (driver.isW3CProtocol()) {
           driverRes = renameKey(driverRes, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY);
         } else {
@@ -435,4 +436,4 @@ async function doJwpProxy (driver, req, res) {
 }
 
 
-export { MJSONWP, routeConfiguringFunction, isSessionCommand };
+export { MJSONWP, routeConfiguringFunction, isSessionCommand, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY };

--- a/test/basedriver/helpers-specs.js
+++ b/test/basedriver/helpers-specs.js
@@ -68,5 +68,36 @@ describe('helpers', function () {
         should.equal(renameKey(item), item);
       });
     });
+    it('should rename keys on big complex objects', function () {
+      const input = [
+        {'foo': 'bar'},
+        {
+          hello: {
+            world: {
+              'foo': 'BAR',
+            }
+          },
+          foo: 'bahr'
+        },
+        'foo',
+        null,
+        0
+      ];
+      const expectedOutput = [
+        {'FOO': 'bar'},
+        {
+          hello: {
+            world: {
+              'FOO': 'BAR',
+            }
+          },
+          FOO: 'bahr'
+        },
+        'foo',
+        null,
+        0
+      ];
+      renameKey(input, 'foo', 'FOO').should.deep.equal(expectedOutput);
+    });
   });
 });

--- a/test/basedriver/helpers-specs.js
+++ b/test/basedriver/helpers-specs.js
@@ -1,4 +1,4 @@
-import { isPackageOrBundle, unzipFile } from '../../lib/basedriver/helpers';
+import { isPackageOrBundle, unzipFile, renameKey } from '../../lib/basedriver/helpers';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
@@ -7,6 +7,7 @@ import { system, fs } from 'appium-support';
 import mockFS from 'mock-fs';
 
 chai.use(chaiAsPromised);
+const should = chai.should();
 
 describe('helpers', function () {
   describe('#isPackageOrBundle', function () {
@@ -43,6 +44,29 @@ describe('helpers', function () {
       await unzipFile(path.resolve(mockDir, 'FakeIOSApp.app.zip'));
       await fs.readFile(path.resolve(mockDir, 'FakeIOSApp.app'), 'utf8').should.eventually.deep.equal('this is not really an app\n');
       forceWindows.restore();
+    });
+  });
+
+  describe('#renameKey', function () {
+    it('should translate key in an object', function () {
+      renameKey({'foo': 'hello world'}, 'foo', 'bar').should.eql({'bar': 'hello world'});
+    });
+    it('should translate key in an object within an object', function () {
+      renameKey({'key': {'foo': 'hello world'}}, 'foo', 'bar').should.eql({'key': {'bar': 'hello world'}});
+    });
+    it('should translate key in an object with an array', function () {
+      renameKey([
+        {'key': {'foo': 'hello world'}},
+        {'foo': 'HELLO WORLD'}
+      ], 'foo', 'bar').should.eql([
+        {'key': {'bar': 'hello world'}},
+        {'bar': 'HELLO WORLD'}
+      ]);
+    });
+    it('should not do anything to primitives', function () {
+      [0, 1, -1, true, false, null, undefined, "", "Hello World"].forEach((item) => {
+        should.equal(renameKey(item), item);
+      });
     });
   });
 });

--- a/test/mjsonwp/mjsonwp-e2e-specs.js
+++ b/test/mjsonwp/mjsonwp-e2e-specs.js
@@ -9,6 +9,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import HTTPStatusCodes from 'http-status-codes';
 import { createProxyServer, addHandler } from './helpers';
+import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY } from '../../lib/mjsonwp/mjsonwp';
 
 let should = chai.should();
 chai.use(chaiAsPromised);
@@ -457,15 +458,14 @@ describe('MJSONWP', async function () {
         });
 
         it(`should translate element format from MJSONWP to W3C`, async function () {
-          const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
           const retValue = [
             {
               something: {
-                ELEMENT: 'fooo',
+                [MJSONWP_ELEMENT_KEY]: 'fooo',
                 other: 'bar'
               }
             }, {
-              ELEMENT: 'bar'
+              [MJSONWP_ELEMENT_KEY]: 'bar'
             },
             'ignore',
           ];

--- a/test/mjsonwp/mjsonwp-e2e-specs.js
+++ b/test/mjsonwp/mjsonwp-e2e-specs.js
@@ -456,7 +456,45 @@ describe('MJSONWP', async function () {
           delete driver.performActions;
         });
 
-        it(`should fail with a 408 error if it throws a TimeoutError exception`, async function () {
+        it(`should translate element format from MJSONWP to W3C`, async function () {
+          const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
+          const retValue = [
+            {
+              something: {
+                ELEMENT: 'fooo',
+                other: 'bar'
+              }
+            }, {
+              ELEMENT: 'bar'
+            },
+            'ignore',
+          ];
+
+          const expectedValue = [
+            {
+              something: {
+                [W3C_ELEMENT_KEY]: 'fooo',
+                other: 'bar'
+              }
+            }, {
+              [W3C_ELEMENT_KEY]: 'bar'
+            },
+            'ignore',
+          ];
+
+          const findElementsBackup = driver.findElements;
+          driver.findElements = () => retValue;
+          const {value} = await request.post(`${sessionUrl}/elements`, {
+            json: {
+              using: 'whatever',
+              value: 'whatever',
+            },
+          });
+          value.should.deep.equal(expectedValue);
+          driver.findElements = findElementsBackup;
+        });
+
+        it(`should fail with a 408 error if it throws a TimeoutError exception`, async () => {
           sinon.stub(driver, 'setUrl', () => { throw new errors.TimeoutError; });
           let {statusCode} = await request({
             url: `${sessionUrl}/url`,


### PR DESCRIPTION
* If server encounters a response that has the wrong key name (if it's a W3C session and ELEMENT is provided when it should be 'element-6066-11e4-a52e-4f735466cecf'), rename all instances of that key
* Added a helper method `renameKey` that recursively finds instances of a 'key' and renames it
* Added unit tests for `renameKey`
* Added e2e test that mocks `findElements`, calls `/elements` endpoint and verifies that the payload was correctly renamed