### PR TITLE
'reset' re-uses same protocol

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -346,10 +346,15 @@ class BaseDriver extends Protocol {
     // We also need to preserve the unexpected shutdown, and make sure it is not cancelled during reset.
     this.resetOnUnexpectedShutdown = () => {};
 
+    // Construct the arguments for createSession depending on the protocol type
+    const args = this.protocol === BaseDriver.DRIVER_PROTOCOL.W3C ?
+      [undefined, undefined, {alwaysMatch: this.caps, firstMatch: [{}]}] :
+      [this.caps];
+
     try {
       await this.deleteSession(this.sessionId);
       log.debug('Restarting app');
-      await this.createSession(this.caps);
+      await this.createSession(...args);
     } finally {
       // always restore state.
       for (let [key, value] of _.toPairs(currentConfig)) {

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -403,6 +403,33 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         });
       });
     });
+    describe('.reset', function () {
+      it('should reset as W3C if the original session was W3C', async function () {
+        const caps = {
+          alwaysMatch: {
+            deviceName: 'Fake',
+            automationName: 'Fake',
+            platformName: 'Fake',
+          },
+          firstMatch: [{}],
+        };
+        await d.createSession(undefined, undefined, caps);
+        d.protocol.should.equal('W3C');
+        await d.reset();
+        d.protocol.should.equal('W3C');
+      });
+      it('should reset as MJSONWP if the original session was MJSONWP', async function () {
+        const caps = {
+          deviceName: 'Fake',
+          automationName: 'Fake',
+          platformName: 'Fake',
+        };
+        await d.createSession(caps);
+        d.protocol.should.equal('MJSONWP');
+        await d.reset();
+        d.protocol.should.equal('MJSONWP');
+      });
+    });
   });
 
   describe('DeviceSettings', function () {


### PR DESCRIPTION
* Before, it was creating a new session and using the processed caps
* Problem was, if it was W3C it would create a MJSONWP
* Now it checks the protocol before resetting and passes in the appropriate args to createSession depending on the protocol type

(related to: https://github.com/appium/appium/issues/10819)