### PR TITLE
Log errors which happen during caps merging

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -185,7 +185,9 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
       if (matchedCaps) {
         break;
       }
-    } catch (ign) { }
+    } catch (err) {
+      log.warn(err.message);
+    }
   }
 
   // Returns variables for testing purposes


### PR DESCRIPTION
It is more useful to see such errors in the log rather than just ignoring them