### PR TITLE
add POST for system_time in order to set payload

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -347,7 +347,8 @@ const METHOD_MAP = {
     POST: {command: 'mobileShake'}
   },
   '/wd/hub/session/:sessionId/appium/device/system_time': {
-    GET: {command: 'getDeviceTime', payloadParams: {optional: ['format']}}
+    GET: {command: 'getDeviceTime', payloadParams: {optional: ['format']}},
+    POST: {command: 'getDeviceTime', payloadParams: {optional: ['format']}}
   },
   '/wd/hub/session/:sessionId/appium/device/lock': {
     POST: {command: 'lock', payloadParams: {optional: ['seconds']}}

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('9e59ddee');
+      hash.should.equal('17fb263f');
     });
   });
 


### PR DESCRIPTION
related to: https://github.com/appium/python-client/issues/311

I would like to accept `POST` method for `system_time` like `app_state` in order to accept the optional parameters by some clients which can not add payload in their GET method.
Python client does not allow to set payload in GET method while Java and Ruby clients could.
