### PR TITLE
Fix the default value of payload parameters

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -242,7 +242,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // turn the command and json payload into an argument list for
       // the driver methods
-      let args = makeArgs(req.params, jsonObj, spec.payloadParams || [], driver.protocol);
+      let args = makeArgs(req.params, jsonObj, spec.payloadParams || {}, driver.protocol);
       let driverRes;
       // validate command args according to MJSONWP
       if (validators[spec.command]) {


### PR DESCRIPTION
Default value of payload parameters is an array(`[]`). However, as long as I saw the implementation of `makeArgs`, it seems to expect an object. So I think `{}` is correct for the default value. `[]` is working because an array is also an object in JavaScript, tho.