### PR TITLE
Change the request type of queryAppState to POST

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -439,6 +439,11 @@ const METHOD_MAP = {
     }
   },
   '/wd/hub/session/:sessionId/appium/device/app_state': {
+    GET: {command: 'queryAppState',
+      payloadParams: {
+        required: [['appId'], ['bundleId']]
+      }
+    },
     POST: {command: 'queryAppState',
       payloadParams: {
         required: [['appId'], ['bundleId']]

--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -439,7 +439,7 @@ const METHOD_MAP = {
     }
   },
   '/wd/hub/session/:sessionId/appium/device/app_state': {
-    GET: {command: 'queryAppState',
+    POST: {command: 'queryAppState',
       payloadParams: {
         required: [['appId'], ['bundleId']]
       }

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('f01bd2e6');
+      hash.should.equal('e4612508');
     });
   });
 

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('eefd5dd0');
+      hash.should.equal('f01bd2e6');
     });
   });
 


### PR DESCRIPTION
Unfortunately java client does not support sending parameters in get requests, so I must change it to POST