### PR TITLE
Reassign 'errorFromCode' to 'errorFromW3CJSONCode'

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ import { Protocol, routeConfiguringFunction, errors, isErrorType,
          NO_SESSION_ID_COMMANDS, isSessionCommand } from './lib/protocol';
 
 export { Protocol, routeConfiguringFunction, errors, isErrorType,
-         errorFromMJSONWPStatusCode, errorFromW3CJsonCode, errorFromW3CJsonCode as errorFromCode,
+         errorFromMJSONWPStatusCode, errorFromW3CJsonCode, errorFromMJSONWPStatusCode as errorFromCode,
          ALL_COMMANDS, METHOD_MAP, routeToCommandName,
          NO_SESSION_ID_COMMANDS, isSessionCommand };
 


### PR DESCRIPTION
* When doing refactoring, erroFromCode was split into 'errorFromMJSONWPStatusCode' and 'errorFromW3CJsonCode'
* 'errorFromCode' was being exported as an alias for 'errorFromW3CJSONCode' to avoid breaking changes
* Should have been an alias for 'errorFromMJSONWPStatusCode' though

(fixes this issuehttps://circleci.com/gh/appium/appium-xcuitest-driver/1617?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

The unit test sure saved me on this one