### PR TITLE
Fix protocol parsing

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -450,7 +450,7 @@ async function doJwpProxy (driver, req, res) {
 
 /**
  * Check a driver command respond and see if the protocol and value was passed in
- * @param {Object} driverRes
+ * @param {Object} driverRes Response returned by `executeCommand` in an inner driver
  * @throws Will throw an error if driverRes.error is provided
  */
 function parseProtocol (driverRes) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -450,7 +450,7 @@ async function doJwpProxy (driver, req, res) {
 
 /**
  * Check a driver command respond and see if the protocol and value was passed in
- * @param {Object} driverRes Response returned by `executeCommand` in an inner driver
+ * @param {Object} driverRes Response returned by `executeCommand` in an inner driver 
  * @throws Will throw an error if driverRes.error is provided
  */
 function parseProtocol (driverRes) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -453,14 +453,18 @@ async function doJwpProxy (driver, req, res) {
  * @param {Object} driverRes
  */
 function parseProtocol (driverRes) {
-  if (_.isObject(driverRes) && _.isString(driverRes.protocol)) {
-    if (_.has(driverRes, 'value')) {
-      let isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
-      let isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
-      return {isW3C, isMJSONWP, value: driverRes.value};
-    } else if (_.isError(driverRes.error)) {
-      throw driverRes.error;
-    }
+  if (!_.isPlainObject(driverRes) || !_.isString(driverRes.protocol)) {
+    return null;
+  }
+
+  if (_.has(driverRes, 'value')) {
+    let isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
+    let isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
+    return {isW3C, isMJSONWP, value: driverRes.value};
+  }
+
+  if (_.isError(driverRes.error)) {
+    throw driverRes.error;
   }
 }
 

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -450,7 +450,7 @@ async function doJwpProxy (driver, req, res) {
 
 /**
  * Check a driver command respond and see if the protocol and value was passed in
- * @param {Object} driverRes Response returned by `executeCommand` in an inner driver 
+ * @param {Object} driverRes Response returned by `executeCommand` in an inner driver
  * @throws Will throw an error if driverRes.error is provided
  */
 function parseProtocol (driverRes) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -269,14 +269,11 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // If `executeCommand` was overridden and the method returns an object
       // with a protocol and value/error property, re-assign the protocol
-      if (_.isObject(driverRes) && _.isString(driverRes.protocol) && (!_.isNil(driverRes.value) || _.isError(driverRes.error))) {
-        isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
-        isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
-        if (driverRes.value) {
-          driverRes = driverRes.value;
-        } else if (driverRes.error) {
-          throw driverRes.error;
-        }
+      const parsedDriverRes = parseProtocol(driverRes);
+      if (parsedDriverRes) {
+        isW3C = parsedDriverRes.isW3C;
+        isMJSONWP = parsedDriverRes.isMJSONWP;
+        driverRes = parsedDriverRes.value;
       }
 
       // unpack createSession response
@@ -451,5 +448,21 @@ async function doJwpProxy (driver, req, res) {
   }
 }
 
+/**
+ * Check a driver command respond and see if the protocol and value was passed in
+ * @param {Object} driverRes
+ */
+function parseProtocol (driverRes) {
+  if (_.isObject(driverRes) && _.isString(driverRes.protocol)) {
+    if (_.has(driverRes, 'value')) {
+      let isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
+      let isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
+      return {isW3C, isMJSONWP, value: driverRes.value};
+    } else if (_.isError(driverRes.error)) {
+      throw driverRes.error;
+    }
+  }
+}
 
-export { Protocol, routeConfiguringFunction, isSessionCommand, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY };
+
+export { Protocol, routeConfiguringFunction, isSessionCommand, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY, parseProtocol };

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -451,6 +451,7 @@ async function doJwpProxy (driver, req, res) {
 /**
  * Check a driver command respond and see if the protocol and value was passed in
  * @param {Object} driverRes
+ * @throws Will throw an error if driverRes.error is provided
  */
 function parseProtocol (driverRes) {
   if (!_.isPlainObject(driverRes) || !_.isString(driverRes.protocol)) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -452,6 +452,7 @@ async function doJwpProxy (driver, req, res) {
  * Check a driver command respond and see if the protocol and value was passed in
  * @param {Object} driverRes Response returned by `executeCommand` in an inner driver
  * @throws Will throw an error if driverRes.error is provided
+ * @returns {Object} isW3C, isMJSONWP and driver value or null if it isn't parsable
  */
 function parseProtocol (driverRes) {
   if (!_.isPlainObject(driverRes) || !_.isString(driverRes.protocol)) {
@@ -467,6 +468,8 @@ function parseProtocol (driverRes) {
   if (_.isError(driverRes.error)) {
     throw driverRes.error;
   }
+
+  return null;
 }
 
 

--- a/test/protocol/protocol-specs.js
+++ b/test/protocol/protocol-specs.js
@@ -10,10 +10,7 @@ chai.use(chaiAsPromised);
 
 describe('Protocol', async function () {
 
-  //TODO: more tests!:
-  // Unknown commands should return 404
-
-  describe('direct to driver', function () {
+  describe('#parseProtocol', function () {
     it('should parse {protocol: "MJSONWP"} as MJSONWP', function () {
       parseProtocol({protocol: 'MJSONWP', value: undefined}).should.eql({isW3C: false, isMJSONWP: true, value: undefined});
     });

--- a/test/protocol/protocol-specs.js
+++ b/test/protocol/protocol-specs.js
@@ -1,0 +1,40 @@
+// transpile:mocha
+
+import '../..'; // NOTE: For some reason this file needs to be imported to prevent a babel error
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { parseProtocol } from '../../lib/protocol/protocol';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('Protocol', async function () {
+
+  //TODO: more tests!:
+  // Unknown commands should return 404
+
+  describe('direct to driver', function () {
+    it('should parse {protocol: "MJSONWP"} as MJSONWP', function () {
+      parseProtocol({protocol: 'MJSONWP', value: undefined}).should.eql({isW3C: false, isMJSONWP: true, value: undefined});
+    });
+    it('should parse {protocol: "W3C"} as W3C', function () {
+      parseProtocol({protocol: 'W3C', value: undefined}).should.eql({isW3C: true, isMJSONWP: false, value: undefined});
+    });
+    it('should parse {protocol: "MJSONWP", value: false} as MJSONWP with value: false', function () {
+      parseProtocol({protocol: 'MJSONWP', value: false}).should.eql({isW3C: false, isMJSONWP: true, value: false});
+    });
+    it('should parse {protocol: "W3C", value: 0} as W3C with value: 0', function () {
+      parseProtocol({protocol: 'W3C', value: 0}).should.eql({isW3C: true, isMJSONWP: false, value: 0});
+    });
+    it('should parse {protocol: "MJSONWP", value: "string"}', function () {
+      parseProtocol({protocol: 'MJSONWP', value: "string"}).should.eql({isW3C: false, isMJSONWP: true, value: "string"});
+    });
+    it('should parse {protocol: "W3C", value: {obj}}', function () {
+      const value = {hello: 'world', goodbye: 'whirl'};
+      parseProtocol({protocol: 'MJSONWP', value}).should.eql({isW3C: false, isMJSONWP: true, value});
+    });
+    it('should throw if {protocol: "MJSONWP", error}', function () {
+      (() => parseProtocol({protocol: 'W3C', error: new Error('some error')})).should.throw(/some error/);
+    });
+  });
+});


### PR DESCRIPTION
* Some problems with parsing `{protocol: <protocol>, value: <value>}`
  * `(!_.isNil(driverRes.value)` was incorrect check because `value` can be undefined or null; replaced it with `_.has(driverRes, 'value')` to check that the `value` property was set
  *  ```
       if (driverRes.value) {
          driverRes = driverRes.value;
        } 
      ``` 

      was also incorrect because `driverRes.value` may be false-y

* Moved logic into it's own function and then added tests to cover the problem cases