### PR TITLE
Remove the redundant logging from getResponseForW3CError helper

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -818,13 +818,10 @@ function getResponseForW3CError (err) {
   let w3cErrorString;
 
   if (!err.w3cStatus) {
-    if (util.hasValue(err.status)) {
+    err = util.hasValue(err.status)
       // If it's a JSONWP error, find corresponding error
-      err = errorFromMJSONWPStatusCode(err.status, err.value);
-    } else {
-      w3cLog.error(`Encountered internal error running command: ${err.stack}`);
-      err = new errors.UnknownError(err.message);
-    }
+      ? errorFromMJSONWPStatusCode(err.status, err.value)
+      : new errors.UnknownError(err.message);
   }
 
   if (isErrorType(err, errors.BadParametersError)) {


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/11245