### PR TITLE
Fix reset tests for importation

### DIFF
--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -5,6 +5,7 @@ import B from 'bluebird';
 import { DeviceSettings } from '../..';
 import BaseDriver from "../../lib/basedriver/driver";
 
+
 const should = chai.should();
 chai.use(chaiAsPromised);
 
@@ -406,11 +407,11 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
     describe('.reset', function () {
       it('should reset as W3C if the original session was W3C', async function () {
         const caps = {
-          alwaysMatch: {
+          alwaysMatch: Object.assign({}, defaultCaps, {
             deviceName: 'Fake',
             automationName: 'Fake',
             platformName: 'Fake',
-          },
+          }),
           firstMatch: [{}],
         };
         await d.createSession(undefined, undefined, caps);
@@ -419,11 +420,11 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         d.protocol.should.equal('W3C');
       });
       it('should reset as MJSONWP if the original session was MJSONWP', async function () {
-        const caps = {
+        const caps = Object.assign({}, defaultCaps, {
           deviceName: 'Fake',
           automationName: 'Fake',
           platformName: 'Fake',
-        };
+        });
         await d.createSession(caps);
         d.protocol.should.equal('MJSONWP');
         await d.reset();


### PR DESCRIPTION
Reset tests were recently added, which do not work when the tests are imported and run in different packages (see, for instance, https://github.com/appium/appium-fake-driver/blob/master/test/driver-e2e-specs.js#L22, whose tests fail as in https://travis-ci.org/appium/appium-fake-driver/jobs/390458912#L2452).

This is because the caps constraints are changed for the different driver, and these tests don't allow for it. So just extend the caps, like the other tests.