### PR TITLE
Enforce UTF-8 encoding on request headers

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -168,7 +168,7 @@ async function downloadFile (sourceUrl, suffix) {
         if (res.statusCode >= 400) {
           return reject(`Error downloading file: ${res.statusCode}`);
         }
-        contentType = res.headers['content-type'];
+        contentType = res.headers['Content-Type'];
       })
       .pipe(_fs.createWriteStream(targetPath))
       .on('error', reject)

--- a/lib/express/README.md
+++ b/lib/express/README.md
@@ -25,11 +25,11 @@ import { server } from 'appium-base-driver';
 // configure the routes
 function configureRoutes (app) {
   app.get('/hello', (req, res) => {
-    res.header['content-type'] = 'text/html';
+    res.header['Content-Type'] = 'text/html';
     res.status(200).send('Hello');
   });
   app.get('/world', (req, res) => {
-    res.header['content-type'] = 'text/html';
+    res.header['Content-Type'] = 'text/html';
     res.status(200).send('World');
   });
 }

--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -6,7 +6,7 @@ function allowCrossDomain (req, res, next) {
   try {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS,DELETE');
-    res.header('Access-Control-Allow-Headers', 'origin, content-type, accept');
+    res.header('Access-Control-Allow-Headers', 'Origin, Content-Type, Accept');
 
     // need to respond 200 to OPTIONS
     if ('OPTIONS' === req.method) {
@@ -22,17 +22,17 @@ function allowCrossDomain (req, res, next) {
 
 function fixPythonContentType (req, res, next) {
   // hack because python client library gives us wrong content-type
-  if (/^\/wd/.test(req.path) && /^Python/.test(req.headers['user-agent'])) {
-    if (req.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      req.headers['content-type'] = 'application/json';
+  if (/^\/wd/.test(req.path) && /^Python/.test(req.headers['User-Agent'])) {
+    if (req.headers['Content-Type'] === 'application/x-www-form-urlencoded') {
+      req.headers['Content-Type'] = 'application/json; charset=utf-8';
     }
   }
   next();
 }
 
 function defaultToJSONContentType (req, res, next) {
-  if (!req.headers['content-type']) {
-    req.headers['content-type'] = 'application/json';
+  if (!req.headers['Content-Type']) {
+    req.headers['Content-Type'] = 'application/json; charset=utf-8';
   }
   next();
 }

--- a/lib/express/static.js
+++ b/lib/express/static.js
@@ -18,7 +18,7 @@ async function guineaPigTemplate (req, res, page) {
   let params = {
     throwError,
     serverTime: parseInt(Date.now() / 1000, 10),
-    userAgent: req.headers['user-agent'],
+    userAgent: req.headers['User-Agent'],
     comment: 'None'
   };
   if (req.method === 'POST') {

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -104,9 +104,9 @@ class JWProxy {
       url: newUrl,
       method,
       headers: {
-        'Content-type': 'application/json',
-        'user-agent': 'appium',
-        accept: '*/*',
+        'Content-Type': 'application/json; charset=utf-8',
+        'User-Agent': 'appium',
+        Accept: '*/*',
       },
       resolveWithFullResponse: true,
       timeout: this.timeout,
@@ -190,7 +190,7 @@ class JWProxy {
   async proxyReqRes (req, res) {
     let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
     res.headers = response.headers;
-    res.set('Content-type', response.headers['content-type']);
+    res.set('Content-Type', response.headers['Content-Type']);
     // if the proxied response contains a sessionId that the downstream
     // driver has generated, we don't want to return that to the client.
     // Instead, return the id from the request or from current session

--- a/test/express/server-specs.js
+++ b/test/express/server-specs.js
@@ -36,17 +36,17 @@ describe('server', function () {
     errorStub = sinon.stub(console, 'error');
     function configureRoutes (app) {
       app.get('/', (req, res) => {
-        res.header['content-type'] = 'text/html';
+        res.header['Content-Type'] = 'text/html';
         res.status(200).send('Hello World!');
       });
       app.get('/wd/hub/python', (req, res) => {
-        res.status(200).send(req.headers['content-type']);
+        res.status(200).send(req.headers['Content-Type']);
       });
       app.get('/error', () => {
         throw new Error('hahaha');
       });
       app.get('/pause', async (req, res) => {
-        res.header['content-type'] = 'text/html';
+        res.header['Content-Type'] = 'text/html';
         await B.delay(1000);
         res.status(200).send('We have waited!');
       });
@@ -66,11 +66,11 @@ describe('server', function () {
     let body = await request({
       url: 'http://localhost:8181/wd/hub/python',
       headers: {
-        'user-agent': 'Python',
-        'content-type': 'application/x-www-form-urlencoded'
+        'User-Agent': 'Python',
+        'Content-Type': 'application/x-www-form-urlencoded'
       }
     });
-    body.should.eql('application/json');
+    body.should.eql('application/json; charset=utf-8');
   });
   it('should catch errors in the catchall', async function () {
     await request('http://localhost:8181/error')

--- a/test/jsonwp-proxy/mock-request.js
+++ b/test/jsonwp-proxy/mock-request.js
@@ -32,7 +32,7 @@ async function request (opts) {
   let [statusCode, body] = resFixture(opts.url, opts.method, opts.json);
   let response = {
     statusCode,
-    headers: {'Content-type': 'application/json'},
+    headers: {'Content-Type': 'application/json; charset=utf-8'},
     body
   };
   return response;

--- a/test/jsonwp-proxy/proxy-specs.js
+++ b/test/jsonwp-proxy/proxy-specs.js
@@ -166,7 +166,7 @@ describe('proxy', function () {
       let j = mockProxy();
       let [req, res] = buildReqRes('/status', 'GET');
       await j.proxyReqRes(req, res);
-      res.headers['Content-type'].should.equal('application/json');
+      res.headers['Content-Type'].should.equal('application/json; charset=utf-8');
       res.sentCode.should.equal(200);
       res.sentBody.should.eql({status: 0, value: {foo: 'bar'}});
     });

--- a/test/protocol/protocol-e2e-specs.js
+++ b/test/protocol/protocol-e2e-specs.js
@@ -167,7 +167,7 @@ describe('Protocol', async function () {
         simple: false // 404 errors fulfill the promise, rather than rejecting
       });
 
-      res.headers['content-type'].should.include('text/plain');
+      res.headers['Content-Type'].should.include('text/plain');
     });
 
     it('should throw not yet implemented for unfilledout commands', async function () {


### PR DESCRIPTION
This should resolve issues like https://github.com/appium/ruby_lib/issues/598#issuecomment-392308793, since some HTTP servers fall back to ASCII instead of UTF-8 if the content encoding is not set explicitly in request headers.

@KazuCocoa FYI