### PR TITLE
Remove samba support

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -4,8 +4,7 @@ import url from 'url';
 import logger from './logger';
 import _fs from 'fs';
 import B from 'bluebird';
-import { tempDir, system, fs, util, zip } from 'appium-support';
-import { exec } from 'teen_process';
+import { tempDir, fs, util, zip } from 'appium-support';
 import request from 'request';
 import asyncRequest from 'request-promise';
 import LRU from 'lru-cache';
@@ -46,7 +45,7 @@ function getCachedApplicationPath (link, currentModified) {
   return null;
 }
 
-async function configureApp (app, supportedAppExtensions, mountRoot = "Volumes", windowsShareUserName = "", windowsSharePassword = "") {
+async function configureApp (app, supportedAppExtensions) {
   if (!_.isString(app)) {
     // immediately shortcircuit if not given an app
     return;
@@ -61,15 +60,7 @@ async function configureApp (app, supportedAppExtensions, mountRoot = "Volumes",
   const isUrl = ['http:', 'https:'].includes(protocol);
   let currentModified = null;
 
-  if (newApp.startsWith('\\\\')) {
-    // Use the app from Windows network share
-    logger.info(`Downloading the application '${newApp}' from SMB share...`);
-    newApp = await copyFromWindowsNetworkShare(newApp, mountRoot, windowsShareUserName, windowsSharePassword);
-    if (!await fs.exists(newApp)) {
-      throw new Error(`The application at '${app}' does not exist or is not accessible for download`);
-    }
-    logger.info(`Downloaded the app to '${newApp}'`);
-  } else if (isUrl) {
+  if (isUrl) {
     // Use the app from remote URL
     logger.info(`Using downloadable app '${newApp}'`);
     const headers = await retrieveHeaders(newApp);
@@ -240,54 +231,6 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
   } finally {
     await fs.rimraf(tmpRoot);
   }
-}
-
-async function copyFromWindowsNetworkShare (app, mountRoot, windowsUserName, windowsPassword) {
-  return system.isWindows()
-    ? await copyLocallyFromWindowsShare(app)
-    : await mountWindowsShareOnMac(app, mountRoot, windowsUserName, windowsPassword);
-}
-
-async function mountWindowsShareOnMac (app, mountRoot, windowsUserName, windowsPassword) {
-  let pathSplit = app.split("\\");
-  let networkShare = pathSplit[2];
-  let rootFolder = pathSplit[3];
-  app = app.replace(/\\/g, "/");
-  app = app.replace(`/${networkShare}`, mountRoot);
-  let mountPath = `/${mountRoot}/${rootFolder}`;
-
-  let mountNetworkShare = async function () {
-    await fs.mkdir(mountPath);
-    let mountArgs = [`-t`, `smbfs`, `//${windowsUserName}:${windowsPassword}@${networkShare}/${rootFolder}`, mountPath];
-    try {
-      await exec('mount', mountArgs);
-    } catch (err) {
-      logger.errorAndThrow(`Error mounting: ${err.message}`);
-    }
-  };
-
-  if (await fs.exists(mountPath)) {
-    if (await fs.exists(app)) {
-      return app;
-    }
-    let umountArgs = [mountPath];
-    try {
-      await exec('umount', umountArgs);
-    } catch (err) {
-      logger.error(`Error Unmounting :${err.message}`);
-    }
-    await fs.rimraf(mountRoot);
-  }
-  await mountNetworkShare();
-  return app;
-}
-
-async function copyLocallyFromWindowsShare (app) {
-  const fileInfo = await tempDir.open({
-    prefix: path.basename(app),
-    suffix: ''
-  });
-  return await fs.copyFile(app, fileInfo.path);
 }
 
 function isPackageOrBundle (app) {


### PR DESCRIPTION
I've checked all depending drivers and none of them passes more than two parameters to `configureApp` 

Also, the current implementation is not very optimal (I'm not quite sure it ever worked). It would be more effective to use smb2 library, but I don't see a purpose to implement that right now.