### PR TITLE
Fixed W3C error messaging

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ export default BaseDriver;
 
 // MJSONWP exports
 import { Protocol, routeConfiguringFunction, errors, isErrorType,
-         errorFromCode, ALL_COMMANDS, METHOD_MAP, routeToCommandName,
+         errorFromMJSONWPStatusCode, errorFromW3CJsonCode,
+         ALL_COMMANDS, METHOD_MAP, routeToCommandName,
          NO_SESSION_ID_COMMANDS, isSessionCommand } from './lib/protocol';
 
 export { Protocol, routeConfiguringFunction, errors, isErrorType,
-         errorFromCode, ALL_COMMANDS, METHOD_MAP, routeToCommandName,
+         errorFromMJSONWPStatusCode, errorFromW3CJsonCode, errorFromW3CJsonCode as errorFromCode,
+         ALL_COMMANDS, METHOD_MAP, routeToCommandName,
          NO_SESSION_ID_COMMANDS, isSessionCommand };
 
 // Express exports

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -150,7 +150,7 @@ class JWProxy {
         responseError = _.isPlainObject(e.error) ? e.error : null;
       }
       throw new errors.ProxyRequestError(`Could not proxy command to remote server. `  +
-                            `Original error: ${e.message}`, responseError, e.statusCode, e.error);
+                            `Original error: ${e.message}`, responseError, e.statusCode);
     }
     return [res, resBody];
   }

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -150,7 +150,7 @@ class JWProxy {
         responseError = _.isPlainObject(e.error) ? e.error : null;
       }
       throw new errors.ProxyRequestError(`Could not proxy command to remote server. `  +
-                          `Original error: ${e.message}`, responseError);
+                            `Original error: ${e.message}`, responseError, e.statusCode, e.error);
     }
     return [res, resBody];
   }

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -539,8 +539,14 @@ class BadParametersError extends ES6Error {
  * for proxy failure to generate the client response.
  */
 class ProxyRequestError extends ES6Error {
-  constructor (err, jsonwp) {
-    let message = `Proxy request unsuccessful. ${util.hasValue(jsonwp) ? jsonwp.value : ''}`;
+  constructor (err, jsonwp, httpStatus, w3cError) {
+    let origMessage = '';
+    if (util.hasValue(jsonwp)) {
+      origMessage = jsonwp.value;
+    } else if (_.isPlainObject(w3cError) && w3cError.message) {
+      origMessage = w3cError.value.message;
+    }
+    let message = `Proxy request unsuccessful. ${origMessage}`;
     super(err || message);
     this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
     if (typeof jsonwp === 'string') {
@@ -548,16 +554,19 @@ class ProxyRequestError extends ES6Error {
     } else {
       this.jsonwp = jsonwp;
     }
+    this.w3cStatus = httpStatus;
+    if (_.isPlainObject(w3cError) && _.isPlainObject(w3cError.value)) {
+      this.w3c = w3cError.value;
+    }
   }
 
   getActualError () {
     // If it's MJSONWP error, returns actual error cause for request failure based on `jsonwp.status`
     if (util.hasValue(this.jsonwp) && util.hasValue(this.jsonwp.status) && util.hasValue(this.jsonwp.value)) {
       return errorFromMJSONWPStatusCode(this.jsonwp.status, this.jsonwp.value);
-    } else if (_.isPlainObject(this.jsonwp.value) && util.hasValue(this.jsonwp.value.error)) {
-      return errorFromW3CJsonCode(this.jsonwp.value.error, this.jsonwp.value.message);
+    } else if (util.hasValue(this.w3c) && _.isNumber(this.w3cStatus) && this.w3cStatus >= 300) {
+      return errorFromW3CJsonCode(this.w3c.error, this.message);
     }
-    // TODO: Handle W3C proxying
     return new UnknownError(this.message);
   }
 }
@@ -630,9 +639,13 @@ function isErrorType (err, type) {
     let hasJsonwpObj = !!err.jsonwp;
     if (hasJsonwpObj) {
       return !!err.jsonwp.status;
-    } else {
-      return false;
     }
+
+    if (_.isPlainObject(err.w3c)) {
+      return _.isNumber(err.w3cStatus) && err.w3cStatus >= 300;
+    }
+
+    return false;
   }
   return err.constructor.name === type.name;
 }

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -552,7 +552,7 @@ class ProxyRequestError extends ES6Error {
     super(err || message);
 
     this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
-    if (typeof responseError === 'string') {
+    if (_.isString(responseError)) {
       this.jsonwp = JSON.parse(responseError);
     } else {
       if (_.isPlainObject(responseError) && _.isPlainObject(responseError.value)) {
@@ -640,8 +640,7 @@ function isErrorType (err, type) {
     return !!err.jsonwpCode;
   } else if (type.name === ProxyRequestError.name) {
     // `status` is `0` on success
-    let hasJsonwpObj = !!err.jsonwp;
-    if (hasJsonwpObj) {
+    if (err.jsonwp) {
       return !!err.jsonwp.status;
     }
 
@@ -657,10 +656,11 @@ function isErrorType (err, type) {
 /**
  * Retrieve an error derived from MJSONWP status
  * @param {number} code JSONWP status code
- * @param {string} message
+ * @param {string} message The error message
+ * @return {ProtocolError} The error that is associated with provided JSONWP status code
  */
 function errorFromMJSONWPStatusCode (code, message) {
-  if (code !== 13 && jsonwpErrorCodeMap[code]) {
+  if (code !== UnknownError.code() && jsonwpErrorCodeMap[code]) {
     return new jsonwpErrorCodeMap[code](message);
   }
   return new UnknownError(message);
@@ -669,6 +669,8 @@ function errorFromMJSONWPStatusCode (code, message) {
 /**
  * Retrieve an error derived from W3C JSON Code
  * @param {string} code W3C error string (see https://www.w3.org/TR/webdriver/#handling-errors `JSON Error Code` column)
+ * @param {string} the error message
+ * @return {ProtocolError}  The error that is associated with the W3C error string
  */
 function errorFromW3CJsonCode (code, message) {
   if (code && w3cErrorCodeMap[code.toLowerCase()]) {

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -539,24 +539,28 @@ class BadParametersError extends ES6Error {
  * for proxy failure to generate the client response.
  */
 class ProxyRequestError extends ES6Error {
-  constructor (err, jsonwp, httpStatus, w3cError) {
+  constructor (err, responseError, httpStatus) {
     let origMessage = '';
-    if (util.hasValue(jsonwp)) {
-      origMessage = jsonwp.value;
-    } else if (_.isPlainObject(w3cError) && w3cError.message) {
-      origMessage = w3cError.value.message;
+    if (util.hasValue(responseError)) {
+      if (_.isString(responseError.value)) {
+        origMessage = responseError.value;
+      } else if (_.isPlainObject(responseError.value) && _.isString(responseError.value.message)) {
+        origMessage = responseError.value.message;
+      }
     }
     let message = `Proxy request unsuccessful. ${origMessage}`;
     super(err || message);
+
     this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
-    if (typeof jsonwp === 'string') {
-      this.jsonwp = JSON.parse(jsonwp);
+    if (typeof responseError === 'string') {
+      this.jsonwp = JSON.parse(responseError);
     } else {
-      this.jsonwp = jsonwp;
-    }
-    this.w3cStatus = httpStatus;
-    if (_.isPlainObject(w3cError) && _.isPlainObject(w3cError.value)) {
-      this.w3c = w3cError.value;
+      if (_.isPlainObject(responseError) && _.isPlainObject(responseError.value)) {
+        this.w3c = responseError.value;
+        this.w3cStatus = httpStatus || HTTPStatusCodes.BAD_REQUEST;
+      } else {
+        this.jsonwp = responseError;
+      }
     }
   }
 

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -28,7 +28,7 @@ class NoSuchDriverError extends ProtocolError {
     return HTTPStatusCodes.NOT_FOUND;
   }
   static error () {
-    return 'The given session id is not in the list of active sessions';
+    return 'invalid session id';
   }
   constructor (err) {
     super(err || 'A session is either terminated or not started', NoSuchDriverError.code(), NoSuchDriverError.w3cStatus(), NoSuchDriverError.error());
@@ -57,7 +57,7 @@ class NoSuchFrameError extends ProtocolError {
     return 8;
   }
   static error () {
-    return 'A command to switch to a frame could not be satisfied because the frame could not be found';
+    return 'no such frame';
   }
   constructor (err) {
     super(err || 'A request to switch to a frame could not be satisfied because ' +
@@ -73,7 +73,7 @@ class UnknownCommandError extends ProtocolError {
     return HTTPStatusCodes.NOT_FOUND;
   }
   static error () {
-    return 'A command could not be executed because the remote end is not aware of it';
+    return 'unknown command';
   }
   constructor (err) {
     super(err || 'The requested resource could not be found, or a request was ' +
@@ -87,7 +87,7 @@ class StaleElementReferenceError extends ProtocolError {
     return 10;
   }
   static error () {
-    return 'A command failed because the referenced element is no longer attached to the DOM';
+    return 'stale element reference';
   }
   constructor (err) {
     super(err || 'An element command failed because the referenced element is no ' +
@@ -110,7 +110,7 @@ class InvalidElementStateError extends ProtocolError {
     return 12;
   }
   static error () {
-    return 'A command could not be completed because the element is in an invalid state';
+    return 'invalid element state';
   }
   constructor (err) {
     super(err || 'An element command could not be completed because the element is ' +
@@ -127,7 +127,7 @@ class UnknownError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'An unknown error occurred in the remote end while processing the command';
+    return 'unknown error';
   }
   constructor (originalError) {
     let origMessage = originalError;
@@ -149,10 +149,10 @@ class UnknownMethodError extends ProtocolError {
     return HTTPStatusCodes.METHOD_NOT_ALLOWED;
   }
   static error () {
-    return 'The requested command matched a known URL but did not match an method for that URL';
+    return 'unknown method';
   }
   constructor (err) {
-    super(err || 'Unknown method.', null, UnknownMethodError.w3cStatus(), UnknownMethodError.error());
+    super(err || 'The requested command matched a known URL but did not match an method for that URL', null, UnknownMethodError.w3cStatus(), UnknownMethodError.error());
   }
 }
 
@@ -161,7 +161,7 @@ class UnsupportedOperationError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'A command that should have executed properly cannot be supported for some reason';
+    return 'unsupported operation';
   }
   constructor (err) {
     super(err || 'A server-side error occurred. Command cannot be supported.',
@@ -174,7 +174,7 @@ class ElementIsNotSelectableError extends ProtocolError {
     return 15;
   }
   static error () {
-    return 'An attempt was made to select an element that cannot be selected';
+    return 'element not selectable';
   }
   constructor (err) {
     super(err || 'An attempt was made to select an element that cannot be selected.',
@@ -184,28 +184,28 @@ class ElementIsNotSelectableError extends ProtocolError {
 
 class ElementClickInterceptedError extends ProtocolError {
   static error () {
-    return 'The Element Click command could not be completed because the element receiving the events is obscuring the element that was requested clicked';
+    return 'element click intercepted';
   }
   constructor (err) {
-    super(err || ElementClickInterceptedError.error(), ElementIsNotSelectableError.code(), null, ElementClickInterceptedError.error());
+    super(err || 'The Element Click command could not be completed because the element receiving the events is obscuring the element that was requested clicked', ElementIsNotSelectableError.code(), null, ElementClickInterceptedError.error());
   }
 }
 
 class ElementNotInteractableError extends ProtocolError {
   static error () {
-    return 'A command could not be completed because the element is not pointer- or keyboard interactable';
+    return 'element not interactable';
   }
   constructor (err) {
-    super(err || ElementNotInteractableError.error(), ElementIsNotSelectableError.code(), null, ElementNotInteractableError.error());
+    super(err || 'A command could not be completed because the element is not pointer- or keyboard interactable', ElementIsNotSelectableError.code(), null, ElementNotInteractableError.error());
   }
 }
 
 class InsecureCertificateError extends ProtocolError {
   static error () {
-    return 'An action caused the user agent to hit a certificate warning, which is usually the result of an expired or invalid TLS certificate.';
+    return 'insecure certificate';
   }
   constructor (err) {
-    super(err || InsecureCertificateError.error(), ElementIsNotSelectableError.code(), null, InsecureCertificateError.error());
+    super(err || 'Navigation caused the user agent to hit a certificate warning, which is usually the result of an expired or invalid TLS certificate', ElementIsNotSelectableError.code(), null, InsecureCertificateError.error());
   }
 }
 
@@ -217,7 +217,7 @@ class JavaScriptError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'An error occurred while executing JavaScript supplied by the user';
+    return 'javascript error';
   }
   constructor (err) {
     super(err || 'An error occurred while executing user supplied JavaScript.',
@@ -243,7 +243,7 @@ class TimeoutError extends ProtocolError {
     return HTTPStatusCodes.REQUEST_TIMEOUT;
   }
   static error () {
-    return 'An operation did not complete before its timeout expired';
+    return 'timeout';
   }
   constructor (err) {
     super(err || 'An operation did not complete before its timeout expired.',
@@ -256,7 +256,7 @@ class NoSuchWindowError extends ProtocolError {
     return 23;
   }
   static error () {
-    return 'A command to switch to a window could not be satisfied because the window could not be found';
+    return 'no such window';
   }
   constructor (err) {
     super(err || 'A request to switch to a different window could not be satisfied ' +
@@ -265,6 +265,9 @@ class NoSuchWindowError extends ProtocolError {
 }
 
 class InvalidArgumentError extends ProtocolError {
+  static error () {
+    return 'invalid argument';
+  }
   constructor (err) {
     super(err || 'The arguments passed to the command are either invalid or malformed', null, null, BadParametersError.error());
   }
@@ -275,7 +278,7 @@ class InvalidCookieDomainError extends ProtocolError {
     return 24;
   }
   static error () {
-    return 'An illegal attempt was made to set a cookie under a different domain than the current page';
+    return 'invalid cookie domain';
   }
   constructor (err) {
     super(err || 'An illegal attempt was made to set a cookie under a different ' +
@@ -285,10 +288,10 @@ class InvalidCookieDomainError extends ProtocolError {
 
 class InvalidCoordinatesError extends ProtocolError {
   static error () {
-    return 'The coordinates provided to an interactions operation are invalid';
+    return 'invalid coordinates';
   }
   constructor (err) {
-    super(err || InvalidCoordinatesError.error(), ElementIsNotSelectableError.code(), null, InvalidCoordinatesError.error());
+    super(err || 'The coordinates provided to an interactions operation are invalid', ElementIsNotSelectableError.code(), null, InvalidCoordinatesError.error());
   }
 }
 
@@ -297,10 +300,10 @@ class NoSuchCookieError extends ProtocolError {
     return HTTPStatusCodes.NOT_FOUND;
   }
   static error () {
-    return 'No cookie matching the given path name was found amongst the associated cookies of the current browsing context’s active document';
+    return 'no such cookie';
   }
   constructor (err) {
-    super(err || 'Could not find cookie', null, NoSuchCookieError.w3cStatus(), NoSuchCookieError.error());
+    super(err || 'No cookie matching the given path name was found amongst the associated cookies of the current browsing context’s active document', null, NoSuchCookieError.w3cStatus(), NoSuchCookieError.error());
   }
 }
 
@@ -312,7 +315,7 @@ class UnableToSetCookieError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'A command to set a cookie’s value could not be satisfied';
+    return 'unable to set cookie';
   }
   constructor (err) {
     super(err || 'A request to set a cookie\'s value could not be satisfied.',
@@ -328,7 +331,7 @@ class UnexpectedAlertOpenError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'A modal dialog was open, blocking this operation';
+    return 'unexpected alert open';
   }
   constructor (err) {
     super(err || 'A modal dialog was open, blocking this operation',
@@ -354,7 +357,7 @@ class ScriptTimeoutError extends ProtocolError {
     return HTTPStatusCodes.REQUEST_TIMEOUT;
   }
   static error () {
-    return 'A script did not complete before its timeout expired';
+    return 'script timeout';
   }
   constructor (err) {
     super(err || 'A script did not complete before its timeout expired.',
@@ -396,7 +399,7 @@ class InvalidSelectorError extends ProtocolError {
     return 32;
   }
   static error () {
-    return 'Argument was an invalid selector';
+    return 'invalid selector';
   }
   constructor (err) {
     super(err || 'Argument was an invalid selector (e.g. XPath/CSS).',
@@ -412,7 +415,7 @@ class SessionNotCreatedError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'A new session could not be created';
+    return 'session not created';
   }
   constructor (details) {
     let message = 'A new session could not be created.';
@@ -432,7 +435,7 @@ class MoveTargetOutOfBoundsError extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'The target for mouse interaction is not in the browser’s viewport and cannot be brought into that viewport';
+    return 'move target out of bounds';
   }
   constructor (err) {
     super(err || 'Target provided for a move action is out of bounds.',
@@ -442,10 +445,10 @@ class MoveTargetOutOfBoundsError extends ProtocolError {
 
 class NoSuchAlertError extends ProtocolError {
   static error () {
-    return 'An attempt was made to operate on a modal dialog when one was not open';
+    return 'no such alert';
   }
   constructor (err) {
-    super(err || NoSuchAlertError.error(), null, null, NoSuchAlertError.error());
+    super(err || 'The target for mouse interaction is not in the browser’s viewport and cannot be brought into that viewport', null, null, NoSuchAlertError.error());
   }
 }
 
@@ -468,7 +471,7 @@ class InvalidContextError extends ProtocolError {
   }
 }
 
-// Treat this as an alias for UnknownCommandError
+// This is an alias for UnknownMethodError
 class NotYetImplementedError extends ProtocolError {
   static code () {
     return 13;
@@ -476,9 +479,12 @@ class NotYetImplementedError extends ProtocolError {
   static w3cStatus () {
     return HTTPStatusCodes.NOT_FOUND; // W3C equivalent is called 'Unknown Command' (A command could not be executed because the remote end is not aware of it)
   }
+  static error () {
+    return 'unknown method';
+  }
   constructor (err) {
     super(err || 'Method has not yet been implemented',
-      NotYetImplementedError.code(), NotYetImplementedError.w3cStatus(), UnknownCommandError.error());
+      NotYetImplementedError.code(), NotYetImplementedError.w3cStatus(), NotYetImplementedError.error());
   }
 }
 
@@ -499,10 +505,10 @@ class UnableToCaptureScreen extends ProtocolError {
     return HTTPStatusCodes.INTERNAL_SERVER_ERROR;
   }
   static error () {
-    return 'A screen capture was made impossible';
+    return 'unable to capture screen';
   }
   constructor (err) {
-    super(err || 'Unable to capture screen', null, UnableToCaptureScreen.w3cStatus(), UnableToCaptureScreen.error());
+    super(err || 'A screen capture was made impossible', null, UnableToCaptureScreen.w3cStatus(), UnableToCaptureScreen.error());
   }
 }
 
@@ -510,7 +516,7 @@ class UnableToCaptureScreen extends ProtocolError {
 // Equivalent to W3C InvalidArgumentError
 class BadParametersError extends ES6Error {
   static error () {
-    return 'The arguments passed to a command are either invalid or malformed';
+    return 'invalid argument';
   }
   constructor (requiredParams, actualParams, errMessage) {
     let message;
@@ -631,8 +637,6 @@ function isErrorType (err, type) {
   return err.constructor.name === type.name;
 }
 
-// retrieve an error with the code and message
-
 /**
  * Retrieve an error derived from MJSONWP status
  * @param {number} code JSONWP status code
@@ -650,8 +654,8 @@ function errorFromMJSONWPStatusCode (code, message) {
  * @param {string} code W3C error string (see https://www.w3.org/TR/webdriver/#handling-errors `JSON Error Code` column)
  */
 function errorFromW3CJsonCode (code, message) {
-  if (w3cErrorCodeMap[code]) {
-    return new w3cErrorCodeMap[code](message);
+  if (code && w3cErrorCodeMap[code.toLowerCase()]) {
+    return new w3cErrorCodeMap[code.toLowerCase()](message);
   }
   return new UnknownError(message);
 }
@@ -667,12 +671,13 @@ function getResponseForW3CError (err) {
   if (isErrorType(err, errors.BadParametersError)) {
     // respond with a 400 if we have bad parameters
     w3cLog.debug(`Bad parameters: ${err}`);
-    httpStatus = HTTPStatusCodes.BAD_REQUEST;
-    error = 'The arguments passed to a command are either invalid or malformed';
+    error = BadParametersError.error();
   } else {
     error = err.error;
   }
+
   httpStatus = err.w3cStatus;
+
   let httpResBody = {
     value: {
       error,

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -44,7 +44,7 @@ class NoSuchElementError extends ProtocolError {
     return HTTPStatusCodes.NOT_FOUND;
   }
   static error () {
-    return 'An element could not be located on the page using the given search parameters';
+    return 'no such element';
   }
   constructor (err) {
     super(err || 'An element could not be located on the page using the given ' +
@@ -545,9 +545,11 @@ class ProxyRequestError extends ES6Error {
   }
 
   getActualError () {
+    // If it's MJSONWP error, returns actual error cause for request failure based on `jsonwp.status`
     if (util.hasValue(this.jsonwp) && util.hasValue(this.jsonwp.status) && util.hasValue(this.jsonwp.value)) {
-      //returns actual error cause for request failure based on `jsonwp.status`
-      return errorFromCode(this.jsonwp.status, this.jsonwp.value);
+      return errorFromMJSONWPStatusCode(this.jsonwp.status, this.jsonwp.value);
+    } else if (_.isPlainObject(this.jsonwp.value) && util.hasValue(this.jsonwp.value.error)) {
+      return errorFromW3CJsonCode(this.jsonwp.value.error, this.jsonwp.value.message);
     }
     // TODO: Handle W3C proxying
     return new UnknownError(this.message);
@@ -596,12 +598,21 @@ const errors = {NotYetImplementedError,
                 ProxyRequestError};
 
 // map of error code to error class
-const errorCodeMap = {};
+const jsonwpErrorCodeMap = {};
 for (let ErrorClass of _.values(errors)) {
   if (ErrorClass.code) {
-    errorCodeMap[ErrorClass.code()] = ErrorClass;
+    jsonwpErrorCodeMap[ErrorClass.code()] = ErrorClass;
   }
 }
+
+const w3cErrorCodeMap = {};
+for (let ErrorClass of _.values(errors)) {
+  if (ErrorClass.error) {
+    w3cErrorCodeMap[ErrorClass.error()] = ErrorClass;
+  }
+}
+
+
 
 function isErrorType (err, type) {
   // `name` property is the constructor name
@@ -621,9 +632,26 @@ function isErrorType (err, type) {
 }
 
 // retrieve an error with the code and message
-function errorFromCode (code, message) {
-  if (code !== 13 && errorCodeMap[code]) {
-    return new errorCodeMap[code](message);
+
+/**
+ * Retrieve an error derived from MJSONWP status
+ * @param {number} code JSONWP status code
+ * @param {string} message
+ */
+function errorFromMJSONWPStatusCode (code, message) {
+  if (code !== 13 && jsonwpErrorCodeMap[code]) {
+    return new jsonwpErrorCodeMap[code](message);
+  }
+  return new UnknownError(message);
+}
+
+/**
+ * Retrieve an error derived from W3C JSON Code
+ * @param {string} code W3C error string (see https://www.w3.org/TR/webdriver/#handling-errors `JSON Error Code` column)
+ */
+function errorFromW3CJsonCode (code, message) {
+  if (w3cErrorCodeMap[code]) {
+    return new w3cErrorCodeMap[code](message);
   }
   return new UnknownError(message);
 }
@@ -682,4 +710,4 @@ function getResponseForJsonwpError (err) {
   return [httpStatus, httpResBody];
 }
 
-export { ProtocolError, errors, isErrorType, errorFromCode, getResponseForW3CError, getResponseForJsonwpError };
+export { ProtocolError, errors, isErrorType, errorFromMJSONWPStatusCode, errorFromW3CJsonCode, getResponseForW3CError, getResponseForJsonwpError };

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -4,8 +4,8 @@ import { Protocol, isSessionCommand,
          routeConfiguringFunction } from './protocol';
 import { NO_SESSION_ID_COMMANDS, ALL_COMMANDS, METHOD_MAP,
          routeToCommandName } from './routes';
-import { errors, isErrorType, errorFromCode } from './errors';
+import { errors, isErrorType, errorFromMJSONWPStatusCode, errorFromW3CJsonCode } from './errors';
 
 export { Protocol, routeConfiguringFunction, errors, isErrorType,
-         errorFromCode, ALL_COMMANDS, METHOD_MAP, routeToCommandName,
+         errorFromMJSONWPStatusCode, errorFromW3CJsonCode, ALL_COMMANDS, METHOD_MAP, routeToCommandName,
          NO_SESSION_ID_COMMANDS, isSessionCommand };

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -296,7 +296,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // if the status is not 0,  throw the appropriate error for status code.
       if (util.hasValue(driverRes)) {
-        if (util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0 && !_.isNaN(driverRes.status)) {
+        if (util.hasValue(driverRes.status) && !isNaN(driverRes.status) && parseInt(driverRes.status, 10) !== 0) {
           throw errorFromMJSONWPStatusCode(driverRes.status, driverRes.value);
         } else if (_.isPlainObject(driverRes.value) && driverRes.value.error) {
           throw errorFromW3CJsonCode(driverRes.value.error, driverRes.value.message);

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { logger, util } from 'appium-support';
 import { validators } from './validators';
-import { errors, isErrorType, ProtocolError, errorFromCode, getResponseForW3CError, getResponseForJsonwpError } from './errors';
+import { errors, isErrorType, ProtocolError, errorFromMJSONWPStatusCode, getResponseForW3CError, getResponseForJsonwpError } from './errors';
 import { METHOD_MAP, NO_SESSION_ID_COMMANDS } from './routes';
 import { renameKey } from '../basedriver/helpers';
 import B from 'bluebird';
@@ -296,7 +296,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // if the status is not 0,  throw the appropriate error for status code.
       if (util.hasValue(driverRes) && util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0) {
-        throw errorFromCode(driverRes.status, driverRes.value);
+        throw errorFromMJSONWPStatusCode(driverRes.status, driverRes.value);
       }
 
       // Response status should be the status set by the driver response.

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { logger, util } from 'appium-support';
 import { validators } from './validators';
-import { errors, isErrorType, ProtocolError, errorFromMJSONWPStatusCode, getResponseForW3CError, getResponseForJsonwpError } from './errors';
+import { errors, isErrorType, ProtocolError, errorFromMJSONWPStatusCode, errorFromW3CJsonCode, getResponseForW3CError, getResponseForJsonwpError } from './errors';
 import { METHOD_MAP, NO_SESSION_ID_COMMANDS } from './routes';
 import { renameKey } from '../basedriver/helpers';
 import B from 'bluebird';
@@ -295,8 +295,12 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // if the status is not 0,  throw the appropriate error for status code.
-      if (util.hasValue(driverRes) && util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0) {
-        throw errorFromMJSONWPStatusCode(driverRes.status, driverRes.value);
+      if (util.hasValue(driverRes)) {
+        if (util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0) {
+          throw errorFromMJSONWPStatusCode(driverRes.status, driverRes.value);
+        } else if (_.isPlainObject(driverRes.value) && driverRes.value.error) {
+          throw errorFromW3CJsonCode(driverRes.value.error, driverRes.value.message);
+        }
       }
 
       // Response status should be the status set by the driver response.

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -296,7 +296,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // if the status is not 0,  throw the appropriate error for status code.
       if (util.hasValue(driverRes)) {
-        if (util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0) {
+        if (util.hasValue(driverRes.status) && parseInt(driverRes.status, 10) !== 0 && !_.isNaN(driverRes.status)) {
           throw errorFromMJSONWPStatusCode(driverRes.status, driverRes.value);
         } else if (_.isPlainObject(driverRes.value) && driverRes.value.error) {
           throw errorFromW3CJsonCode(driverRes.value.error, driverRes.value.message);

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -3,6 +3,7 @@ import { getResponseForW3CError } from '../../lib/protocol/errors';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
+import HTTPStatusCodes from 'http-status-codes';
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -388,16 +389,15 @@ describe('.getActualError', function () {
 
   describe('W3C', function () {
     it('should map a 404 no such element error as a NoSuchElementError', function () {
-      const actualError = new errors.ProxyRequestError('Error message does not matter', {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', null, HTTPStatusCodes.NOT_FOUND, {
         value: {
           error: errors.NoSuchElementError.error(),
-
         },
       }).getActualError();
       isErrorType(actualError, errors.NoSuchElementError).should.be.true;
     });
     it('should map a 400 StaleElementReferenceError', function () {
-      const actualError = new errors.ProxyRequestError('Error message does not matter', {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', null, HTTPStatusCodes.BAD_REQUEST, {
         value: {
           error: errors.StaleElementReferenceError.error(),
 
@@ -406,12 +406,12 @@ describe('.getActualError', function () {
       isErrorType(actualError, errors.StaleElementReferenceError).should.be.true;
     });
     it('should map an unknown error to UnknownError', function () {
-      const actualError = new errors.ProxyRequestError('Error message does not matter', {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', null, {
         value: {
           error: 'Not a valid w3c JSON code'
 
         },
-      }).getActualError();
+      }, 456).getActualError();
       isErrorType(actualError, errors.UnknownError).should.be.true;
     });
   });

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -1,4 +1,4 @@
-import { errors, errorFromMJSONWPStatusCode, isErrorType } from '../..';
+import { errors, errorFromMJSONWPStatusCode, errorFromW3CJsonCode, isErrorType } from '../..';
 import { getResponseForW3CError } from '../../lib/protocol/errors';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -10,102 +10,226 @@ chai.should();
 // Error codes and messages have been added according to JsonWireProtocol see
 // https://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_Codes
 let errorsList = [
-  {errorName: 'NoSuchDriverError',
-   errorMsg: 'A session is either terminated or not started',
-   errorCode: 6},
-  {errorName: 'NoSuchElementError',
-   errorMsg: 'An element could not be located on the page using the ' +
-             'given search parameters.',
-   errorCode: 7},
-  {errorName: 'NoSuchFrameError',
-   errorMsg: 'A request to switch to a frame could not be satisfied ' +
-             'because the frame could not be found.',
-   errorCode: 8},
-  {errorName: 'UnknownCommandError',
-   errorMsg: 'The requested resource could not be found, or a request ' +
-             'was received using an HTTP method that is not supported by ' +
-             'the mapped resource.',
-   errorCode: 9},
-  {errorName: 'StaleElementReferenceError',
-   errorMsg: 'An element command failed because the referenced element is ' +
-             'no longer attached to the DOM.',
-   errorCode: 10},
-  {errorName: 'ElementNotVisibleError',
-   errorMsg: 'An element command could not be completed because the ' +
-             'element is not visible on the page.',
-   errorCode: 11},
-  {errorName: 'InvalidElementStateError',
-   errorMsg: 'An element command could not be completed because the element ' +
-             'is in an invalid state (e.g. attempting to click a disabled ' +
-             'element).',
-   errorCode: 12},
-  {errorName: 'UnknownError',
-   errorMsg: 'An unknown server-side error occurred while processing the ' +
-             'command.',
-   errorCode: 13},
-  {errorName: 'ElementIsNotSelectableError',
-   errorMsg: 'An attempt was made to select an element that cannot ' +
-             'be selected.',
-   errorCode: 15},
-  {errorName: 'JavaScriptError',
-   errorMsg: 'An error occurred while executing user supplied JavaScript.',
-   errorCode: 17},
-  {errorName: 'XPathLookupError',
-   errorMsg: 'An error occurred while searching for an element by XPath.',
-   errorCode: 19},
-  {errorName: 'TimeoutError',
-   errorMsg: 'An operation did not complete before its timeout expired.',
-   errorCode: 21},
-  {errorName: 'NoSuchWindowError',
-   errorMsg: 'A request to switch to a different window could not be ' +
-             'satisfied because the window could not be found.',
-   errorCode: 23},
-  {errorName: 'InvalidCookieDomainError',
-   errorMsg: 'An illegal attempt was made to set a cookie under a different ' +
-             'domain than the current page.',
-   errorCode: 24},
-  {errorName: 'UnableToSetCookieError',
-   errorMsg: `A request to set a cookie's value could not be satisfied.`,
-   errorCode: 25},
-  {errorName: 'UnexpectedAlertOpenError',
-   errorMsg: 'A modal dialog was open, blocking this operation',
-   errorCode: 26},
-  {errorName: 'NoAlertOpenError',
-   errorMsg: 'An attempt was made to operate on a modal dialog when one was ' +
-             'not open.',
-   errorCode: 27},
-  {errorName: 'ScriptTimeoutError',
-   errorMsg: 'A script did not complete before its timeout expired.',
-   errorCode: 28},
-  {errorName: 'InvalidElementCoordinatesError',
-   errorMsg: 'The coordinates provided to an interactions operation are ' +
-             'invalid.',
-   errorCode: 29},
-  {errorName: 'IMENotAvailableError',
-   errorMsg: 'IME was not available.',
-   errorCode: 30},
-  {errorName: 'IMEEngineActivationFailedError',
-   errorMsg: 'An IME engine could not be started.',
-   errorCode: 31},
-  {errorName: 'InvalidSelectorError',
-   errorMsg: 'Argument was an invalid selector (e.g. XPath/CSS).',
-   errorCode: 32},
-  {errorName: 'SessionNotCreatedError',
-   errorMsg: 'A new session could not be created.',
-   errorCode: 33},
-  {errorName: 'MoveTargetOutOfBoundsError',
-   errorMsg: 'Target provided for a move action is out of bounds.',
-   errorCode: 34},
-  {errorName: 'NotYetImplementedError',
-   errorMsg: 'Method has not yet been implemented',
-   errorCode: 13}
+  {
+    errorName: 'NoSuchDriverError',
+    errorMsg: 'A session is either terminated or not started',
+    error: 'invalid session id',
+    errorCode: 6
+  },
+  {
+    errorName: 'ElementClickInterceptedError',
+    errorMsg: 'The Element Click command could not be completed because the element receiving the events is obscuring the element that was requested clicked',
+    error: 'element click intercepted',
+  },
+  {
+    errorName: 'ElementNotInteractableError',
+    errorMsg: 'A command could not be completed because the element is not pointer- or keyboard interactable',
+    error: 'element not interactable',
+  },
+  {
+    errorName: 'InsecureCertificateError',
+    errorMsg: 'Navigation caused the user agent to hit a certificate warning, which is usually the result of an expired or invalid TLS certificate',
+    error: 'insecure certificate',
+  },
+  {
+    errorName: 'InvalidArgumentError',
+    errorMsg: 'The arguments passed to the command are either invalid or malformed',
+    error: 'invalid argument',
+  },
+  {
+    errorName: 'NoSuchElementError',
+    errorMsg: 'An element could not be located on the page using the ' +
+        'given search parameters.',
+    error: 'no such element',
+    errorCode: 7
+  },
+  {
+    errorName: 'NoSuchFrameError',
+    errorMsg: 'A request to switch to a frame could not be satisfied ' +
+        'because the frame could not be found.',
+    error: 'no such frame',
+    errorCode: 8
+  },
+  {
+    errorName: 'UnknownCommandError',
+    errorMsg: 'The requested resource could not be found, or a request ' +
+        'was received using an HTTP method that is not supported by ' +
+        'the mapped resource.',
+    error: 'unknown command',
+    errorCode: 9
+  },
+  {
+    errorName: 'StaleElementReferenceError',
+    errorMsg: 'An element command failed because the referenced element is ' +
+        'no longer attached to the DOM.',
+    error: 'stale element reference',
+    errorCode: 10
+  },
+  {
+    errorName: 'ElementNotVisibleError',
+    errorMsg: 'An element command could not be completed because the ' +
+        'element is not visible on the page.',
+    errorCode: 11
+  },
+  {
+    errorName: 'InvalidElementStateError',
+    errorMsg: 'An element command could not be completed because the element ' +
+        'is in an invalid state (e.g. attempting to click a disabled ' +
+        'element).',
+    error: 'invalid element state',
+    errorCode: 12
+  },
+  {
+    errorName: 'UnknownError',
+    errorMsg: 'An unknown server-side error occurred while processing the ' +
+        'command.',
+    error: 'unknown error',
+    errorCode: 13
+  },
+  {
+    errorName: 'ElementIsNotSelectableError',
+    errorMsg: 'An attempt was made to select an element that cannot ' +
+        'be selected.',
+    error: 'element not selectable',
+    errorCode: 15
+  },
+  {
+    errorName: 'JavaScriptError',
+    errorMsg: 'An error occurred while executing user supplied JavaScript.',
+    error: 'javascript error',
+    errorCode: 17
+  },
+  {
+    errorName: 'XPathLookupError',
+    errorMsg: 'An error occurred while searching for an element by XPath.',
+    errorCode: 19
+  },
+  {
+    errorName: 'TimeoutError',
+    errorMsg: 'An operation did not complete before its timeout expired.',
+    error: 'timeout',
+    errorCode: 21
+  },
+  {
+    errorName: 'NoSuchWindowError',
+    errorMsg: 'A request to switch to a different window could not be ' +
+        'satisfied because the window could not be found.',
+    error: 'no such window',
+    errorCode: 23
+  },
+  {
+    errorName: 'InvalidCookieDomainError',
+    errorMsg: 'An illegal attempt was made to set a cookie under a different ' +
+        'domain than the current page.',
+    error: 'invalid cookie domain',
+    errorCode: 24
+  },
+  {
+    errorName: 'InvalidCoordinatesError',
+    errorMsg: 'The coordinates provided to an interactions operation are invalid',
+    error: 'invalid coordinates',
+  },
+  {
+    errorName: 'UnableToSetCookieError',
+    errorMsg: `A request to set a cookie's value could not be satisfied.`,
+    error: 'unable to set cookie',
+    errorCode: 25
+  },
+  {
+    errorName: 'UnexpectedAlertOpenError',
+    errorMsg: 'A modal dialog was open, blocking this operation',
+    error: 'unexpected alert open',
+    errorCode: 26
+  },
+  {
+    errorName: 'NoAlertOpenError',
+    errorMsg: 'An attempt was made to operate on a modal dialog when one was ' +
+        'not open.',
+    errorCode: 27
+  },
+  {
+    errorName: 'ScriptTimeoutError',
+    errorMsg: 'A script did not complete before its timeout expired.',
+    error: 'script timeout',
+    errorCode: 28
+  },
+  {
+    errorName: 'InvalidElementCoordinatesError',
+    errorMsg: 'The coordinates provided to an interactions operation are ' +
+        'invalid.',
+    errorCode: 29
+  },
+  {
+    errorName: 'IMENotAvailableError',
+    errorMsg: 'IME was not available.',
+    errorCode: 30
+  },
+  {
+    errorName: 'IMEEngineActivationFailedError',
+    errorMsg: 'An IME engine could not be started.',
+    errorCode: 31
+  },
+  {
+    errorName: 'InvalidSelectorError',
+    errorMsg: 'Argument was an invalid selector (e.g. XPath/CSS).',
+    error: 'invalid selector',
+    errorCode: 32
+  },
+  {
+    errorName: 'SessionNotCreatedError',
+    errorMsg: 'A new session could not be created.',
+    error: 'session not created',
+    errorCode: 33
+  },
+  {
+    errorName: 'MoveTargetOutOfBoundsError',
+    errorMsg: 'Target provided for a move action is out of bounds.',
+    error: 'move target out of bounds',
+    errorCode: 34
+  },
+  {
+    errorName: 'NoSuchAlertError',
+    errorMsg: 'The target for mouse interaction is not in the browser’s viewport and cannot be brought into that viewport',
+    error: 'no such alert',
+  },
+  {
+    errorName: 'NoSuchCookieError',
+    errorMsg: 'No cookie matching the given path name was found amongst the associated cookies of the current browsing context’s active document',
+    error: 'no such cookie',
+  },
+  {
+    errorName: 'NotYetImplementedError',
+    errorMsg: 'Method has not yet been implemented',
+    error: 'unknown method',
+    errorCode: 13
+  },
+  {
+    errorName: 'UnknownCommandError',
+    errorMsg: 'The requested resource could not be found, or a request was received using an HTTP method that is not supported by the mapped resource.',
+    error: 'unknown command',
+  },
+  {
+    errorName: 'UnknownMethodError',
+    errorMsg: 'The requested command matched a known URL but did not match an method for that URL',
+    error: 'unknown method',
+  },
+  {
+    errorName: 'UnsupportedOperationError',
+    errorMsg: 'A server-side error occurred. Command cannot be supported.',
+    error: 'unsupported operation',
+  },
 ];
 
 describe('errors', function () {
   for (let error of errorsList) {
-    it(error.errorName + ' should have correct code and messg', function () {
-      new errors[error.errorName]()
-        .should.have.property('jsonwpCode', error.errorCode);
+    it(error.errorName + ' should have a JSONWP code or W3C code and messg', function () {
+      if (error.errorCode) {
+        new errors[error.errorName]()
+          .should.have.property('jsonwpCode', error.errorCode);
+      } else {
+        new errors[error.errorName]()
+          .should.have.property('error', error.error);
+      }
       new errors[error.errorName]()
         .should.have.property('message', error.errorMsg);
     });
@@ -127,15 +251,19 @@ describe('errorFromMJSONWPStatusCode', function () {
   for (let error of errorsList) {
     if (error.errorName !== 'NotYetImplementedError') {
       it(error.errorCode + ' should return correct error', function () {
-        errorFromMJSONWPStatusCode(error.errorCode)
-          .should.have.property('jsonwpCode', error.errorCode);
-        errorFromMJSONWPStatusCode(error.errorCode)
-          .should.have.property('message', error.errorMsg);
-        if (!_.includes([13, 33], error.errorCode)) {
-          errorFromMJSONWPStatusCode(error.errorCode, 'abcd')
+        if (error.errorCode) {
+          errorFromMJSONWPStatusCode(error.errorCode)
             .should.have.property('jsonwpCode', error.errorCode);
-          errorFromMJSONWPStatusCode(error.errorCode, 'abcd')
-            .should.have.property('message', 'abcd');
+          errorFromMJSONWPStatusCode(error.errorCode)
+            .should.have.property('message', error.errorMsg);
+          if (!_.includes([13, 33], error.errorCode)) {
+            errorFromMJSONWPStatusCode(error.errorCode, 'abcd')
+              .should.have.property('jsonwpCode', error.errorCode);
+            errorFromMJSONWPStatusCode(error.errorCode, 'abcd')
+              .should.have.property('message', 'abcd');
+          }
+        } else {
+          isErrorType(errorFromMJSONWPStatusCode(error.errorCode), errors.UnknownError).should.be.true;
         }
       });
     }
@@ -146,6 +274,26 @@ describe('errorFromMJSONWPStatusCode', function () {
     errorFromMJSONWPStatusCode(99)
       .should.have.property('message', 'An unknown server-side error occurred ' +
                                        'while processing the command.');
+  });
+});
+describe('errorFromW3CJsonCode', function () {
+  for (let error of errorsList) {
+    if (error.errorName !== 'NotYetImplementedError') {
+      it(error.errorName + ' should return correct error', function () {
+        const {error:w3cError} = error;
+        if (w3cError) {
+          errorFromW3CJsonCode(w3cError).error.should.equal(error.error);
+          errorFromW3CJsonCode(w3cError).should.have.property('message', error.errorMsg);
+        } else {
+          isErrorType(errorFromW3CJsonCode(w3cError), errors.UnknownError).should.be.true;
+        }
+      });
+    }
+  }
+  it('should parse unknown errors', function () {
+    isErrorType(errorFromW3CJsonCode('not a real error code'), errors.UnknownError).should.be.true;
+    errorFromW3CJsonCode('not a real error code').message.should.match(/An unknown server-side error occurred/);
+    errorFromW3CJsonCode('not a real error code').error.should.equal('unknown error');
   });
 });
 describe('w3c Status Codes', function () {
@@ -187,7 +335,7 @@ describe('.getResponseForW3CError', function () {
       httpStatus.should.equal(500);
       const {error, message, stacktrace} = httpResponseBody.value;
       message.should.match(/Some random error/);
-      error.should.equal('An unknown error occurred in the remote end while processing the command');
+      error.should.equal('unknown error');
       stacktrace.should.match(/at getResponseForW3CError/);
       stacktrace.should.match(/Some random error/);
       stacktrace.should.match(/errors-specs.js/);
@@ -207,7 +355,7 @@ describe('.getResponseForW3CError', function () {
     const [httpStatus, httpResponseBody] = getResponseForW3CError(badParamsError);
     httpStatus.should.equal(400);
     const {error, message, stacktrace} = httpResponseBody.value;
-    error.should.equal('The arguments passed to a command are either invalid or malformed');
+    error.should.equal('invalid argument');
     message.should.match(/__BAR__/);
     message.should.match(/__HELLO_WORLD__/);
     stacktrace.should.match(/errors-specs.js/);

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -389,20 +389,20 @@ describe('.getActualError', function () {
 
   describe('W3C', function () {
     it('should map a 404 no such element error as a NoSuchElementError', function () {
-      const actualError = new errors.ProxyRequestError('Error message does not matter', null, HTTPStatusCodes.NOT_FOUND, {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', {
         value: {
           error: errors.NoSuchElementError.error(),
         },
-      }).getActualError();
+      }, HTTPStatusCodes.NOT_FOUND).getActualError();
       isErrorType(actualError, errors.NoSuchElementError).should.be.true;
     });
     it('should map a 400 StaleElementReferenceError', function () {
-      const actualError = new errors.ProxyRequestError('Error message does not matter', null, HTTPStatusCodes.BAD_REQUEST, {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', {
         value: {
           error: errors.StaleElementReferenceError.error(),
 
         },
-      }).getActualError();
+      }, HTTPStatusCodes.BAD_REQUEST).getActualError();
       isErrorType(actualError, errors.StaleElementReferenceError).should.be.true;
     });
     it('should map an unknown error to UnknownError', function () {

--- a/test/protocol/protocol-e2e-specs.js
+++ b/test/protocol/protocol-e2e-specs.js
@@ -437,7 +437,7 @@ describe('Protocol', async function () {
           message.should.match(/Parameters were incorrect/);
           stacktrace.should.match(/protocol.js/);
           w3cError.should.be.a.string;
-          w3cError.should.equal(errors.BadParametersError.error());
+          w3cError.should.equal(errors.InvalidArgumentError.error());
         });
 
         it(`should throw 404 Not Found exception if the command hasn't been implemented yet`, async function () {
@@ -452,7 +452,7 @@ describe('Protocol', async function () {
           message.should.match(/Method has not yet been implemented/);
           stacktrace.should.match(/protocol.js/);
           w3cError.should.be.a.string;
-          w3cError.should.equal(errors.UnknownCommandError.error());
+          w3cError.should.equal(errors.NotYetImplementedError.error());
           message.should.match(/Method has not yet been implemented/);
         });
 


### PR DESCRIPTION
* Rename '.error' property to correct W3C property
    * The error property in the ProtocolError objects should match up with https://www.w3.org/TR/webdriver/#handling-errors under the 'JSON Error Code' column
    * Did this and added tests for all of these
* Add proxying for W3C responses 
    * If a W3C Response is provided by a proxy, map to the correct error
    * Checks if `value` is an object and `value.error` and maps it based on that (`value.error` is the W3C error code)
    * Broke off `errorFromCode` into `errorFromMJSONWPStatusCode` and `errorFromW3CJsonCode`