### PR TITLE
Convert JSONWP proxy errors

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -685,9 +685,15 @@ function errorFromW3CJsonCode (code, message) {
 function getResponseForW3CError (err) {
   let httpStatus;
   let error;
+
   if (!err.w3cStatus) {
-    w3cLog.error(`Encountered internal error running command: ${err.stack}`);
-    err = new errors.UnknownError(err.message);
+    if (util.hasValue(err.status)) {
+      // If it's a JSONWP error, find corresponding error
+      err = errorFromMJSONWPStatusCode(err.status, err.value);
+    } else {
+      w3cLog.error(`Encountered internal error running command: ${err.stack}`);
+      err = new errors.UnknownError(err.message);
+    }
   }
 
   if (isErrorType(err, errors.BadParametersError)) {

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -361,6 +361,19 @@ describe('.getResponseForW3CError', function () {
     message.should.match(/__HELLO_WORLD__/);
     stacktrace.should.match(/errors-specs.js/);
   });
+  it('should translate JSONWP errors', function () {
+    const [httpStatus, httpResponseBody] = getResponseForW3CError({
+      status: 7,
+      value: 'My custom message',
+      sessionId: 'Fake Session Id',
+    });
+    httpStatus.should.equal(404);
+    const {error, message, stacktrace} = httpResponseBody.value;
+    message.should.equal('My custom message');
+    error.should.equal('no such element');
+    stacktrace.should.exist;
+
+  });
 });
 describe('.getActualError', function () {
   describe('MJSONWP', function () {


### PR DESCRIPTION
* Previously, if a proxied response has a status code >= 0 but http status code 200, the error is thrown but it's an unknown error because the 'getResponseForW3CError' function doesn't translate the error
* Now, it translates the JSONWP error using logic we already have that accomplishes this
* Added E2E test that tests a proxy that returns 200 but status 7 to check that it throws the correct ElementNotFoundError
* Added unit test to handle the new case in 'getResponseForW3CError'

The real-life case that this handles is that ChromeDriver often returns errors with a 200 status code (see https://github.com/appium/appium/issues/10207)