### PR TITLE
Apply command timeout only if queuing is enabled

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -307,7 +307,7 @@ class BaseDriver extends Protocol {
     // automatic session deletion in this.onCommandTimeout. Of course we don't
     // want to trigger the timer when the user is shutting down the session
     // intentionally
-    if (cmd !== 'deleteSession') {
+    if (this.isCommandsQueueEnabled && cmd !== 'deleteSession') {
       // reseting existing timeout
       this.startNewCommandTimeout();
     }


### PR DESCRIPTION
We should not set timeouts for commands that belong exclusively to the umbrella driver