### PR TITLE
make allowing CORS conditional

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -15,7 +15,7 @@ import { addWebSocketHandler, removeWebSocketHandler, removeAllWebSocketHandlers
 import B from 'bluebird';
 
 
-async function server (configureRoutes, port, hostname = null) {
+async function server (configureRoutes, port, hostname = null, allowCors = true) {
   // create the actual http server
   let app = express();
   let httpServer = http.createServer(app);
@@ -52,7 +52,7 @@ async function server (configureRoutes, port, hostname = null) {
       socket.setTimeout(600 * 1000); // 10 minute timeout
       socket.on('error', reject);
     });
-    configureServer(app, configureRoutes);
+    configureServer(app, configureRoutes, allowCors);
 
     let serverArgs = [port];
     if (hostname) {
@@ -69,7 +69,7 @@ async function server (configureRoutes, port, hostname = null) {
   });
 }
 
-function configureServer (app, configureRoutes, shouldAllowCrossDomain = true) {
+function configureServer (app, configureRoutes, allowCors = true) {
   app.use(endLogFormatter);
 
   // set up static assets
@@ -81,7 +81,7 @@ function configureServer (app, configureRoutes, shouldAllowCrossDomain = true) {
   app.use('/wd/hub/crash', produceCrash);
 
   // add middlewares
-  if (shouldAllowCrossDomain) {
+  if (allowCors) {
     app.use(allowCrossDomain);
   }
   app.use(fixPythonContentType);

--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -69,7 +69,7 @@ async function server (configureRoutes, port, hostname = null) {
   });
 }
 
-function configureServer (app, configureRoutes) {
+function configureServer (app, configureRoutes, shouldAllowCrossDomain = true) {
   app.use(endLogFormatter);
 
   // set up static assets
@@ -81,7 +81,9 @@ function configureServer (app, configureRoutes) {
   app.use('/wd/hub/crash', produceCrash);
 
   // add middlewares
-  app.use(allowCrossDomain);
+  if (shouldAllowCrossDomain) {
+    app.use(allowCrossDomain);
+  }
   app.use(fixPythonContentType);
   app.use(defaultToJSONContentType);
   app.use(bodyParser.urlencoded({extended: true}));


### PR DESCRIPTION
It turns out blindly allowing CORS could be a security hazard (who knew)
See https://github.com/w3c/webdriver/pull/1362 for the conversation that led to this realization.
This change makes the cross domain middleware conditional (defaulting to the current behavior).
This way Appium can pass in 'false' based on a flag, for better server security.