### PR TITLE
Enforce UTF-8 encoding on request headers

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -20,7 +20,7 @@ async function getModificationDate (url) {
     logger.debug(`Cannot send HEAD request to '${url}'. Original error: ${e.message}`);
     return null;
   }
-  const value = response.headers['Last-Modified'];
+  const value = response.headers['last-modified'];
   logger.debug(`Got '${value}' as 'Last-Modified' HEAD response header value of '${url}'`);
   return value ? new Date(value) : null;
 }

--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -24,7 +24,7 @@ function fixPythonContentType (req, res, next) {
   // hack because python client library gives us wrong content-type
   if (/^\/wd/.test(req.path) && /^Python/.test(req.headers['user-agent'])) {
     if (req.headers['content-type'] === 'application/x-www-form-urlencoded') {
-      req.headers['content-type'] = 'application/json';
+      req.headers['content-type'] = 'application/json; charset=utf-8';
     }
   }
   next();
@@ -32,7 +32,7 @@ function fixPythonContentType (req, res, next) {
 
 function defaultToJSONContentType (req, res, next) {
   if (!req.headers['content-type']) {
-    req.headers['content-type'] = 'application/json';
+    req.headers['content-type'] = 'application/json; charset=utf-8';
   }
   next();
 }

--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -56,7 +56,7 @@ function catch4XXHandler (err, req, res, next) {
     // set the content type to `text/plain`
     // https://code.google.com/p/selenium/wiki/JsonWireProtocol#Responses
     log.debug(`Setting content type to 'text/plain' for HTTP status '${err.status}'`);
-    res.set('Content-Type', 'text/plain');
+    res.set('content-type', 'text/plain');
     res.status(err.status).send(`Unable to process request: ${err.message}`);
   } else {
     next(err);
@@ -67,7 +67,7 @@ function catch404Handler (req, res) {
   // set the content type to `text/plain`
   // https://code.google.com/p/selenium/wiki/JsonWireProtocol#Responses
   log.debug('No route found. Setting content type to \'text/plain\'');
-  res.set('Content-Type', 'text/plain');
+  res.set('content-type', 'text/plain');
   res.status(404).send(`The URL '${req.originalUrl}' did not map to a valid resource`);
 }
 

--- a/lib/express/static.js
+++ b/lib/express/static.js
@@ -29,7 +29,7 @@ async function guineaPigTemplate (req, res, page) {
     log.debug(`Waiting ${delay}ms before responding`);
     await B.delay(delay);
   }
-  res.set('Content-Type', 'text/html');
+  res.set('content-type', 'text/html');
   res.cookie('guineacookie1', 'i am a cookie value', {path: '/'});
   res.cookie('guineacookie2', 'cookié2', {path: '/'});
   res.cookie('guineacookie3', 'cant access this', {

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -104,8 +104,8 @@ class JWProxy {
       url: newUrl,
       method,
       headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'User-Agent': 'appium',
+        'content-type': 'application/json; charset=utf-8',
+        'user-agent': 'appium',
         accept: '*/*',
       },
       resolveWithFullResponse: true,
@@ -190,7 +190,7 @@ class JWProxy {
   async proxyReqRes (req, res) {
     let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
     res.headers = response.headers;
-    res.set('Content-Type', response.headers['content-type']);
+    res.set('content-type', response.headers['content-type']);
     // if the proxied response contains a sessionId that the downstream
     // driver has generated, we don't want to return that to the client.
     // Instead, return the id from the request or from current session

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -104,8 +104,8 @@ class JWProxy {
       url: newUrl,
       method,
       headers: {
-        'Content-type': 'application/json',
-        'user-agent': 'appium',
+        'Content-Type': 'application/json; charset=utf-8',
+        'User-Agent': 'appium',
         accept: '*/*',
       },
       resolveWithFullResponse: true,
@@ -190,7 +190,7 @@ class JWProxy {
   async proxyReqRes (req, res) {
     let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
     res.headers = response.headers;
-    res.set('Content-type', response.headers['content-type']);
+    res.set('Content-Type', response.headers['content-type']);
     // if the proxied response contains a sessionId that the downstream
     // driver has generated, we don't want to return that to the client.
     // Instead, return the id from the request or from current session

--- a/test/basedriver/helpers-e2e-specs.js
+++ b/test/basedriver/helpers-e2e-specs.js
@@ -87,9 +87,9 @@ describe('app download and configuration', function () {
             }
             // for testing zip file content types
             if (req.url.indexOf('mime-zip') !== -1) {
-              res.setHeader('Content-Type', 'application/zip');
+              res.setHeader('content-type', 'application/zip');
             } else if (req.url.indexOf('mime-bip') !== 1) {
-              res.setHeader('Content-Type', 'application/bip');
+              res.setHeader('content-type', 'application/bip');
             }
             serve(req, res, finalhandler(req, res));
           });

--- a/test/express/server-specs.js
+++ b/test/express/server-specs.js
@@ -70,7 +70,7 @@ describe('server', function () {
         'content-type': 'application/x-www-form-urlencoded'
       }
     });
-    body.should.eql('application/json');
+    body.should.eql('application/json; charset=utf-8');
   });
   it('should catch errors in the catchall', async function () {
     await request('http://localhost:8181/error')

--- a/test/jsonwp-proxy/mock-request.js
+++ b/test/jsonwp-proxy/mock-request.js
@@ -32,7 +32,7 @@ async function request (opts) {
   let [statusCode, body] = resFixture(opts.url, opts.method, opts.json);
   let response = {
     statusCode,
-    headers: {'Content-type': 'application/json'},
+    headers: {'content-type': 'application/json; charset=utf-8'},
     body
   };
   return response;

--- a/test/jsonwp-proxy/proxy-specs.js
+++ b/test/jsonwp-proxy/proxy-specs.js
@@ -166,7 +166,7 @@ describe('proxy', function () {
       let j = mockProxy();
       let [req, res] = buildReqRes('/status', 'GET');
       await j.proxyReqRes(req, res);
-      res.headers['Content-type'].should.equal('application/json');
+      res.headers['content-type'].should.equal('application/json; charset=utf-8');
       res.sentCode.should.equal(200);
       res.sentBody.should.eql({status: 0, value: {foo: 'bar'}});
     });


### PR DESCRIPTION
This should resolve issues like appium/ruby_lib#598 (comment), since some HTTP servers fall back to ASCII instead of UTF-8 if the content encoding is not set explicitly in request headers.

@KazuCocoa FYI