### PR TITLE
Do not use static variables yet

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -209,11 +209,6 @@ class BaseDriver extends Protocol {
     return true;
   }
 
-  static DRIVER_PROTOCOL = {
-    W3C: 'W3C',
-    MJSONWP: 'MJSONWP',
-  };
-
   isMjsonwpProtocol () {
     return this.protocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP;
   }
@@ -465,6 +460,11 @@ class BaseDriver extends Protocol {
     return this.managedDrivers;
   }
 }
+
+BaseDriver.DRIVER_PROTOCOL = {
+  W3C: 'W3C',
+  MJSONWP: 'MJSONWP',
+};
 
 for (let [cmd, fn] of _.toPairs(commands)) {
   BaseDriver.prototype[cmd] = fn;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "3.12.0",
+  "version": "3.13.0",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
`static` variables are unsupported EcmaScript (just experimental). Usage of `static` variables is experimental and seems to have been broken by a later babel version