### PR TITLE
Remove list of possible values for platformName cap

### DIFF
--- a/lib/basedriver/desired-caps.js
+++ b/lib/basedriver/desired-caps.js
@@ -7,15 +7,6 @@ let desiredCapabilityConstraints = {
   platformName: {
     presence: true,
     isString: true,
-    inclusionCaseInsensitive: [
-      'iOS',
-      'Android',
-      'FirefoxOS',
-      'Windows',
-      'Mac',
-      'Tizen',
-      'Fake'
-    ]
   },
   deviceName: {
     presence: true,


### PR DESCRIPTION
The base driver should not know anything about the possible platforms that are available. That is the responsibility of the umbrella driver (see https://github.com/appium/appium/blob/master/lib/appium.js#L120-L124). Having them here both muddies that the base driver does, and also requires publishing this package in addition to the main umbrella driver when a new driver is added.

The base driver should only know that `platformName` exists, is required, and takes a string. The umbrella driver should know all the possibilities. And each individual driver should know a single possible `platformName` (e.g., `appium-ios-driver` should know only of `iOS` as a possible value).