### PR TITLE
Get message for MJSONWP error

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -771,6 +771,9 @@ function isErrorType (err, type) {
  * @return {ProtocolError} The error that is associated with provided JSONWP status code
  */
 function errorFromMJSONWPStatusCode (code, message) {
+  if (message && message.message) {
+    message = message.message;
+  }
   if (code !== UnknownError.code() && jsonwpErrorCodeMap[code]) {
     mjsonwpLog.debug(`Matched JSONWP error code ${code} to ${jsonwpErrorCodeMap[code].name}`);
     return new jsonwpErrorCodeMap[code](message);


### PR DESCRIPTION
Recent changes have broken the handling of proxy errors in certain cases. In particular, Chromedriver returns a value that has a message inside it, so we need to unwrap it.

See https://github.com/appium/appium-chromedriver/issues/90