### PR TITLE
Fix: Add 'app' cap to reset tests

### DIFF
--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -408,6 +408,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       it('should reset as W3C if the original session was W3C', async function () {
         const caps = {
           alwaysMatch: Object.assign({}, defaultCaps, {
+            app: 'Fake',
             deviceName: 'Fake',
             automationName: 'Fake',
             platformName: 'Fake',
@@ -421,6 +422,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       });
       it('should reset as MJSONWP if the original session was MJSONWP', async function () {
         const caps = Object.assign({}, defaultCaps, {
+          app: 'Fake',
           deviceName: 'Fake',
           automationName: 'Fake',
           platformName: 'Fake',


### PR DESCRIPTION
* This test worked fine in base driver but these tests also run in fake driver and don't work beause `app ` is a required capability
* Added `app=fake` to caps

Should fix broken test: https://travis-ci.org/appium/appium-fake-driver/jobs/395675224