### PR TITLE
Tune application management endpoints

### DIFF
--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -398,15 +398,45 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/current_package': {
     GET: {command: 'getCurrentPackage'}
   },
+  //region Applications Management
   '/wd/hub/session/:sessionId/appium/device/install_app': {
-    POST: {command: 'installApp', payloadParams: {required: ['appPath']}}
+    POST: {command: 'installApp',
+      payloadParams: {
+        required: ['appPath'],
+        optional: ['options']
+      }
+    }
   },
   '/wd/hub/session/:sessionId/appium/device/remove_app': {
-    POST: {command: 'removeApp', payloadParams: {required: [['appId'], ['bundleId']]}}
+    POST: {command: 'removeApp',
+      payloadParams: {
+        required: [['appId'], ['bundleId']],
+        optional: ['options']
+      }
+    }
+  },
+  '/wd/hub/session/:sessionId/appium/device/terminate_app': {
+    POST: {command: 'terminateApp',
+      payloadParams: {
+        required: [['appId'], ['bundleId']]
+      }
+    }
   },
   '/wd/hub/session/:sessionId/appium/device/app_installed': {
-    POST: {command: 'isAppInstalled', payloadParams: {required: ['bundleId']}}
+    POST: {command: 'isAppInstalled',
+      payloadParams: {
+        required: [['appId'], ['bundleId']]
+      }
+    }
   },
+  '/wd/hub/session/:sessionId/appium/device/app_state': {
+    GET: {command: 'queryAppState',
+      payloadParams: {
+        required: [['appId'], ['bundleId']]
+      }
+    }
+  },
+  //endregion
   '/wd/hub/session/:sessionId/appium/device/hide_keyboard': {
     POST: {command: 'hideKeyboard', payloadParams: {optional: ['strategy', 'key', 'keyCode', 'keyName']}}
   },

--- a/lib/mjsonwp/routes.js
+++ b/lib/mjsonwp/routes.js
@@ -418,7 +418,8 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/terminate_app': {
     POST: {command: 'terminateApp',
       payloadParams: {
-        required: [['appId'], ['bundleId']]
+        required: [['appId'], ['bundleId']],
+        optional: ['options']
       }
     }
   },

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -40,7 +40,7 @@ describe('MJSONWP', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('f634eef8');
+      hash.should.equal('59c5e66c');
     });
   });
 

--- a/test/mjsonwp/routes-specs.js
+++ b/test/mjsonwp/routes-specs.js
@@ -40,7 +40,7 @@ describe('MJSONWP', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('21ceab6b');
+      hash.should.equal('f634eef8');
     });
   });
 


### PR DESCRIPTION
I'd like to generalise this application management interface for both Android and iOS (XCUITest) and deprecate the corresponding `mobile:` helpers in the next major driver version.

Related to https://github.com/appium/appium-android-driver/pull/300