### PR TITLE
Sync w3c codes with the recent spec

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -20,7 +20,8 @@ class ProtocolError extends ES6Error {
 }
 
 // https://github.com/SeleniumHQ/selenium/blob/176b4a9e3082ac1926f2a436eb346760c37a5998/java/client/src/org/openqa/selenium/remote/ErrorCodes.java#L215
-// https://www.w3.org/TR/webdriver/#handling-errors
+// https://github.com/SeleniumHQ/selenium/issues/5562#issuecomment-370379470
+// https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error-code
 
 class NoSuchDriverError extends ProtocolError {
   static code () {
@@ -64,7 +65,7 @@ class NoSuchFrameError extends ProtocolError {
     return 'no such frame';
   }
   static w3cStatus () {
-    return HTTPStatusCodes.BAD_REQUEST;
+    return HTTPStatusCodes.NOT_FOUND;
   }
   constructor (err) {
     super(err || 'A request to switch to a frame could not be satisfied because ' +
@@ -95,7 +96,7 @@ class StaleElementReferenceError extends ProtocolError {
     return 10;
   }
   static w3cStatus () {
-    return HTTPStatusCodes.BAD_REQUEST;
+    return HTTPStatusCodes.NOT_FOUND;
   }
   static error () {
     return 'stale element reference';
@@ -318,7 +319,7 @@ class NoSuchWindowError extends ProtocolError {
     return 'no such window';
   }
   static w3cStatus () {
-    return HTTPStatusCodes.BAD_REQUEST;
+    return HTTPStatusCodes.NOT_FOUND;
   }
   constructor (err) {
     super(err || 'A request to switch to a different window could not be satisfied ' +
@@ -414,7 +415,7 @@ class NoAlertOpenError extends ProtocolError {
     return 27;
   }
   static w3cStatus () {
-    return HTTPStatusCodes.BAD_REQUEST;
+    return HTTPStatusCodes.NOT_FOUND;
   }
   static error () {
     return 'no such alert';

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -301,6 +301,10 @@ describe('w3c Status Codes', function () {
   it('should match the correct error codes', function () {
     let non400Errors = [
       ['NoSuchDriverError', 404],
+      ['NoSuchFrameError', 404],
+      ['NoAlertOpenError', 404],
+      ['NoSuchWindowError', 404],
+      ['StaleElementReferenceError', 404],
       ['JavaScriptError', 500],
       ['MoveTargetOutOfBoundsError', 500],
       ['NoSuchCookieError', 404],


### PR DESCRIPTION
It looks like we should always use the spec at https://w3c.github.io/webdriver/webdriver-spec.html, which is up to date. See https://github.com/SeleniumHQ/selenium/issues/5562 for more details.