### PR TITLE
Parse strings for W3C and JSON

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -552,15 +552,18 @@ class ProxyRequestError extends ES6Error {
     super(err || message);
 
     this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
+
+    // If a string was provided, parse the string
     if (_.isString(responseError)) {
-      this.jsonwp = JSON.parse(responseError);
+      responseError = JSON.parse(responseError);
+    }
+
+    // If the response error is an object and value is an object, it's a W3C error (for JSONWP value is a string)
+    if (_.isPlainObject(responseError) && _.isPlainObject(responseError.value)) {
+      this.w3c = responseError.value;
+      this.w3cStatus = httpStatus || HTTPStatusCodes.BAD_REQUEST;
     } else {
-      if (_.isPlainObject(responseError) && _.isPlainObject(responseError.value)) {
-        this.w3c = responseError.value;
-        this.w3cStatus = httpStatus || HTTPStatusCodes.BAD_REQUEST;
-      } else {
-        this.jsonwp = responseError;
-      }
+      this.jsonwp = responseError;
     }
   }
 

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -385,6 +385,13 @@ describe('.getActualError', function () {
       }).getActualError();
       isErrorType(actualError, errors.UnknownError).should.be.true;
     });
+    it('should parse a JSON string', function () {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', JSON.stringify({
+        value: 'Does not matter',
+        status: -100
+      })).getActualError();
+      isErrorType(actualError, errors.UnknownError).should.be.true;
+    });
   });
 
   describe('W3C', function () {
@@ -413,6 +420,15 @@ describe('.getActualError', function () {
         },
       }, 456).getActualError();
       isErrorType(actualError, errors.UnknownError).should.be.true;
+    });
+    it('should parse a JSON string', function () {
+      const actualError = new errors.ProxyRequestError('Error message does not matter', JSON.stringify({
+        value: {
+          error: errors.StaleElementReferenceError.error(),
+
+        },
+      }), HTTPStatusCodes.BAD_REQUEST).getActualError();
+      isErrorType(actualError, errors.StaleElementReferenceError).should.be.true;
     });
   });
 });


### PR DESCRIPTION
* Previously if the proxy error was a string it assumed it was jsonwp and parsed it
* Now it parses the responseError and then does it's normal business
* Added tests to `errors-specs.js` that have the fix (the `W3C --> should parse a JSON string` test failed before the fxi was put in)