### PR TITLE
rename the jsonwp proxy logger so it's less confusing in the logs

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -8,7 +8,7 @@ import { routeToCommandName } from '../protocol/routes';
 import ProtocolConverter from './protocol-converter';
 
 
-const log = logger.getLogger('JSONWP Proxy');
+const log = logger.getLogger('WD Proxy');
 // TODO: Make this value configurable as a server side capability
 const LOG_OBJ_LENGTH = 1024; // MAX LENGTH Logged to file / console
 const DEFAULT_REQUEST_TIMEOUT = 240000;


### PR DESCRIPTION
It's a bit confusing to see [JSONWP Proxy] mixed in with W3C sessions, so choose a more neutral name.