### PR TITLE
add user-agent to list of cors headers

### DIFF
--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -6,7 +6,7 @@ function allowCrossDomain (req, res, next) {
   try {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS, DELETE');
-    res.header('Access-Control-Allow-Headers', 'Cache-Control, Pragma, Origin, X-Requested-With, Content-Type, Accept');
+    res.header('Access-Control-Allow-Headers', 'Cache-Control, Pragma, Origin, X-Requested-With, Content-Type, Accept, User-Agent');
 
     // need to respond 200 to OPTIONS
     if ('OPTIONS' === req.method) {


### PR DESCRIPTION
webdriverio apparently now sends the `user-agent` header, so for it to work over the web we need to add that to the cors header list.