### PR TITLE
Clean up error message from protocol

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -360,7 +360,13 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // Use the logger that's specific to this response
       const protocolLogger = isW3C ? w3cLog : mjsonwpLog;
 
-      protocolLogger.error(`Encountered internal error running command:  ${JSON.stringify(err)} ${err.stacktrace || err.stack}`);
+      let errMsg = err.stacktrace || err.stack;
+      if (!errMsg.includes(err.message)) {
+        // if the message has more information, add it. but often the message
+        // is the first part of the stack trace
+        errMsg = `${err.message} ${errMsg}`;
+      }
+      protocolLogger.error(`Encountered internal error running command: ${errMsg}`);
       if (isErrorType(err, errors.ProxyRequestError)) {
         actualErr = err.getActualError();
       }


### PR DESCRIPTION
Printing the error and then the stack trace leads to odd output. See, for instance, https://gist.github.com/saikrishna321/fa515b751d937f3c466671ec704633f9#file-latest-beta13-L152-L157.

If the message in the error is not included in the stack trace (it usually is, but not always) then append it. Otherwise the stack trace has as much information as the rest of the error does.