### PR TITLE
Properly parse error codes for different protocols

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -775,7 +775,7 @@ function errorFromMJSONWPStatusCode (code, message) {
 /**
  * Retrieve an error derived from W3C JSON Code
  * @param {string} code W3C error string (see https://www.w3.org/TR/webdriver/#handling-errors `JSON Error Code` column)
- * @param {string} the error message
+ * @param {string} message the error message
  * @return {ProtocolError}  The error that is associated with the W3C error string
  */
 function errorFromW3CJsonCode (code, message) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -463,7 +463,7 @@ function parseProtocol (driverRes) {
   if (_.has(driverRes, 'value')) {
     return {isW3C, isMJSONWP, value: driverRes.value};
   }
-  if (_.has(driverRes, 'error') && _.isPlainObject(driverRes.error)) {
+  if (_.has(driverRes, 'error')) {
     if (isMJSONWP) {
       return {isW3C, isMJSONWP, value: {
         status: driverRes.error.jsonwpCode,

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -451,7 +451,6 @@ async function doJwpProxy (driver, req, res) {
 /**
  * Check a driver command respond and see if the protocol and value was passed in
  * @param {Object} driverRes Response returned by `executeCommand` in an inner driver
- * @throws Will throw an error if driverRes.error is provided
  * @returns {Object} isW3C, isMJSONWP and driver value or null if it isn't parsable
  */
 function parseProtocol (driverRes) {
@@ -459,14 +458,26 @@ function parseProtocol (driverRes) {
     return null;
   }
 
+  const isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
+  const isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
   if (_.has(driverRes, 'value')) {
-    let isW3C = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.W3C;
-    let isMJSONWP = driverRes.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
     return {isW3C, isMJSONWP, value: driverRes.value};
   }
-
-  if (_.isError(driverRes.error)) {
-    throw driverRes.error;
+  if (_.has(driverRes, 'error') && _.isPlainObject(driverRes.error)) {
+    if (isMJSONWP) {
+      return {isW3C, isMJSONWP, value: {
+        status: driverRes.error.jsonwpCode,
+        value: driverRes.error.message,
+      }};
+    }
+    if (isW3C) {
+      return {isW3C, isMJSONWP, value: {
+        value: {
+          error: driverRes.error.error,
+          message: driverRes.error.message,
+        }
+      }};
+    }
   }
 
   return null;

--- a/test/protocol/protocol-specs.js
+++ b/test/protocol/protocol-specs.js
@@ -30,8 +30,18 @@ describe('Protocol', async function () {
       const value = {hello: 'world', goodbye: 'whirl'};
       parseProtocol({protocol: 'MJSONWP', value}).should.eql({isW3C: false, isMJSONWP: true, value});
     });
-    it('should throw if {protocol: "MJSONWP", error}', function () {
-      (() => parseProtocol({protocol: 'W3C', error: new Error('some error')})).should.throw(/some error/);
+    it('should return an error if {protocol: "W3C", error}', function () {
+      parseProtocol({
+        protocol: 'W3C',
+        error: new Error('some error')
+      }).should.eql({
+        isMJSONWP: false,
+        isW3C: true,
+        value: {value: {
+          error: undefined,
+          message: 'some error'
+        }}
+      });
     });
   });
 });


### PR DESCRIPTION
The `parseProtocol` method should properly return protocol type in the first priority and should not throw until the protocol is set properly. This fixes wrong responses in case of driver failures (like in https://github.com/appium/appium/issues/10681). The only thing I cannot figure out yet is on which stage the original error message is lost, because the resulting one contains the default text of the corresponding protocol error (upd: figured it out - the problem lies inside bootstrap module):

> [debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Returning result: {"status":32,"value":"javax.xml.transform.TransformerException: Expected ), but found: $"}

vs

> org.openqa.selenium.InvalidSelectorException: Argument was an invalid selector (e.g. XPath/CSS). (WARNING: The server did not provide any stacktrace information)
