### PR TITLE
Update dist in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "8"
   - "10"
-sudo: required
-dist: trusty
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -100,10 +100,5 @@
     "ignore": [
       "bluebird"
     ]
-  },
-  "babel": {
-    "plugins": [
-      "@babel/plugin-proposal-class-properties"
-    ]
   }
 }


### PR DESCRIPTION
Clean out the `sudo` and `dist` portions of the Travis config, in preparation for [upcoming changes to defaults](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) in Travis's Linux infrastructure.