### PR TITLE
Force response body conversion to JSON

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -131,6 +131,11 @@ class JWProxy {
     try {
       res = await this.request(reqOpts);
       resBody = res.body;
+      if (!_.isPlainObject(resBody)) {
+        try {
+          resBody = JSON.parse(resBody);
+        } catch (ign) {}
+      }
       log.debug(`Got response with status ${res.statusCode}: ${_.truncate(JSON.stringify(resBody), {length: LOG_OBJ_LENGTH})}`);
       if (/\/session$/.test(url) && method === 'POST') {
         if (res.statusCode === 200) {


### PR DESCRIPTION
I'm not quite sure why, but it looks like the response body is sometimes parsed as correct JSON object, but sometimes it is returned as a string-encoded JSON:

```
2018-04-13 11:05:30:637 - info: [HTTP] --> POST /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/element/76000000-0000-0000-17E4-000000000000/click
2018-04-13 11:05:30:638 - info: [HTTP] {"id":"76000000-0000-0000-17E4-000000000000"}
2018-04-13 11:05:30:638 - info: [W3C] Driver proxy active, passing request on via HTTP proxy
2018-04-13 11:05:30:638 - info: [debug] [XCUITest] Executing command 'proxyReqRes'
2018-04-13 11:05:30:640 - info: [debug] [JSONWP Proxy] Proxying [POST /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/element/76000000-0000-0000-17E4-000000000000/click] to [POST http://127.0.0.1:8100/session/F937B653-D3E0-4532-9F35-158B272D0197/element/76000000-0000-0000-17E4-000000000000/click] with body: {"id":"76000000-0000-0000-17E4-000000000000"}
2018-04-13 11:05:31:159 - info: [debug] [JSONWP Proxy] Got response with status 200: {"status":0,"id":"76000000-0000-0000-17E4-000000000000","value":"","sessionId":"F937B653-D3E0-4532-9F35-158B272D0197"}
2018-04-13 11:05:31:159 - info: [JSONWP Proxy] Replacing sessionId F937B653-D3E0-4532-9F35-158B272D0197 with 928c40ec-341a-4901-9f4a-78ae9eb7f6e8
2018-04-13 11:05:31:162 - info: [HTTP] <-- POST /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/element/76000000-0000-0000-17E4-000000000000/click 200 524 ms - 118
2018-04-13 11:05:31:163 - info: [HTTP] 
2018-04-13 11:05:31:173 - info: [HTTP] --> GET /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/alert/text
2018-04-13 11:05:31:174 - info: [HTTP] {}
2018-04-13 11:05:31:175 - info: [W3C] Driver proxy active, passing request on via HTTP proxy
2018-04-13 11:05:31:175 - info: [debug] [XCUITest] Executing command 'proxyReqRes'
2018-04-13 11:05:31:180 - info: [debug] [JSONWP Proxy] Proxying [GET /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/alert/text] to [GET http://127.0.0.1:8100/session/F937B653-D3E0-4532-9F35-158B272D0197/alert/text] with body: {}
2018-04-13 11:05:31:402 - info: [debug] [JSONWP Proxy] Got response with status 200: "{\n  \"value\" : {\n\n  },\n  \"sessionId\" : \"F937B653-D3E0-4532-9F35-158B272D0197\",\n  \"status\" : 27\n}"
2018-04-13 11:05:31:403 - info: [JSONWP Proxy] Replacing sessionId F937B653-D3E0-4532-9F35-158B272D0197 with 928c40ec-341a-4901-9f4a-78ae9eb7f6e8
2018-04-13 11:05:31:414 - info: [HTTP] <-- GET /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/alert/text 200 231 ms - 75
2018-04-13 11:05:31:415 - info: [HTTP] 
2018-04-13 11:10:38:725 - info: [HTTP] --> GET /wd/hub/session/928c40ec-341a-4901-9f4a-78ae9eb7f6e8/alert/text
2018-04-13 11:10:38:727 - info: [HTTP] {}
```

As you can see in this log the first `/click` API request returned the valid JSON response body, but the following `/alert/text` call  returned an escaped JSON string instead. I'm not quite sure why the `request` library behaves this way, since WDA preprocesses the response properly in both cases. 