### PR TITLE
Change logging level to debug for internal errors

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -315,7 +315,6 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         }
       }
 
-
       // convert undefined to null, but leave all other values the same
       if (_.isUndefined(driverRes)) {
         driverRes = null;
@@ -366,7 +365,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         // is the first part of the stack trace
         errMsg = `${err.message} ${errMsg}`;
       }
-      protocolLogger.error(`Encountered internal error running command: ${errMsg}`);
+      protocolLogger.debug(`Encountered internal error running command: ${errMsg}`);
       if (isErrorType(err, errors.ProxyRequestError)) {
         actualErr = err.getActualError();
       }


### PR DESCRIPTION
This exception does not always mean an error from the client perspective. That is why it would be more appropriate to log it on debug level.