### PR TITLE
Fix: Determine protocol in createSession

### DIFF
--- a/lib/basedriver/commands/session.js
+++ b/lib/basedriver/commands/session.js
@@ -17,6 +17,7 @@ commands.createSession = async function (jsonwpDesiredCapabilities, jsonwpRequir
   // Determine weather we should use jsonwpDesiredCapabilities or w3cCapabilities to get caps from
   let caps;
   if (w3cCapabilities) {
+    this.setProtocolW3C();
     if (jsonwpDesiredCapabilities) {
       log.debug(`W3C capabilities ${_.truncate(JSON.stringify(w3cCapabilities))} and MJSONWP desired capabilities ${_.truncate(w3cCapabilities)} were provided`);
     }
@@ -24,14 +25,18 @@ commands.createSession = async function (jsonwpDesiredCapabilities, jsonwpRequir
     if (jsonwpDesiredCapabilities && !_.isPlainObject(w3cCapabilities)) {
       // If W3C Capabilities and MJSONWP Capabilities were provided and W3C caps aren't a plain object,
       // log a warning and fall back to MJSONWP
-      log.warn(`Expected W3C "capabilities" to be a JSON Object but was provided with: ${JSON.stringify(w3cCapabilities)}`);
+      if (!_.isEmpty(w3cCapabilities)) {
+        log.warn(`Expected W3C "capabilities" to be a JSON Object but was provided with: ${JSON.stringify(w3cCapabilities)}`);
+      }
       log.warn(`Falling back to MJSONWP desired capabilities`);
+      this.setProtocolMJSONWP();
       caps = jsonwpDesiredCapabilities;
     } else {
       log.debug(`Creating session with W3C capabilities: ${_.truncate(JSON.stringify(w3cCapabilities))}`);
       caps = processCapabilities(w3cCapabilities, this.desiredCapConstraints, this.shouldValidateCaps);
     }
   } else {
+    this.setProtocolMJSONWP();
     log.debug(`Creating session with MJSONWP desired capabilities: ${_.truncate(JSON.stringify(jsonwpDesiredCapabilities))}`);
     caps = jsonwpDesiredCapabilities;
   }

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -208,6 +208,14 @@ class BaseDriver extends Protocol {
     return this.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
   }
 
+  setProtocolMJSONWP () {
+    this.protocol = BaseDriver.DRIVER_PROTOCOL.MJSONWP;
+  }
+
+  setProtocolW3C () {
+    this.protocol = BaseDriver.DRIVER_PROTOCOL.W3C;
+  }
+
   /**
    * Test createSession inputs to see if this is a W3C Session or a MJSONWP Session
    */

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -139,6 +139,18 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       d.protocol.should.equal('W3C');
     });
 
+    describe('protocol detection', function () {
+      it('should use MJSONWP if only JSONWP caps are provided', async function () {
+        await d.createSession(defaultCaps);
+        d.protocol.should.equal('MJSONWP');
+      });
+
+      it('should use W3C if only W3C caps are provided', async function () {
+        await d.createSession(null, null, {alwaysMatch: defaultCaps, firstMatch: [{}]});
+        d.protocol.should.equal('W3C');
+      });
+    });
+
     it('should have a method to get driver for a session', async function () {
       let [sessId] = await d.createSession(defaultCaps);
       d.driverForSession(sessId).should.eql(d);


### PR DESCRIPTION
* Previously, we were only checking the HTTP payload to see what protocol should be
* This is inadequate, in the case of drivers that don't proxy W3C Capabilities yet
* The fix now is to set the protocol in `createSession` to see if the W3C caps were proxied through, if they're not, set protocol to MJSONWP
* Added unit test and one e2e test to confirm that this works

(related to: https://github.com/appium/appium/issues/10350)