### PR TITLE
Fix handling of proxy url

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -72,7 +72,7 @@ class JWProxy {
       throw new Error(`Did not know what to do with url '${url}'`);
     }
 
-    const stripPrefixRe = new RegExp('^.+(/(session|status).*)$');
+    const stripPrefixRe = new RegExp('^.+?(/(session|status).*)$');
     if (stripPrefixRe.test(remainingUrl)) {
       remainingUrl = stripPrefixRe.exec(remainingUrl)[1];
     }

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -72,7 +72,7 @@ class JWProxy {
       throw new Error(`Did not know what to do with url '${url}'`);
     }
 
-    const stripPrefixRe = new RegExp('^.+?(/(session|status).*)$');
+    const stripPrefixRe = new RegExp('^.*?(/(session|status).*)$');
     if (stripPrefixRe.test(remainingUrl)) {
       remainingUrl = stripPrefixRe.exec(remainingUrl)[1];
     }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ws": "^6.0.0"
   },
   "scripts": {
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "prepublish": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",

--- a/test/jsonwp-proxy/url-specs.js
+++ b/test/jsonwp-proxy/url-specs.js
@@ -91,7 +91,7 @@ describe('proxying partial urls', function () {
     let proxyUrl = j.getUrlForProxy(incomingUrl);
     proxyUrl.should.equal('http://localhost:4444/wd/hub/session/barbaz/element');
   });
-  it.skip(`should proxy session commands when '/session' is in the url`, function () {
+  it(`should proxy session commands when '/session' is in the url`, function () {
     let incomingUrl = '/wd/hub/session/82a9b7da-faaf-4a1d-8ef3-5e4fb5812200/cookie/session-something-or-other';
     let j = new JWProxy({sessionId: 'barbaz'});
     let proxyUrl = j.getUrlForProxy(incomingUrl);

--- a/test/jsonwp-proxy/url-specs.js
+++ b/test/jsonwp-proxy/url-specs.js
@@ -97,6 +97,12 @@ describe('proxying partial urls', function () {
     let proxyUrl = j.getUrlForProxy(incomingUrl);
     proxyUrl.should.equal('http://localhost:4444/wd/hub/session/barbaz/cookie/session-something-or-other');
   });
+  it(`should proxy session commands when '/session' is in the url and not base on the original url`, function () {
+    let incomingUrl = '/session/82a9b7da-faaf-4a1d-8ef3-5e4fb5812200/cookie/session-something-or-other';
+    let j = new JWProxy({sessionId: 'barbaz'});
+    let proxyUrl = j.getUrlForProxy(incomingUrl);
+    proxyUrl.should.equal('http://localhost:4444/wd/hub/session/barbaz/cookie/session-something-or-other');
+  });
   it('should error session commands without /session without session id', function () {
     let incomingUrl = '/element';
     let j = new JWProxy();


### PR DESCRIPTION
Use [lazy quantifier](https://javascript.info/regexp-greedy-and-lazy#lazy-mode) in proxy url processing, so we don't consume the whole url.

This does what #236 failed to do.