### PR TITLE
Fix sending of commands by JWProxy  class

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { logger, util } from 'appium-support';
 import request from 'request-promise';
 import { getSummaryByCode } from '../jsonwp-status/status';
-import { errors } from '../protocol/errors';
+import { errors, errorFromMJSONWPStatusCode, errorFromW3CJsonCode } from '../protocol/errors';
 
 
 const log = logger.getLogger('JSONWP Proxy');
@@ -157,29 +157,34 @@ class JWProxy {
 
   async command (url, method, body = null) {
     let [response, resBody] = await this.proxy(url, method, body);
-    let statusCodesWithRes = [100, 200, 500];
     resBody = util.safeJsonParse(resBody);
-    if (_.includes(statusCodesWithRes, response.statusCode) &&
-        (_.isUndefined(resBody.status) || _.isUndefined(resBody.value))) {
-      throw new Error(`Did not get a valid response object. Object was: ${JSON.stringify(resBody)}`);
-    }
-    if (_.includes(statusCodesWithRes, response.statusCode)) {
+    if (util.hasValue(resBody.status)) {
+      // Got response in MJSONWP format
       if (response.statusCode === 200 && resBody.status === 0) {
         return resBody.value;
-      } else if (response.statusCode === 200 && _.isUndefined(resBody.status)) {
-        return resBody;
       }
-      let message = getSummaryByCode(resBody.status);
-      if (resBody.value.message) {
-        message += ` (Original error: ${resBody.value.message})`;
+      const status = parseInt(resBody.status, 10);
+      if (!isNaN(status) && status !== 0) {
+        let message = resBody.value;
+        if (_.has(resBody.value, 'message')) {
+          message = _.isEmpty(message) ? resBody.value.message : `${message} ${resBody.value.message}`;
+        }
+        throw errorFromMJSONWPStatusCode(status, _.isEmpty(message) ? getSummaryByCode(status) : message);
       }
-      let e = new Error(message);
-      e.status = resBody.status;
-      e.value = resBody.value;
-      e.httpCode = response.statusCode;
-      throw e;
+    } else if (_.has(resBody, 'value')) {
+      // Got response in W3C format
+      if (response.statusCode === 200) {
+        return resBody.value;
+      }
+      if (_.isPlainObject(resBody.value) && resBody.value.error) {
+        throw errorFromW3CJsonCode(resBody.value.error, resBody.value.message);
+      }
+    } else if (response.statusCode === 200) {
+      // Unknown protocol. Keeping it because of the backward compatibility
+      return resBody;
     }
-    throw new Error(`Did not know what to do with response code '${response.statusCode}'`);
+    throw new errors.UnknownError(`Did not know what to do with response code '${response.statusCode}' ` +
+                                  `and response body '${_.truncate(JSON.stringify(resBody), {length: 300})}'`);
   }
 
   getSessionIdFromUrl (url) {

--- a/test/jsonwp-proxy/proxy-specs.js
+++ b/test/jsonwp-proxy/proxy-specs.js
@@ -130,9 +130,7 @@ describe('proxy', function () {
         e = err;
       }
       should.exist(e);
-      e.message.should.contain('Original error: Invisible element');
-      e.value.should.eql({message: 'Invisible element'});
-      e.status.should.equal(11);
+      e.message.should.contain('Invisible element');
     });
     it('should throw when a command fails with a 200 because the status is not 0', async function () {
       let j = mockProxy({sessionId: '123'});
@@ -143,9 +141,7 @@ describe('proxy', function () {
         e = err;
       }
       should.exist(e);
-      e.message.should.contain('Original error: Invisible element');
-      e.value.should.eql({message: 'Invisible element'});
-      e.status.should.equal(11);
+      e.message.should.contain('Invisible element');
     });
     it('should throw when a command fails with a 100', async function () {
       let j = mockProxy({sessionId: '123'});
@@ -156,9 +152,7 @@ describe('proxy', function () {
         e = err;
       }
       should.exist(e);
-      e.message.should.contain('Original error: chrome not reachable');
-      e.value.should.eql({message: 'chrome not reachable'});
-      e.status.should.equal(0);
+      e.message.should.contain('chrome not reachable');
     });
   });
   describe('req/res proxy', function () {


### PR DESCRIPTION
This method should throw specialised errors instead of the generic one. Also, it supports W3C responses now.

See https://github.com/appium/appium-xcuitest-driver/pull/688#issuecomment-395065421 for more details.

Also, it looks like WDA always returns returns response code as 200 independently of the actual response status. 