### PR TITLE
Remove generic string->boolean warning

### DIFF
--- a/lib/basedriver/desired-caps.js
+++ b/lib/basedriver/desired-caps.js
@@ -89,7 +89,6 @@ validator.validators.isBoolean = function (value) {
 
   // allow a string value
   if (typeof value === 'string' && ['true', 'false', ''].includes(value)) {
-    log.warn('Boolean capability passed in as string. Functionality may be compromised.');
     return null;
   }
 


### PR DESCRIPTION
We have two warnings when a boolean capability is passed in. One generic (removed here) and one specific to the actual capability (see https://github.com/appium/appium-base-driver/blob/master/lib/basedriver/commands/session.js#L114-L129).

The current situation leads to unnecessary logging (taken from https://github.com/appium/appium/issues/12186#issue-411719882)
```
[debug] [BaseDriver] Creating session with W3C capabilities: {"alwaysMatch":{"platformNa...
[BaseDriver] Boolean capability passed in as string. Functionality may be compromised.
[BaseDriver] Boolean capability passed in as string. Functionality may be compromised.
[BaseDriver] Boolean capability passed in as string. Functionality may be compromised.
[BaseDriver] Boolean capability passed in as string. Functionality may be compromised.
[BaseDriver] Boolean capability passed in as string. Functionality may be compromised.
[BaseDriver] Boolean capability passed in as string. Functionality may be compromised.
[BaseDriver] Capability 'noReset' changed from string to boolean. This may cause unexpected behavior
[BaseDriver] Capability 'useKeystore' changed from string to boolean. This may cause unexpected behavior
[BaseDriver] Capability 'unicodeKeyboard' changed from string to boolean. This may cause unexpected behavior
[BaseDriver] Capability 'resetKeyboard' changed from string to boolean. This may cause unexpected behavior
[BaseDriver] Capability 'noSign' changed from string to boolean. This may cause unexpected behavior
[BaseDriver] Capability 'autoGrantPermissions' changed from string to boolean. This may cause unexpected behavior
```