### PR TITLE
Fix find element wrong coordinate

### DIFF
--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -386,7 +386,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
              `screen at ${screenWidth}x${screenHeight}`);
     imgObj = imgObj.resize(screenWidth, screenHeight);
 
-    scale = {xScale: screenWidth / shotWidth, yScale: screenHeight / shotHeight};
+    scale = {xScale: (1.0 * screenWidth) / shotWidth, yScale: (1.0 * screenHeight) / shotHeight};
   }
 
   b64Screenshot = (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
@@ -404,7 +404,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  * @returns {string} base64-encoded scaled template screenshot
  */
 helpers.fixTemplateImageScale = async function (b64Template, scale) {
-  if (!scale) {
+  if (!scale || !_.isNumber(scale)) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -222,19 +222,9 @@ helpers.findByImage = async function (b64Template, {
   let rect = null;
   const condition = async () => {
     try {
-      let {b64Screenshot, recize} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
+      const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
-      if (recize) {
-        // For iOS case, mainly
-        let imgTempObj = await imageUtil.getJimpImage(b64Template);
-        let {width: baseTmpWidth, height: baseTmpHeigh} = imgTempObj.bitmap;
-        log.info(`Scaling template image from ${baseTmpWidth}x${baseTmpHeigh}` +
-                 ` to ${baseTmpWidth * recize.widthRatio}x${baseTmpHeigh * recize.heightRatio}`);
-        log.info(`The ratio is ${recize.widthRatio} and ${recize.heightRatio}`);
-        imgTempObj = await imgTempObj.resize(baseTmpWidth * recize.widthRatio, baseTmpHeigh * recize.heightRatio);
-        b64Template = (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
-      }
-
+      b64Template = await this.fixScaleTemplateImage(b64Template, scale);
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
         b64Template, {threshold})).rect;
       return true;
@@ -314,13 +304,22 @@ helpers.ensureTemplateSize = async function (b64Template, screenWidth, screenHei
 };
 
 /**
+ * @typedef {Object} Screenshot
+ * @property {string} b64Screenshot - base64 based screenshot string
+ */
+/**
+ * @typedef {Object} ScreenshotScale
+ * @property {float} widthRatio - Scale ratio for width
+ * @property {float} heightRatio - Scale ratio for height
+ */
+/**
  * Get the screenshot image that will be used for find by element, potentially
  * altering it in various ways based on user-requested settings
  *
  * @param {int} screenWidth - width of screen
  * @param {int} screenHeight - height of screen
  *
- * @returns {string} base64-encoded screenshot
+ * @returns {Screenshot, ?ScreenshotScale} base64-encoded screenshot and ScreenshotScale
  */
 helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   if (!this.getScreenshot) {
@@ -333,7 +332,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   // between the screenshot and the screen, just return the screenshot now
   if (!this.settings.getSettings().fixImageFindScreenshotDims) {
     log.info(`Not verifying screenshot dimensions match screen`);
-    return b64Screenshot;
+    return {b64Screenshot};
   }
 
   // otherwise, do some verification on the screenshot to make sure it matches
@@ -347,7 +346,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
     // the height and width of the screenshot and the device screen match, which
     // means we should be safe when doing template matches
     log.info('Screenshot size matched screen size');
-    return b64Screenshot;
+    return {b64Screenshot};
   }
 
   // otherwise, if they don't match, it could spell problems for the accuracy
@@ -375,19 +374,52 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 
   // now we know the aspect ratios match, but there might still be a scale
   // mismatch, so just resize based on the screen dimensions
-  let recize;
+  let scale;
   if (screenWidth !== shotWidth) {
     log.info(`Scaling screenshot from ${shotWidth}x${shotHeight} to match ` +
              `screen at ${screenWidth}x${screenHeight}`);
     imgObj = imgObj.resize(screenWidth, screenHeight);
 
-    recize = {widthRatio: screenWidth / shotWidth, heightRatio: screenHeight / shotHeight};
+    scale = {widthRatio: screenWidth / shotWidth, heightRatio: screenHeight / shotHeight};
   }
 
   b64Screenshot = (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
-  return {b64Screenshot, recize};
+  return {b64Screenshot, scale};
 };
 
+
+/**
+ * @typedef {Object} ScreenshotScale
+ * @property {float} widthRatio - Scale ratio for width
+ * @property {float} heightRatio - Scale ratio for height
+ */
+
+/**
+ * Get a image that will be used for template maching.
+ * Returns scaled image if scale ratio is provided.
+ *
+ * @param {string} b64Template - base64-encoded image used as a template to be
+ * matched in the screenshot
+ * @param {?ScreenshotScale} scale - height of screen
+ *
+ * @returns {string} base64-encoded scaled template screenshot
+ */
+helpers.fixScaleTemplateImage = async function (b64Template, scale) {
+  if (!scale) {
+    return b64Template;
+  }
+
+  let imgTempObj = await imageUtil.getJimpImage(b64Template);
+  let {width: baseTempWidth, height: baseTempHeigh} = imgTempObj.bitmap;
+
+  const scaledWidth = baseTempWidth * scale.widthRatio;
+  const scaledHeight = baseTempHeigh * scale.heightRatio;
+  log.info(`Scaling template image from ${baseTempWidth}x${baseTempHeigh}` +
+            ` to ${scaledWidth}x${scaledHeight}`);
+  log.info(`The ratio is ${scale.widthRatio} and ${scale.heightRatio}`);
+  imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
+  return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
+};
 
 Object.assign(extensions, commands, helpers);
 export { commands, helpers, IMAGE_STRATEGY, CUSTOM_STRATEGY };

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -313,8 +313,8 @@ helpers.ensureTemplateSize = async function (b64Template, screenWidth, screenHei
  */
 /**
  * @typedef {Object} ScreenshotScale
- * @property {float} widthRatio - Scale ratio for width
- * @property {float} heightRatio - Scale ratio for height
+ * @property {float} xScale - Scale ratio for width
+ * @property {float} yScale - Scale ratio for height
  */
 /**
  * Get the screenshot image that will be used for find by element, potentially
@@ -386,19 +386,12 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
              `screen at ${screenWidth}x${screenHeight}`);
     imgObj = imgObj.resize(screenWidth, screenHeight);
 
-    scale = {widthRatio: screenWidth / shotWidth, heightRatio: screenHeight / shotHeight};
+    scale = {xScale: screenWidth / shotWidth, yScale: screenHeight / shotHeight};
   }
 
   b64Screenshot = (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
   return {b64Screenshot, scale};
 };
-
-
-/**
- * @typedef {Object} ScreenshotScale
- * @property {float} widthRatio - Scale ratio for width
- * @property {float} heightRatio - Scale ratio for height
- */
 
 /**
  * Get a image that will be used for template maching.
@@ -406,7 +399,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  *
  * @param {string} b64Template - base64-encoded image used as a template to be
  * matched in the screenshot
- * @param {?ScreenshotScale} scale - height of screen
+ * @param {?ScreenshotScale} scale - scale of screen
  *
  * @returns {string} base64-encoded scaled template screenshot
  */
@@ -418,11 +411,11 @@ helpers.fixTemplateImageScale = async function (b64Template, scale) {
   let imgTempObj = await imageUtil.getJimpImage(b64Template);
   let {width: baseTempWidth, height: baseTempHeigh} = imgTempObj.bitmap;
 
-  const scaledWidth = baseTempWidth * scale.widthRatio;
-  const scaledHeight = baseTempHeigh * scale.heightRatio;
+  const scaledWidth = baseTempWidth * scale.xScale;
+  const scaledHeight = baseTempHeigh * scale.yScale;
   log.info(`Scaling template image from ${baseTempWidth}x${baseTempHeigh}` +
             ` to ${scaledWidth}x${scaledHeight}`);
-  log.info(`The ratio is ${scale.widthRatio} and ${scale.heightRatio}`);
+  log.info(`The ratio is ${scale.xScale} and ${scale.yScale}`);
   imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
   return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
 };

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -387,6 +387,10 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  * @returns {string} base64-encoded scaled template screenshot
  */
 helpers.fixImageTemplateScale = async function (b64Template, scale = {}) {
+  if (!scale) {
+    return b64Template;
+  }
+
   const {xScale, yScale} = scale;
   if (!xScale || !yScale) {
     return b64Template;

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -202,7 +202,7 @@ helpers.findByImage = async function (b64Template, {
   const {
     imageMatchThreshold: threshold,
     fixImageTemplateSize,
-    fixTemplateImageScale
+    fixImageTemplateScale
   } = this.settings.getSettings();
 
   log.info(`Finding image element with match threshold ${threshold}`);
@@ -225,8 +225,8 @@ helpers.findByImage = async function (b64Template, {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
-      if (fixTemplateImageScale) {
-        b64Template = await this.fixTemplateImageScale(b64Template, scale);
+      if (fixImageTemplateScale) {
+        b64Template = await this.fixImageTemplateScale(b64Template, scale);
       }
 
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
@@ -399,23 +399,24 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  *
  * @param {string} b64Template - base64-encoded image used as a template to be
  * matched in the screenshot
- * @param {?ScreenshotScale} scale - scale of screen
+ * @param {ScreenshotScale} scale - scale of screen. Default to `{}`
  *
  * @returns {string} base64-encoded scaled template screenshot
  */
-helpers.fixTemplateImageScale = async function (b64Template, scale) {
-  if (!scale || !_.isNumber(scale)) {
+helpers.fixImageTemplateScale = async function (b64Template, scale = {}) {
+  const {xScale, yScale} = scale;
+  if (!xScale || !yScale) {
     return b64Template;
   }
 
   let imgTempObj = await imageUtil.getJimpImage(b64Template);
   let {width: baseTempWidth, height: baseTempHeigh} = imgTempObj.bitmap;
 
-  const scaledWidth = baseTempWidth * scale.xScale;
-  const scaledHeight = baseTempHeigh * scale.yScale;
+  const scaledWidth = baseTempWidth * xScale;
+  const scaledHeight = baseTempHeigh * yScale;
   log.info(`Scaling template image from ${baseTempWidth}x${baseTempHeigh}` +
             ` to ${scaledWidth}x${scaledHeight}`);
-  log.info(`The ratio is ${scale.xScale} and ${scale.yScale}`);
+  log.info(`The ratio is ${xScale} and ${yScale}`);
   imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
   return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
 };

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -222,7 +222,19 @@ helpers.findByImage = async function (b64Template, {
   let rect = null;
   const condition = async () => {
     try {
-      let b64Screenshot = await this.getScreenshotForImageFind(screenWidth, screenHeight);
+      let {b64Screenshot, recize} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
+
+      if (recize) {
+        // For iOS case, mainly
+        let imgTempObj = await imageUtil.getJimpImage(b64Template);
+        let {width: baseTmpWidth, height: baseTmpHeigh} = imgTempObj.bitmap;
+        log.info(`Scaling template image from ${baseTmpWidth}x${baseTmpHeigh}` +
+                 ` to ${baseTmpWidth * recize.widthRatio}x${baseTmpHeigh * recize.heightRatio}`);
+        log.info(`The ratio is ${recize.widthRatio} and ${recize.heightRatio}`);
+        imgTempObj = await imgTempObj.resize(baseTmpWidth * recize.widthRatio, baseTmpHeigh * recize.heightRatio);
+        b64Template = (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
+      }
+
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
         b64Template, {threshold})).rect;
       return true;
@@ -288,11 +300,14 @@ helpers.ensureTemplateSize = async function (b64Template, screenWidth, screenHei
   let imgObj = await imageUtil.getJimpImage(b64Template);
   let {width: tplWidth, height: tplHeight} = imgObj.bitmap;
 
+  log.info(`Template image is ${tplWidth}x${tplHeight}. Screen size is ${screenWidth}x${screenHeight}`);
   // if the template fits inside the screen dimensions, we're good
   if (tplWidth <= screenWidth && tplHeight <= screenHeight) {
     return b64Template;
   }
 
+  log.info(`Scaling template image from ${tplWidth}x${tplHeight} to match ` +
+           `screen at ${screenWidth}x${screenHeight}`);
   // otherwise, scale it to fit inside the screen dimensions
   imgObj = imgObj.scaleToFit(screenWidth, screenHeight);
   return (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
@@ -341,32 +356,36 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   // are two potential types of mismatch: aspect ratio mismatch and scale
   // mismatch. we need to detect and fix both
 
-  const screenAR = screenWidth / screenHeight;
-  const shotAR = shotWidth / shotHeight;
+  // const screenAR = screenWidth / screenHeight;
+  // const shotAR = shotWidth / shotHeight;
 
-  if (screenAR === shotAR) {
-    log.info('Screenshot aspect ratio matched screen aspect ratio');
-  } else {
-    log.warn(`When trying to find an element, determined that the screen ` +
-             `aspect ratio and screenshot aspect ratio are different. Screen ` +
-             `is ${screenWidth}x${screenHeight} whereas screenshot is ` +
-             `${shotWidth}x${shotHeight}.`);
-    shotWidth = shotWidth / (shotAR / screenAR);
-    log.warn(`Resizing screenshot to ${shotWidth}x${shotHeight} to match ` +
-             `screen aspect ratio so that image element coordinates have a ` +
-             `greater chance of being correct.`);
-    imgObj = imgObj.resize(shotWidth, shotHeight);
-  }
+  // if (screenAR === shotAR) {
+  //   log.info('Screenshot aspect ratio matched screen aspect ratio');
+  // } else {
+  //   log.warn(`When trying to find an element, determined that the screen ` +
+  //            `aspect ratio and screenshot aspect ratio are different. Screen ` +
+  //            `is ${screenWidth}x${screenHeight} whereas screenshot is ` +
+  //            `${shotWidth}x${shotHeight}.`);
+  //   shotWidth = shotWidth / (shotAR / screenAR);
+  //   log.warn(`Resizing screenshot to ${shotWidth}x${shotHeight} to match ` +
+  //            `screen aspect ratio so that image element coordinates have a ` +
+  //            `greater chance of being correct.`);
+  //   imgObj = imgObj.resize(shotWidth, shotHeight);
+  // }
 
   // now we know the aspect ratios match, but there might still be a scale
   // mismatch, so just resize based on the screen dimensions
+  let recize;
   if (screenWidth !== shotWidth) {
     log.info(`Scaling screenshot from ${shotWidth}x${shotHeight} to match ` +
              `screen at ${screenWidth}x${screenHeight}`);
     imgObj = imgObj.resize(screenWidth, screenHeight);
+
+    recize = {widthRatio: screenWidth / shotWidth, heightRatio: screenHeight / shotHeight};
   }
 
-  return (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
+  b64Screenshot = (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
+  return {b64Screenshot, recize};
 };
 
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -376,10 +376,12 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   //   imgObj = imgObj.resize(shotWidth, shotHeight);
   // }
 
-  // now we know the aspect ratios match, but there might still be a scale
-  // mismatch, so just resize based on the screen dimensions
+  // Resize based on the screen dimensions only if both width and height are mismatched
+  // since except for that, it might be a situation which is different window rect and
+  // screenshot size like `@driver.window_rect #=>x=0, y=0, width=1080, height=1794` and
+  // `"deviceScreenSize"=>"1080x1920"`
   let scale;
-  if (screenWidth !== shotWidth) {
+  if (screenWidth !== shotWidth && screenHeight !== shotHeight) {
     log.info(`Scaling screenshot from ${shotWidth}x${shotHeight} to match ` +
              `screen at ${screenWidth}x${screenHeight}`);
     imgObj = imgObj.resize(screenWidth, screenHeight);

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -202,7 +202,7 @@ helpers.findByImage = async function (b64Template, {
   const {
     imageMatchThreshold: threshold,
     fixImageTemplateSize,
-    fixScaleTemplateImage
+    fixTemplateImageScale
   } = this.settings.getSettings();
 
   log.info(`Finding image element with match threshold ${threshold}`);
@@ -225,8 +225,8 @@ helpers.findByImage = async function (b64Template, {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
-      if (fixScaleTemplateImage) {
-        b64Template = await this.fixScaleTemplateImage(b64Template, scale);
+      if (fixTemplateImageScale) {
+        b64Template = await this.fixTemplateImageScale(b64Template, scale);
       }
 
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
@@ -410,7 +410,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  *
  * @returns {string} base64-encoded scaled template screenshot
  */
-helpers.fixScaleTemplateImage = async function (b64Template, scale) {
+helpers.fixTemplateImageScale = async function (b64Template, scale) {
   if (!scale) {
     return b64Template;
   }

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -201,7 +201,8 @@ helpers.findByImage = async function (b64Template, {
 }) {
   const {
     imageMatchThreshold: threshold,
-    fixImageTemplateSize
+    fixImageTemplateSize,
+    fixScaleTemplateImage
   } = this.settings.getSettings();
 
   log.info(`Finding image element with match threshold ${threshold}`);
@@ -224,7 +225,10 @@ helpers.findByImage = async function (b64Template, {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
-      b64Template = await this.fixScaleTemplateImage(b64Template, scale);
+      if (fixScaleTemplateImage) {
+        b64Template = await this.fixScaleTemplateImage(b64Template, scale);
+      }
+
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
         b64Template, {threshold})).rect;
       return true;

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -357,24 +357,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   // of coordinates returned by the image match algorithm, since we match based
   // on the screenshot coordinates not the device coordinates themselves. There
   // are two potential types of mismatch: aspect ratio mismatch and scale
-  // mismatch. we need to detect and fix both
-
-  // const screenAR = screenWidth / screenHeight;
-  // const shotAR = shotWidth / shotHeight;
-
-  // if (screenAR === shotAR) {
-  //   log.info('Screenshot aspect ratio matched screen aspect ratio');
-  // } else {
-  //   log.warn(`When trying to find an element, determined that the screen ` +
-  //            `aspect ratio and screenshot aspect ratio are different. Screen ` +
-  //            `is ${screenWidth}x${screenHeight} whereas screenshot is ` +
-  //            `${shotWidth}x${shotHeight}.`);
-  //   shotWidth = shotWidth / (shotAR / screenAR);
-  //   log.warn(`Resizing screenshot to ${shotWidth}x${shotHeight} to match ` +
-  //            `screen aspect ratio so that image element coordinates have a ` +
-  //            `greater chance of being correct.`);
-  //   imgObj = imgObj.resize(shotWidth, shotHeight);
-  // }
+  // mismatch.
 
   // Resize based on the screen dimensions only if both width and height are mismatched
   // since except for that, it might be a situation which is different window rect and

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -23,7 +23,7 @@ const GLOBAL_DEFAULT_SETTINGS = {
   // e.g. iOS has `width=375, height=667` window rect, but its screenshot is
   //      `width=750 × height=1334` pixels. This setting help to adjust the scale
   //      if a user use `width=750 × height=1334` pixels's base template image.
-  fixTemplateImageScale: false,
+  fixImageTemplateScale: false,
 
   // whether Appium should re-check that an image element can be matched
   // against the current screenshot before clicking it

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -23,7 +23,7 @@ const GLOBAL_DEFAULT_SETTINGS = {
   // e.g. iOS has `width=375, height=667` window rect, but its screenshot is
   //      `width=750 × height=1334` pixels. This setting help to adjust the scale
   //      if a user use `width=750 × height=1334` pixels's base template image.
-  fixScaleTemplateImage: false,
+  fixTemplateImageScale: false,
 
   // whether Appium should re-check that an image element can be matched
   // against the current screenshot before clicking it

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -17,6 +17,14 @@ const GLOBAL_DEFAULT_SETTINGS = {
   // complain
   fixImageTemplateSize: false,
 
+  // whether Appium should ensure that an image template sent in during image
+  // element find should have its scale adjusted to display size so the match
+  // algorithm will not complain.
+  // e.g. iOS has `width=375, height=667` window rect, but its screenshot is
+  //      `width=750 × height=1334` pixels. This setting help to adjust the scale
+  //      if a user use `width=750 × height=1334` pixels's base template image.
+  fixScaleTemplateImage: false,
+
   // whether Appium should re-check that an image element can be matched
   // against the current screenshot before clicking it
   checkForImageElementStaleness: true,

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -198,7 +198,7 @@ describe('finding elements by image', function () {
       const screenshotObj = await imageUtil.getJimpImage(b64Screenshot);
       screenshotObj.bitmap.width.should.eql(screen[0]);
       screenshotObj.bitmap.height.should.eql(screen[1]);
-      scale.should.eql({ widthRatio: 1.5, heightRatio: 1.5 });
+      scale.should.eql({ xScale: 1.5, yScale: 1.5 });
     });
     it('should return scaled screenshot with different aspect ratio if not matching screen aspect ratio', async function () {
       const d = new TestDriver();
@@ -211,7 +211,7 @@ describe('finding elements by image', function () {
       let screenshotObj = await imageUtil.getJimpImage(b64Screenshot);
       screenshotObj.bitmap.width.should.eql(screen[0]);
       screenshotObj.bitmap.height.should.eql(screen[1]);
-      scale.should.eql({ widthRatio: 2, heightRatio: 3 });
+      scale.should.eql({ xScale: 2, yScale: 3 });
 
       // then with landscape screen
       screen = [TINY_PNG_DIMS[0] * 3, TINY_PNG_DIMS[1] * 2];
@@ -220,7 +220,7 @@ describe('finding elements by image', function () {
       screenshotObj = await imageUtil.getJimpImage(newScreen);
       screenshotObj.bitmap.width.should.eql(screen[0]);
       screenshotObj.bitmap.height.should.eql(screen[1]);
-      newScale.should.eql({ widthRatio: 3, heightRatio: 2 });
+      newScale.should.eql({ xScale: 3, yScale: 2 });
     });
   });
 });

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -93,6 +93,27 @@ describe('finding elements by image', function () {
       imgEl.template.should.eql(newTemplate);
       compareStub.args[0][2].should.eql(newTemplate);
     });
+
+    it('should fix template size scale if requested', async function () {
+      const d = new TestDriver();
+      const newTemplate = 'iVBORbaz';
+      const {compareStub} = basicStub(d);
+      await d.settings.update({fixScaleTemplateImage: true});
+      sinon.stub(d, 'fixScaleTemplateImage').returns(newTemplate);
+      const imgElProto = await d.findByImage(template, {multiple: false});
+      const imgEl = basicImgElVerify(imgElProto, d);
+      imgEl.template.should.eql(newTemplate);
+      compareStub.args[0][2].should.eql(newTemplate);
+    });
+    it('should not fix template size scale if it is not requested', async function () {
+      const d = new TestDriver();
+      const newTemplate = 'iVBORbaz';
+      basicStub(d);
+      await d.settings.update({});
+      sinon.stub(d, 'fixScaleTemplateImage').returns(newTemplate);
+      d.fixScaleTemplateImage.callCount.should.eql(0);
+    });
+
     it('should throw an error if template match fails', async function () {
       const d = new TestDriver();
       const {compareStub} = basicStub(d);

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -98,8 +98,8 @@ describe('finding elements by image', function () {
       const d = new TestDriver();
       const newTemplate = 'iVBORbaz';
       const {compareStub} = basicStub(d);
-      await d.settings.update({fixScaleTemplateImage: true});
-      sinon.stub(d, 'fixScaleTemplateImage').returns(newTemplate);
+      await d.settings.update({fixTemplateImageScale: true});
+      sinon.stub(d, 'fixTemplateImageScale').returns(newTemplate);
       const imgElProto = await d.findByImage(template, {multiple: false});
       const imgEl = basicImgElVerify(imgElProto, d);
       imgEl.template.should.eql(newTemplate);
@@ -110,8 +110,8 @@ describe('finding elements by image', function () {
       const newTemplate = 'iVBORbaz';
       basicStub(d);
       await d.settings.update({});
-      sinon.stub(d, 'fixScaleTemplateImage').returns(newTemplate);
-      d.fixScaleTemplateImage.callCount.should.eql(0);
+      sinon.stub(d, 'fixTemplateImageScale').returns(newTemplate);
+      d.fixTemplateImageScale.callCount.should.eql(0);
     });
 
     it('should throw an error if template match fails', async function () {

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -98,8 +98,8 @@ describe('finding elements by image', function () {
       const d = new TestDriver();
       const newTemplate = 'iVBORbaz';
       const {compareStub} = basicStub(d);
-      await d.settings.update({fixTemplateImageScale: true});
-      sinon.stub(d, 'fixTemplateImageScale').returns(newTemplate);
+      await d.settings.update({fixImageTemplateScale: true});
+      sinon.stub(d, 'fixImageTemplateScale').returns(newTemplate);
       const imgElProto = await d.findByImage(template, {multiple: false});
       const imgEl = basicImgElVerify(imgElProto, d);
       imgEl.template.should.eql(newTemplate);
@@ -110,20 +110,22 @@ describe('finding elements by image', function () {
       const newTemplate = 'iVBORbaz';
       basicStub(d);
       await d.settings.update({});
-      sinon.stub(d, 'fixTemplateImageScale').returns(newTemplate);
-      d.fixTemplateImageScale.callCount.should.eql(0);
+      sinon.stub(d, 'fixImageTemplateScale').returns(newTemplate);
+      d.fixImageTemplateScale.callCount.should.eql(0);
     });
     it('should not fix template size scale if no scale value', async function () {
       const newTemplate = 'iVBORbaz';
-      await helpers.fixTemplateImageScale(newTemplate).should.eventually.eql(newTemplate);
+      await helpers.fixImageTemplateScale(newTemplate).should.eventually.eql(newTemplate);
     });
     it('should not fix template size scale if it is not number', async function () {
       const newTemplate = 'iVBORbaz';
-      await helpers.fixTemplateImageScale(newTemplate, 'wrong-scale').should.eventually.eql(newTemplate);
+      await helpers.fixImageTemplateScale(newTemplate, 'wrong-scale')
+        .should.eventually.eql(newTemplate);
     });
     it('should fix template size scale', async function () {
-      const newTemplate = 'iVBORbaz';
-      await helpers.fixTemplateImageScale(newTemplate, { xScale: 1.5, yScale: 1.5 }).should.eventually.eql(newTemplate);
+      const actual = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAWElEQVR4AU3BQRWAQAhAwa/PGBsEgrC16AFBKEIPXW7OXO+Rmey9iQjMjHFzrLUwM7qbqmLcHKpKRFBVuDvj4agq3B1VRUQYT2bS3QwRQVUZF/CaGRHB3wc1vSZbHO5+BgAAAABJRU5ErkJggg==';
+      await helpers.fixImageTemplateScale(TINY_PNG, { xScale: 1.5, yScale: 1.5 })
+        .should.eventually.eql(actual);
     });
 
     it('should throw an error if template match fails', async function () {

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -3,7 +3,7 @@ import path from 'path';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import { BaseDriver, ImageElement } from '../../..';
-import { IMAGE_STRATEGY, CUSTOM_STRATEGY } from '../../../lib/basedriver/commands/find';
+import { IMAGE_STRATEGY, CUSTOM_STRATEGY, helpers } from '../../../lib/basedriver/commands/find';
 import { imageUtil } from 'appium-support';
 
 
@@ -112,6 +112,18 @@ describe('finding elements by image', function () {
       await d.settings.update({});
       sinon.stub(d, 'fixTemplateImageScale').returns(newTemplate);
       d.fixTemplateImageScale.callCount.should.eql(0);
+    });
+    it('should not fix template size scale if no scale value', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixTemplateImageScale(newTemplate).should.eventually.eql(newTemplate);
+    });
+    it('should not fix template size scale if it is not number', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixTemplateImageScale(newTemplate, 'wrong-scale').should.eventually.eql(newTemplate);
+    });
+    it('should fix template size scale', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixTemplateImageScale(newTemplate, { xScale: 1.5, yScale: 1.5 }).should.eventually.eql(newTemplate);
     });
 
     it('should throw an error if template match fails', async function () {

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -117,6 +117,11 @@ describe('finding elements by image', function () {
       const newTemplate = 'iVBORbaz';
       await helpers.fixImageTemplateScale(newTemplate).should.eventually.eql(newTemplate);
     });
+    it('should not fix template size scale if it is null', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixImageTemplateScale(newTemplate, null)
+        .should.eventually.eql(newTemplate);
+    });
     it('should not fix template size scale if it is not number', async function () {
       const newTemplate = 'iVBORbaz';
       await helpers.fixImageTemplateScale(newTemplate, 'wrong-scale')


### PR DESCRIPTION
closes https://github.com/appium/appium/issues/12209

@jlipps Can you give me a good example app for `if (screenAR === shotAR)` lines I can confirm?
I simply commented out for now. If we do not need this, I would like to remove them.

---

will update https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/image-elements.md later

---


# problem

_find by image_ feature returns wrong coordinate in Android and iOS case.
test cases in below test section fails even it compares same image/element.

## For Android

In [here](https://github.com/appium/appium-base-driver/blob/4eab674f92acfb1dd958fd48c9bbc9399d0d4e74/lib/basedriver/commands/find.js#L344-L359), Appium scales screenshot to window size. Then, Appium uses the scaled image as an input for `compareImages`.

e.g.
The screenshot is `1080x1920`. The window size is `1080x1794`. OpenCV compares a template image with the screenshot which is scaled from `1080x1920` to `1080x1794`. Then Appium returns `1080x1794` based coordinations if it succeeds to find the template image. (But the returns coordinate should be `1080x1920` based one, since `find_element :accessibility_id, xxxx` returns rect based on `1080x1920` based size.

## For iOS

iOS returns `750 × 1334 pixels` screenshot evern the window size is `width=375, height=667`.
`compareImages` uses scaled screenshot from `750 × 1334 pixels` to `width=375, height=667`. The ratio is 2.
Users should coordinate a template image scale if they would like to use `750 × 1334 pixels` screenshot based image as the template image to fixt to `width=375, height=667`.

It means:
Cannot find proper image

```ruby
el = @@driver.find_element :accessibility_id, 'Buttons' # find an element labelled 'buttons'
@driver.save_element_screenshot el, 'test_ios_button.png' # Save the element image

image_element = @driver.find_element_by_image 'test_ios_button.png' # Find image with the above element
image_element # raise no element found error because the input image is based on `750 × 1334 pixels` size
```

Then, users should do:
```ruby
el = @@driver.find_element :accessibility_id, 'Buttons' # find an element labelled 'buttons'
@driver.save_element_screenshot el, 'test_ios_button.png' # Save the element image

# Need a process to scale `test_ios_button.png` down to fit to `width=375, height=667` size

image_element = @driver.find_element_by_image 'test_ios_button.png'
image_element # can find image
```

# Implementation
- Get rid of [here](https://github.com/appium/appium-base-driver/blob/4eab674f92acfb1dd958fd48c9bbc9399d0d4e74/lib/basedriver/commands/find.js#L344-L359)
    - @jlipps Do you have a good example for this implementation?
- Introduce `fixScaleTemplateImage` for iOS case to reduce user actions for an input image

# test
https://github.com/appium/ruby_lib_core/pull/193/files is an example to make sure this PR works.
In the test, I ensured the below case for Android and iOS:

1. Find an element
2. Get the element screenshot
3. Find an element by image using _step2_ 's partial image
4. Assert _rect_ etc between `step1` and `step3`

They worked after this PR.
(This includes landscape and portrait mode.)