### PR TITLE
Avoid TypeError if stacktrace is undefined

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -438,7 +438,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       if (!_.includes(errMsg, err.message)) {
         // if the message has more information, add it. but often the message
         // is the first part of the stack trace
-        errMsg = `${err.message}${errMsg ? (' ' + errMsg) : ''}`;
+        errMsg = `${err.message}${errMsg ? ('\n' + errMsg) : ''}`;
       }
       SESSIONS_CACHE.getLogger(req.params.sessionId || newSessionId, currentProtocol).debug(`Encountered ` +
         `internal error running command: ${errMsg}`);

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -435,10 +435,10 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       currentProtocol = currentProtocol || extractProtocol(driver, req.params.sessionId || newSessionId);
 
       let errMsg = err.stacktrace || err.stack;
-      if (!errMsg.includes(err.message)) {
+      if (!_.includes(errMsg, err.message)) {
         // if the message has more information, add it. but often the message
         // is the first part of the stack trace
-        errMsg = `${err.message} ${errMsg}`;
+        errMsg = `${err.message}${errMsg ? (' ' + errMsg) : ''}`;
       }
       SESSIONS_CACHE.getLogger(req.params.sessionId || newSessionId, currentProtocol).debug(`Encountered ` +
         `internal error running command: ${errMsg}`);


### PR DESCRIPTION
I'm not quite sure how it is possible that error instance does not have stack property (perhaps a node issue), but it happens: https://gist.github.com/saikrishna321/a88fd256d03e9c6ce865c632dc24b3fd