### PR TITLE
Parse protocol from executeCommand

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -5,6 +5,7 @@ import { errors, isErrorType, ProtocolError, errorFromMJSONWPStatusCode, errorFr
 import { METHOD_MAP, NO_SESSION_ID_COMMANDS } from './routes';
 import { renameKey } from '../basedriver/helpers';
 import B from 'bluebird';
+import BaseDriver from '../basedriver/driver';
 
 
 const mjsonwpLog = logger.getLogger('MJSONWP');
@@ -198,6 +199,8 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
     let httpResBody = {};
     let httpStatus = 200;
     let newSessionId;
+    let isW3C;
+    let isMJSONWP;
 
     // get the appropriate logger depending on the protocol that is being used
     const log = getLogByProtocol(driver);
@@ -259,12 +262,29 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         driverRes = await driver.execute(spec.command, ...args);
       }
 
+      // Get the protocol after executeCommand (when command is `createSession`, protocol is assigned within
+      // createSession function)
+      isW3C = driver.isW3CProtocol();
+      isMJSONWP = driver.isMjsonwpProtocol();
+
+      // If `executeCommand` was overridden and the method returns an object
+      // with a protocol and value/error property, re-assign the protocol
+      if (_.isObject(driverRes) && _.isString(driverRes.protocol) && (!_.isNil(driverRes.value) || _.isError(driverRes.error))) {
+        isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
+        isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
+        if (driverRes.value) {
+          driverRes = driverRes.value;
+        } else if (driverRes.error) {
+          throw driverRes.error;
+        }
+      }
+
       // unpack createSession response
       if (spec.command === 'createSession') {
         newSessionId = driverRes[0];
-        if (driver.isMjsonwpProtocol()) {
+        if (isMJSONWP) {
           driverRes = driverRes[1];
-        } else if (driver.isW3CProtocol()) {
+        } else if (isW3C) {
           driverRes = {
             capabilities: driverRes[1],
           };
@@ -274,7 +294,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // If the MJSONWP element key format (ELEMENT) was provided translate it to W3C element key format (element-6066-11e4-a52e-4f735466cecf)
       // and vice-versa
       if (driverRes) {
-        if (driver.isW3CProtocol()) {
+        if (isW3C) {
           driverRes = renameKey(driverRes, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY);
         } else {
           driverRes = renameKey(driverRes, W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY);
@@ -304,7 +324,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // Response status should be the status set by the driver response.
-      if (driver.isMjsonwpProtocol()) {
+      if (!isW3C) {
         httpResBody.status = (_.isNil(driverRes) || _.isUndefined(driverRes.status)) ? JSONWP_SUCCESS_STATUS_CODE : driverRes.status;
       }
       httpResBody.value = driverRes;
@@ -315,18 +335,40 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // based on the type of error that we encountered
       let actualErr = err;
 
+      if (_.isUndefined(isMJSONWP)) {
+        isMJSONWP = driver.isMjsonwpProtocol();
+      }
+
+      if (_.isUndefined(isW3C)) {
+        isW3C = driver.isW3CProtocol();
+      }
+
       if (isErrorType(err, errors.ProxyRequestError)) {
         log.error(`Encountered internal error running command:  ${JSON.stringify(err)} ${err.stack}`);
         actualErr = err.getActualError(driver.protocol);
-      } else if (
-        driver.isMjsonwpProtocol() &&
-        (!(isErrorType(err, ProtocolError) || isErrorType(err, errors.BadParametersError)))
-      ) {
+      } else if (!isW3C && (!(isErrorType(err, ProtocolError) || isErrorType(err, errors.BadParametersError)))) {
         log.error(`Encountered internal error running command: ${err.stack}`);
         actualErr = new errors.UnknownError(err);
       }
 
-      [httpStatus, httpResBody] = driver.isMjsonwpProtocol() ? getResponseForJsonwpError(actualErr) : getResponseForW3CError(actualErr);
+      if (isW3C) {
+        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
+      } else if (isMJSONWP) {
+        [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);
+      } else {
+        // If it's unknown what the protocol is (like if it's `getStatus` prior to `createSession`), merge the responses
+        // together to be protocol-agnostic
+        let jsonwpRes = getResponseForJsonwpError(actualErr);
+        let w3cRes = getResponseForW3CError(actualErr);
+
+        httpResBody = {
+          ...jsonwpRes[1],
+          ...w3cRes[1],
+        };
+
+        // Use the JSONWP status code (which is usually 500)
+        httpStatus = jsonwpRes[0];
+      }
     }
 
     // decode the response, which is either a string or json
@@ -334,7 +376,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       res.status(httpStatus).send(httpResBody);
     } else {
       if (newSessionId) {
-        if (driver.isW3CProtocol()) {
+        if (isW3C) {
           httpResBody.value.sessionId = newSessionId;
         } else {
           httpResBody.sessionId = newSessionId;
@@ -344,10 +386,9 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // Don't include sessionId in W3C responses
-      if (driver.isW3CProtocol()) {
+      if (isW3C) {
         delete httpResBody.sessionId;
       }
-
       res.status(httpStatus).json(httpResBody);
     }
   };

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -216,7 +216,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           simple: false
         });
         // make sure that the request gets to the server before our shutdown
-        await B.delay(20);
+        await B.delay(100);
         d.startUnexpectedShutdown(new Error('Crashytimes'));
         let res = await p;
         res.status.should.equal(13);


### PR DESCRIPTION
(look at this PR first: https://github.com/appium/appium/pull/10362)

* If `executeCommand` returns an object that has a property 'protocol' and either a 'value' property or an 'error' property, adjust the response so that we respond with the protocol that the `executeCommand` function told us to use for the response
* Also: Added to delay in the 'unexpected exits' test because I was getting a race condition
