### PR TITLE
allow correct downloading of zipped apps without content type header

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -94,13 +94,20 @@ async function configureApp (app, supportedAppExtensions) {
         APPLICATIONS_CACHE.del(app);
       }
       let fileName = `appium-app${_.first(supportedAppExtensions)}`;
+
+      // to determine if we need to unzip the app, we have a number of places
+      // to look: content type, content disposition, or the file extension
+      const downloadZipName = 'appium-app.zip';
       if (headers['content-type']) {
         logger.debug(`Content-Type: ${headers['content-type']}`);
         // the filetype may not be obvious for certain urls, so check the mime type too
         if (ZIP_MIME_TYPES.includes(headers['content-type'])) {
-          fileName = 'appium-app.zip';
+          fileName = downloadZipName;
           shouldUnzipApp = true;
         }
+      } else if (ZIP_EXTS.includes(path.extname(newApp))) {
+        fileName = downloadZipName;
+        shouldUnzipApp = true;
       }
       if (headers['content-disposition'] && /^attachment/i.test(headers['content-disposition'])) {
         const match = /filename="([^"]+)/i.exec(headers['content-disposition']);


### PR DESCRIPTION
this case was missed in the refactor, causing a regression. should definitely get something like this in before 1.10