### PR TITLE
Add logging commands to the base driver

### DIFF
--- a/lib/basedriver/commands/index.js
+++ b/lib/basedriver/commands/index.js
@@ -2,6 +2,8 @@ import sessionCmds from './session';
 import settingsCmds from './settings';
 import timeoutCmds from './timeout';
 import findCmds from './find';
+import logCmds from './log';
+
 
 let commands = {};
 Object.assign(
@@ -10,6 +12,7 @@ Object.assign(
   settingsCmds,
   timeoutCmds,
   findCmds,
+  logCmds,
   // add other command types here
 );
 

--- a/lib/basedriver/commands/log.js
+++ b/lib/basedriver/commands/log.js
@@ -1,0 +1,39 @@
+import log from '../logger';
+import _ from 'lodash';
+
+
+const commands = {}, helpers = {}, extensions = {};
+
+// override in sub-classes, with appropriate logs
+// in the form of
+//   {
+//     type: {
+//       description: 'some useful text',
+//       getter: () => {}, // some function that will be called to get the logs
+//     }
+//   }
+extensions.supportedLogTypes = [];
+
+commands.getLogTypes = function () {
+  log.debug('Retrieving supported log types');
+  return _.keys(this.supportedLogTypes);
+};
+
+commands.getLog = async function (logType) {
+  log.debug(`Retrieving '${logType}' logs`);
+
+  if (!this.getLogTypes().includes(logType)) {
+    const logsTypesWithDescriptions = _.reduce(this.supportedLogTypes, function (result, value, key) {
+      result[key] = value.description;
+      return result;
+    }, {});
+    throw new Error(`Unsupported log type '${logType}'. ` +
+      `Supported types: ${JSON.stringify(logsTypesWithDescriptions)}`);
+  }
+
+  return await this.supportedLogTypes[logType].getter(this);
+};
+
+Object.assign(extensions, commands, helpers);
+export { commands, helpers};
+export default extensions;

--- a/lib/basedriver/commands/log.js
+++ b/lib/basedriver/commands/log.js
@@ -12,7 +12,7 @@ const commands = {}, helpers = {}, extensions = {};
 //       getter: () => {}, // some function that will be called to get the logs
 //     }
 //   }
-extensions.supportedLogTypes = [];
+extensions.supportedLogTypes = {};
 
 commands.getLogTypes = function () {
   log.debug('Retrieving supported log types');

--- a/test/basedriver/commands/log-specs.js
+++ b/test/basedriver/commands/log-specs.js
@@ -1,0 +1,72 @@
+import logCommands from '../../../lib/basedriver/commands/log';
+import chai from 'chai';
+import sinon from 'sinon';
+import _ from 'lodash';
+
+
+chai.should();
+const expect = chai.expect;
+
+const FIRST_LOGS = ['first', 'logs'];
+const SECOND_LOGS = ['second', 'logs'];
+const SUPPORTED_LOG_TYPES = {
+  one: {
+    description: 'First logs',
+    getter: () => _.clone(FIRST_LOGS),
+  },
+  two: {
+    description: 'Seconds logs',
+    getter: () => _.clone(SECOND_LOGS),
+  },
+};
+
+describe('log commands -', function () {
+  beforeEach(function () {
+    // reset the supported log types
+    logCommands.supportedLogTypes = [];
+  });
+  describe('getLogTypes', function () {
+    it('should return empty array when no supported log types', async function () {
+      (await logCommands.getLogTypes()).should.eql([]);
+    });
+    it('should return keys to log type object', async function () {
+      logCommands.supportedLogTypes = SUPPORTED_LOG_TYPES;
+      (await logCommands.getLogTypes()).should.eql(['one', 'two']);
+    });
+  });
+  describe('getLog', function () {
+    beforeEach(function () {
+      sinon.spy(SUPPORTED_LOG_TYPES.one, 'getter');
+      sinon.spy(SUPPORTED_LOG_TYPES.two, 'getter');
+    });
+    afterEach(function () {
+      SUPPORTED_LOG_TYPES.one.getter.restore();
+      SUPPORTED_LOG_TYPES.two.getter.restore();
+    });
+    it('should throw error if log type not supported', async function () {
+      await logCommands.getLog('one').should.be.rejected;
+      SUPPORTED_LOG_TYPES.one.getter.called.should.be.false;
+      SUPPORTED_LOG_TYPES.two.getter.called.should.be.false;
+    });
+    it('should throw an error with available log types if log type not supported', async function () {
+      logCommands.supportedLogTypes = SUPPORTED_LOG_TYPES;
+      let err;
+      try {
+        await logCommands.getLog('three');
+      } catch (_err) {
+        err = _err;
+      }
+      expect(err).to.exist;
+      err.message.should.eql(`Unsupported log type 'three'. Supported types: {"one":"First logs","two":"Seconds logs"}`);
+      SUPPORTED_LOG_TYPES.one.getter.called.should.be.false;
+      SUPPORTED_LOG_TYPES.two.getter.called.should.be.false;
+    });
+    it('should call getter on appropriate log when found', async function () {
+      logCommands.supportedLogTypes = SUPPORTED_LOG_TYPES;
+      let logs = await logCommands.getLog('one');
+      logs.should.eql(FIRST_LOGS);
+      SUPPORTED_LOG_TYPES.one.getter.called.should.be.true;
+      SUPPORTED_LOG_TYPES.two.getter.called.should.be.false;
+    });
+  });
+});

--- a/test/basedriver/commands/log-specs.js
+++ b/test/basedriver/commands/log-specs.js
@@ -1,10 +1,12 @@
 import logCommands from '../../../lib/basedriver/commands/log';
 import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import _ from 'lodash';
 
 
 chai.should();
+chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 const FIRST_LOGS = ['first', 'logs'];
@@ -23,7 +25,7 @@ const SUPPORTED_LOG_TYPES = {
 describe('log commands -', function () {
   beforeEach(function () {
     // reset the supported log types
-    logCommands.supportedLogTypes = [];
+    logCommands.supportedLogTypes = {};
   });
   describe('getLogTypes', function () {
     it('should return empty array when no supported log types', async function () {
@@ -44,7 +46,7 @@ describe('log commands -', function () {
       SUPPORTED_LOG_TYPES.two.getter.restore();
     });
     it('should throw error if log type not supported', async function () {
-      await logCommands.getLog('one').should.be.rejected;
+      await logCommands.getLog('one').should.eventually.be.rejected;
       SUPPORTED_LOG_TYPES.one.getter.called.should.be.false;
       SUPPORTED_LOG_TYPES.two.getter.called.should.be.false;
     });


### PR DESCRIPTION
Implement https://github.com/appium/appium-ios-driver/pull/267 and https://github.com/appium/appium-android-driver/pull/338/files in the base driver. The subclasses ought to just remove their implementations of `getLogTypes` and `getLog`, and make sure there is a `supportedLogTypes` property with the correct log types for that instance.