### PR TITLE
Tune the list of allowed headers for CORS

### DIFF
--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -5,19 +5,17 @@ import { errors } from '../protocol';
 function allowCrossDomain (req, res, next) {
   try {
     res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS,DELETE');
-    res.header('Access-Control-Allow-Headers', 'origin, content-type, accept');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS, DELETE');
+    res.header('Access-Control-Allow-Headers', 'Cache-Control, Pragma, Origin, X-Requested-With, Content-Type, Accept');
 
     // need to respond 200 to OPTIONS
     if ('OPTIONS' === req.method) {
-      res.sendStatus(200);
-    } else {
-      next();
+      return res.sendStatus(200);
     }
   } catch (err) {
     log.error(`Unexpected error: ${err.stack}`);
-    next();
   }
+  next();
 }
 
 function fixPythonContentType (req, res, next) {


### PR DESCRIPTION
It looks like Chrome is quite sensitive to such stuff: http://williambert.online/2013/06/allow-cors-with-localhost-in-chrome/