### PR TITLE
Add base to regexp for original proxy url

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -72,7 +72,7 @@ class JWProxy {
       throw new Error(`Did not know what to do with url '${url}'`);
     }
 
-    const stripPrefixRe = new RegExp('^.+(/(session|status).*)$');
+    const stripPrefixRe = new RegExp(`^${this.base}(/(session|status).*)$`);
     if (stripPrefixRe.test(remainingUrl)) {
       remainingUrl = stripPrefixRe.exec(remainingUrl)[1];
     }
@@ -97,6 +97,7 @@ class JWProxy {
       throw new Error(`Could not find :session section for url: ${remainingUrl}`);
     }
     remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
+
     return proxyBase + remainingUrl;
   }
 


### PR DESCRIPTION
If another part of the URL has "session" in it, the greedy regexp will take that instead of the one we want. So, if it is set, add it to the regexp so we get the correct "session"

This ought to fix https://github.com/appium/appium/issues/11052