### PR TITLE
Fix template scale in find element by image

### DIFF
--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -12,6 +12,10 @@ const commands = {}, helpers = {}, extensions = {};
 const IMAGE_STRATEGY = '-image';
 const CUSTOM_STRATEGY = '-custom';
 
+// Used to compar ratio and screen width
+// Pixel is basically under 1080 for example. 100K is probably enough fo a while.
+const DEFAULT_ROUND_FLOAT = 100000;
+
 // Override the following function for your own driver, and the rest is taken
 // care of!
 
@@ -369,7 +373,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 
   const screenAR = screenWidth / screenHeight;
   const shotAR = shotWidth / shotHeight;
-  if (screenAR === shotAR) {
+  if (Math.round(screenAR * DEFAULT_ROUND_FLOAT) === Math.round(shotAR * DEFAULT_ROUND_FLOAT)) {
     log.info('Screenshot aspect ratio matched screen aspect ratio');
   } else {
     log.warn(`When trying to find an element, determined that the screen ` +
@@ -473,8 +477,9 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
     return b64Template;
   }
 
-  // Return if the scale is default (1.0) value
-  if ((xScale - DEFAULT_FIX_IMAGE_TEMPLATE_SCALE) <= 0 && (yScale - DEFAULT_FIX_IMAGE_TEMPLATE_SCALE) === 0) {
+  // Return if the scale is default, 1, value
+  if (Math.round(xScale * DEFAULT_ROUND_FLOAT) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * DEFAULT_ROUND_FLOAT)
+      && Math.round(yScale * DEFAULT_ROUND_FLOAT === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * DEFAULT_ROUND_FLOAT))) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -203,7 +203,7 @@ helpers.findByImage = async function (b64Template, {
     imageMatchThreshold: threshold,
     fixImageTemplateSize,
     fixImageTemplateScale,
-    defaultScaleImageTemplate
+    defaultImageTemplateScale
   } = this.settings.getSettings();
 
   log.info(`Finding image element with match threshold ${threshold}`);
@@ -227,7 +227,7 @@ helpers.findByImage = async function (b64Template, {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
       b64Template = await this.fixImageTemplateScale(b64Template, {
-        defaultScaleImageTemplate, fixImageTemplateScale, ...scale
+        defaultImageTemplateScale, fixImageTemplateScale, ...scale
       });
 
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
@@ -380,7 +380,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 /**
  * @typedef {Object} ImageTemplateSettings
  * @property {float} fixImageTemplateScale - fixImageTemplateScale in device-settings
- * @property {float} defaultScaleImageTemplate - defaultScaleImageTemplate in device-settings
+ * @property {float} defaultImageTemplateScale - defaultImageTemplateScale in device-settings
  */
 /**
  * Get a image that will be used for template maching.
@@ -398,35 +398,35 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
     return b64Template;
   }
 
-  const default_scale = 1.0;
-  const defaultSettings = {
+  const defaultScale = 1.0;
+  const defaultOpts = {
     fixImageTemplateScale: false,
-    defaultScaleImageTemplate: DEFAULT_TEMPLATE_IMAGE_SCALE,
-    xScale: default_scale,
-    yScale: default_scale
+    defaultImageTemplateScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
+    xScale: defaultScale,
+    yScale: defaultScale
   };
-  _.defaults(opts, defaultSettings);
+  _.defaults(opts, defaultOpts);
 
   let {xScale, yScale} = opts;
   // Default
-  if (opts.defaultScaleImageTemplate === DEFAULT_TEMPLATE_IMAGE_SCALE && !opts.fixImageTemplateScale) {
+  if (opts.defaultImageTemplateScale === DEFAULT_TEMPLATE_IMAGE_SCALE && !opts.fixImageTemplateScale) {
     return b64Template;
   }
 
   if (opts.fixImageTemplateScale) {
-    xScale = xScale * opts.defaultScaleImageTemplate;
-    yScale = yScale * opts.defaultScaleImageTemplate;
+    xScale = xScale * opts.defaultImageTemplateScale;
+    yScale = yScale * opts.defaultImageTemplateScale;
   } else {
-    xScale = yScale = 1.0 * opts.defaultScaleImageTemplate;
+    xScale = yScale = 1.0 * opts.defaultImageTemplateScale;
   }
 
-  // xScale and yScale can be NaN if opts.defaultScaleImageTemplate is string, for example
+  // xScale and yScale can be NaN if opts.defaultImageTemplateScale is string, for example
   if (!xScale || !yScale) {
     return b64Template;
   }
 
   // Return if the scale is deatul (1.0) value
-  if (xScale === default_scale && yScale === default_scale) {
+  if (xScale === defaultScale && yScale === defaultScale) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -365,7 +365,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   // are two potential types of mismatch: aspect ratio mismatch and scale
   // mismatch. we need to detect and fix both
 
-  let scale = {xScale: 1.0, yScale: 1.0};
+  const scale = {xScale: 1.0, yScale: 1.0};
 
   const screenAR = screenWidth / screenHeight;
   const shotAR = shotWidth / shotHeight;

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -400,6 +400,9 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 
     scale.xScale *= scaleFactor;
     scale.yScale *= scaleFactor;
+
+    shotWidth = imgObj.bitmap.width;
+    shotHeight = imgObj.bitmap.height;
   }
 
   // Resize based on the screen dimensions only if both width and height are mismatched

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -2,7 +2,7 @@ import log from '../logger';
 import { logger, imageUtil } from 'appium-support';
 import _ from 'lodash';
 import { errors } from '../../..';
-import { MATCH_TEMPLATE_MODE } from './images';
+import { MATCH_TEMPLATE_MODE, DEFAULT_TEMPLATE_IMAGE_SCALE } from './images';
 import { W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY } from '../../protocol/protocol';
 import { ImageElement } from '../image-element';
 
@@ -203,7 +203,7 @@ helpers.findByImage = async function (b64Template, {
     imageMatchThreshold: threshold,
     fixImageTemplateSize,
     fixImageTemplateScale,
-    imageTemplateDefaultScale
+    defaultScaleImageTemplate
   } = this.settings.getSettings();
 
   log.info(`Finding image element with match threshold ${threshold}`);
@@ -226,13 +226,9 @@ helpers.findByImage = async function (b64Template, {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
-      if (imageTemplateDefaultScale) {
-        b64Template = await this.setImageTemplateDefaultScale(b64Template, imageTemplateDefaultScale)
-      }
-
-      if (fixImageTemplateScale) {
-        b64Template = await this.fixImageTemplateScale(b64Template, scale);
-      }
+      b64Template = await this.fixImageTemplateScale(b64Template, {
+        defaultScaleImageTemplate, fixImageTemplateScale, ...scale
+      });
 
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
         b64Template, {threshold})).rect;
@@ -382,22 +378,55 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 };
 
 /**
+ * @typedef {Object} ImageTemplateSettings
+ * @property {float} fixImageTemplateScale - fixImageTemplateScale in device-settings
+ * @property {float} defaultScaleImageTemplate - defaultScaleImageTemplate in device-settings
+ */
+/**
  * Get a image that will be used for template maching.
  * Returns scaled image if scale ratio is provided.
  *
+ *
  * @param {string} b64Template - base64-encoded image used as a template to be
  * matched in the screenshot
- * @param {ScreenshotScale} scale - scale of screen. Default to `{}`
+ * @param {ScreenshotScale, ImageTemplateSettings} opts - Image template scale related options
  *
  * @returns {string} base64-encoded scaled template screenshot
  */
-helpers.fixImageTemplateScale = async function (b64Template, scale = {}) {
-  if (!scale) {
+helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
+  if (!opts) {
     return b64Template;
   }
 
-  const {xScale, yScale} = scale;
+  const default_scale = 1.0;
+  const defaultSettings = {
+    fixImageTemplateScale: false,
+    defaultScaleImageTemplate: DEFAULT_TEMPLATE_IMAGE_SCALE,
+    xScale: default_scale,
+    yScale: default_scale
+  };
+  _.defaults(opts, defaultSettings);
+
+  let {xScale, yScale} = opts;
+  // Default
+  if (opts.defaultScaleImageTemplate === DEFAULT_TEMPLATE_IMAGE_SCALE && !opts.fixImageTemplateScale) {
+    return b64Template;
+  }
+
+  if (opts.fixImageTemplateScale) {
+    xScale = xScale * opts.defaultScaleImageTemplate;
+    yScale = yScale * opts.defaultScaleImageTemplate;
+  } else {
+    xScale = yScale = 1.0 * opts.defaultScaleImageTemplate;
+  }
+
+  // xScale and yScale can be NaN if opts.defaultScaleImageTemplate is string, for example
   if (!xScale || !yScale) {
+    return b64Template;
+  }
+
+  // Return if the scale is deatul (1.0) value
+  if (xScale === default_scale && yScale === default_scale) {
     return b64Template;
   }
 
@@ -409,17 +438,6 @@ helpers.fixImageTemplateScale = async function (b64Template, scale = {}) {
   log.info(`Scaling template image from ${baseTempWidth}x${baseTempHeigh}` +
             ` to ${scaledWidth}x${scaledHeight}`);
   log.info(`The ratio is ${xScale} and ${yScale}`);
-  imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
-  return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
-};
-
-helpers.setImageTemplateDefaultScale = async function (b64Template, scale = 1.0) {
-  let imgTempObj = await imageUtil.getJimpImage(b64Template);
-  let {width: baseTempWidth, height: baseTempHeigh} = imgTempObj.bitmap;
-
-  const scaledWidth = baseTempWidth * scale;
-  const scaledHeight = baseTempHeigh * scale;
-
   imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
   return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
 };

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -2,9 +2,9 @@ import log from '../logger';
 import { logger, imageUtil } from 'appium-support';
 import _ from 'lodash';
 import { errors } from '../../..';
-import { MATCH_TEMPLATE_MODE, DEFAULT_TEMPLATE_IMAGE_SCALE } from './images';
+import { MATCH_TEMPLATE_MODE } from './images';
 import { W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY } from '../../protocol/protocol';
-import { ImageElement } from '../image-element';
+import { ImageElement, DEFAULT_TEMPLATE_IMAGE_SCALE } from '../image-element';
 
 
 const commands = {}, helpers = {}, extensions = {};
@@ -183,6 +183,9 @@ commands.findByCustom = async function (selector, multiple) {
  * image is merely to check staleness. If so we can bypass a lot of logic
  * @property {boolean} [multiple=false] - Whether we are finding one element or
  * multiple
+ * @property {boolean} [ignoreDefaultImageTemplateScale=false] - Whether we are
+ * ignore defaultImageTemplateScale. It can be used when you would noe like to
+ * scale b64Template with defaultImageTemplateScale setting.
  */
 
 /**
@@ -198,6 +201,7 @@ commands.findByCustom = async function (selector, multiple) {
 helpers.findByImage = async function (b64Template, {
   shouldCheckStaleness = false,
   multiple = false,
+  ignoreDefaultImageTemplateScale = false,
 }) {
   const {
     imageMatchThreshold: threshold,
@@ -227,7 +231,8 @@ helpers.findByImage = async function (b64Template, {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
 
       b64Template = await this.fixImageTemplateScale(b64Template, {
-        defaultImageTemplateScale, fixImageTemplateScale, ...scale
+        defaultImageTemplateScale, ignoreDefaultImageTemplateScale,
+        fixImageTemplateScale, ...scale
       });
 
       rect = (await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot,
@@ -379,8 +384,12 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 
 /**
  * @typedef {Object} ImageTemplateSettings
- * @property {float} fixImageTemplateScale - fixImageTemplateScale in device-settings
+ * @property {boolean} fixImageTemplateScale - fixImageTemplateScale in device-settings
  * @property {float} defaultImageTemplateScale - defaultImageTemplateScale in device-settings
+ * @property {boolean} ignoreDefaultImageTemplateScale - Ignore defaultImageTemplateScale if it has true.
+ *                                                       If b64Template has been scaled to defaultImageTemplateScale
+ *                                                       or should ignore the scale, this parameter should be true.
+ *                                                       e.e. click in image-element
  */
 /**
  * Get a image that will be used for template maching.
@@ -402,22 +411,31 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
   const defaultOpts = {
     fixImageTemplateScale: false,
     defaultImageTemplateScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
+    ignoreDefaultImageTemplateScale: false,
     xScale: defaultScale,
     yScale: defaultScale
   };
   _.defaults(opts, defaultOpts);
 
+  let defaultImageTemplateScale;
+  if (opts.ignoreDefaultImageTemplateScale) {
+    defaultImageTemplateScale = DEFAULT_TEMPLATE_IMAGE_SCALE;
+  } else {
+    defaultImageTemplateScale = opts.defaultImageTemplateScale;
+  }
+
   let {xScale, yScale} = opts;
   // Default
-  if (opts.defaultImageTemplateScale === DEFAULT_TEMPLATE_IMAGE_SCALE && !opts.fixImageTemplateScale) {
+  if (defaultImageTemplateScale === DEFAULT_TEMPLATE_IMAGE_SCALE && !opts.fixImageTemplateScale) {
     return b64Template;
   }
 
+
   if (opts.fixImageTemplateScale) {
-    xScale = xScale * opts.defaultImageTemplateScale;
-    yScale = yScale * opts.defaultImageTemplateScale;
+    xScale = xScale * defaultImageTemplateScale;
+    yScale = yScale * defaultImageTemplateScale;
   } else {
-    xScale = yScale = 1.0 * opts.defaultImageTemplateScale;
+    xScale = yScale = 1.0 * defaultImageTemplateScale;
   }
 
   // xScale and yScale can be NaN if opts.defaultImageTemplateScale is string, for example

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -202,7 +202,8 @@ helpers.findByImage = async function (b64Template, {
   const {
     imageMatchThreshold: threshold,
     fixImageTemplateSize,
-    fixImageTemplateScale
+    fixImageTemplateScale,
+    imageTemplateDefaultScale
   } = this.settings.getSettings();
 
   log.info(`Finding image element with match threshold ${threshold}`);
@@ -224,6 +225,10 @@ helpers.findByImage = async function (b64Template, {
   const condition = async () => {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
+
+      if (imageTemplateDefaultScale) {
+        b64Template = await this.setImageTemplateDefaultScale(b64Template, imageTemplateDefaultScale)
+      }
 
       if (fixImageTemplateScale) {
         b64Template = await this.fixImageTemplateScale(b64Template, scale);
@@ -404,6 +409,17 @@ helpers.fixImageTemplateScale = async function (b64Template, scale = {}) {
   log.info(`Scaling template image from ${baseTempWidth}x${baseTempHeigh}` +
             ` to ${scaledWidth}x${scaledHeight}`);
   log.info(`The ratio is ${xScale} and ${yScale}`);
+  imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
+  return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
+};
+
+helpers.setImageTemplateDefaultScale = async function (b64Template, scale = 1.0) {
+  let imgTempObj = await imageUtil.getJimpImage(b64Template);
+  let {width: baseTempWidth, height: baseTempHeigh} = imgTempObj.bitmap;
+
+  const scaledWidth = baseTempWidth * scale;
+  const scaledHeight = baseTempHeigh * scale;
+
   imgTempObj = await imgTempObj.resize(scaledWidth, scaledHeight);
   return (await imgTempObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');
 };

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -14,7 +14,7 @@ const CUSTOM_STRATEGY = '-custom';
 
 // Used to compar ratio and screen width
 // Pixel is basically under 1080 for example. 100K is probably enough fo a while.
-const DEFAULT_ROUND_FLOAT = 100000;
+const FLOAT_PERCISION = 100000;
 
 // Override the following function for your own driver, and the rest is taken
 // care of!
@@ -373,7 +373,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
 
   const screenAR = screenWidth / screenHeight;
   const shotAR = shotWidth / shotHeight;
-  if (Math.round(screenAR * DEFAULT_ROUND_FLOAT) === Math.round(shotAR * DEFAULT_ROUND_FLOAT)) {
+  if (Math.round(screenAR * FLOAT_PERCISION) === Math.round(shotAR * FLOAT_PERCISION)) {
     log.info('Screenshot aspect ratio matched screen aspect ratio');
   } else {
     log.warn(`When trying to find an element, determined that the screen ` +
@@ -478,8 +478,8 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
   }
 
   // Return if the scale is default, 1, value
-  if (Math.round(xScale * DEFAULT_ROUND_FLOAT) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * DEFAULT_ROUND_FLOAT)
-      && Math.round(yScale * DEFAULT_ROUND_FLOAT === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * DEFAULT_ROUND_FLOAT))) {
+  if (Math.round(xScale * FLOAT_PERCISION) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PERCISION)
+      && Math.round(yScale * FLOAT_PERCISION === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PERCISION))) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -378,11 +378,13 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
              `${shotWidth}x${shotHeight}.`);
 
     // Select smaller ratio
-    // this.getScreenshot is 540x397, this.getDeviceSize is 1080x1920.
-    // The ratio is {xScale: 2, yScale: 4.83}.
-    // In this case, we must choose `xScale: 2` as scaleFactor.
+    // this.getScreenshot(shotWidth, shotHeight) is 540x397,
+    // this.getDeviceSize(screenWidth, screenHeight) is 1080x1920.
+    // The ratio is {xScale: 0.5, yScale: 0.2}.
+    // In this case, we must choose `yScale: 0.2` as scaleFactor.
     // Because if Appium selects the both ratio, the screenshot will be distorted.
-    // If Appium selects the yScale, width will be bigger than real screenshot.
+    // If Appium selects the xScale, height will be bigger than real screenshot size
+    // which is used to image comparison by OpenCV as a base image.
     const _xScale = (1.0 * shotWidth) / screenWidth;
     const _yScale = (1.0 * shotHeight) / screenHeight;
     const scaleFactor = _xScale >= _yScale ? _yScale : _xScale;

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -363,19 +363,50 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   // of coordinates returned by the image match algorithm, since we match based
   // on the screenshot coordinates not the device coordinates themselves. There
   // are two potential types of mismatch: aspect ratio mismatch and scale
-  // mismatch.
+  // mismatch. we need to detect and fix both
+
+  let scale = {xScale: 1.0, yScale: 1.0};
+
+  const screenAR = screenWidth / screenHeight;
+  const shotAR = shotWidth / shotHeight;
+  if (screenAR === shotAR) {
+    log.info('Screenshot aspect ratio matched screen aspect ratio');
+  } else {
+    log.warn(`When trying to find an element, determined that the screen ` +
+             `aspect ratio and screenshot aspect ratio are different. Screen ` +
+             `is ${screenWidth}x${screenHeight} whereas screenshot is ` +
+             `${shotWidth}x${shotHeight}.`);
+
+    // Select smaller ratio
+    // this.getScreenshot is 540x397, this.getDeviceSize is 1080x1920.
+    // The ratio is {xScale: 2, yScale: 4.83}.
+    // In this case, we must choose `xScale: 2` as scaleFactor.
+    // Because if Appium selects the both ratio, the screenshot will be distorted.
+    // If Appium selects the yScale, width will be bigger than real screenshot.
+    const _xScale = (1.0 * shotWidth) / screenWidth;
+    const _yScale = (1.0 * shotHeight) / screenHeight;
+    const scaleFactor = _xScale >= _yScale ? _yScale : _xScale;
+
+    log.warn(`Resizing screenshot to ${shotWidth * scaleFactor}x${shotHeight * scaleFactor} to match ` +
+             `screen aspect ratio so that image element coordinates have a ` +
+             `greater chance of being correct.`);
+    imgObj = imgObj.resize(shotWidth * scaleFactor, shotHeight * scaleFactor);
+
+    scale.xScale *= scaleFactor;
+    scale.yScale *= scaleFactor;
+  }
 
   // Resize based on the screen dimensions only if both width and height are mismatched
   // since except for that, it might be a situation which is different window rect and
   // screenshot size like `@driver.window_rect #=>x=0, y=0, width=1080, height=1794` and
   // `"deviceScreenSize"=>"1080x1920"`
-  let scale;
   if (screenWidth !== shotWidth && screenHeight !== shotHeight) {
     log.info(`Scaling screenshot from ${shotWidth}x${shotHeight} to match ` +
              `screen at ${screenWidth}x${screenHeight}`);
     imgObj = imgObj.resize(screenWidth, screenHeight);
 
-    scale = {xScale: (1.0 * screenWidth) / shotWidth, yScale: (1.0 * screenHeight) / shotHeight};
+    scale.xScale *= (1.0 * screenWidth) / shotWidth;
+    scale.yScale *= (1.0 * screenHeight) / shotHeight;
   }
 
   b64Screenshot = (await imgObj.getBuffer(imageUtil.MIME_PNG)).toString('base64');

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -407,7 +407,7 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
     return b64Template;
   }
 
-  const defaultScale = 1.0;
+  const defaultScale = 1.0; // To initialise xScale and yScale
   const defaultOpts = {
     fixImageTemplateScale: false,
     defaultImageTemplateScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
@@ -430,11 +430,12 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
     return b64Template;
   }
 
-
+  // Calculate xScale and yScale Appium should scale
   if (opts.fixImageTemplateScale) {
     xScale = xScale * defaultImageTemplateScale;
     yScale = yScale * defaultImageTemplateScale;
   } else {
+    // `1.0 *` makes NaN if defaultImageTemplateScale is no number
     xScale = yScale = 1.0 * defaultImageTemplateScale;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -184,7 +184,7 @@ commands.findByCustom = async function (selector, multiple) {
  * @property {boolean} [multiple=false] - Whether we are finding one element or
  * multiple
  * @property {boolean} [ignoreDefaultImageTemplateScale=false] - Whether we
- * ignore defaultImageTemplateScale. It can be used when you would noe like to
+ * ignore defaultImageTemplateScale. It can be used when you would like to
  * scale b64Template with defaultImageTemplateScale setting.
  */
 
@@ -389,6 +389,9 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  * @property {boolean} ignoreDefaultImageTemplateScale - Ignore defaultImageTemplateScale if it has true.
  * If b64Template has been scaled to defaultImageTemplateScale or should ignore the scale,
  * this parameter should be true. e.g. click in image-element module
+ * @property {float} xScale - Scale ratio for width
+ * @property {float} yScale - Scale ratio for height
+
  */
 /**
  * Get a image that will be used for template maching.
@@ -397,54 +400,49 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  *
  * @param {string} b64Template - base64-encoded image used as a template to be
  * matched in the screenshot
- * @param {ScreenshotScale, ImageTemplateSettings} opts - Image template scale related options
+ * @param {ImageTemplateSettings} opts - Image template scale related options
  *
  * @returns {string} base64-encoded scaled template screenshot
  */
+const DEFAULT_FIX_IMAGE_TEMPLATE_SCALE = 1.0;
 helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
   if (!opts) {
     return b64Template;
   }
 
-  const defaultScale = 1.0; // To initialise xScale and yScale
-  const defaultOpts = {
-    fixImageTemplateScale: false,
-    defaultImageTemplateScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
-    ignoreDefaultImageTemplateScale: false,
-    xScale: defaultScale,
-    yScale: defaultScale
-  };
-  _.defaults(opts, defaultOpts);
+  let {
+    fixImageTemplateScale = false,
+    defaultImageTemplateScale = DEFAULT_TEMPLATE_IMAGE_SCALE,
+    ignoreDefaultImageTemplateScale = false,
+    xScale = DEFAULT_FIX_IMAGE_TEMPLATE_SCALE,
+    yScale = DEFAULT_FIX_IMAGE_TEMPLATE_SCALE
+  } = opts;
 
-  let defaultImageTemplateScale;
-  if (opts.ignoreDefaultImageTemplateScale) {
+  if (ignoreDefaultImageTemplateScale) {
     defaultImageTemplateScale = DEFAULT_TEMPLATE_IMAGE_SCALE;
-  } else {
-    defaultImageTemplateScale = opts.defaultImageTemplateScale;
   }
 
-  let {xScale, yScale} = opts;
   // Default
-  if (defaultImageTemplateScale === DEFAULT_TEMPLATE_IMAGE_SCALE && !opts.fixImageTemplateScale) {
+  if (defaultImageTemplateScale === DEFAULT_TEMPLATE_IMAGE_SCALE && !fixImageTemplateScale) {
     return b64Template;
   }
 
   // Calculate xScale and yScale Appium should scale
-  if (opts.fixImageTemplateScale) {
-    xScale = xScale * defaultImageTemplateScale;
-    yScale = yScale * defaultImageTemplateScale;
+  if (fixImageTemplateScale) {
+    xScale *= defaultImageTemplateScale;
+    yScale *= defaultImageTemplateScale;
   } else {
-    // `1.0 *` makes NaN if defaultImageTemplateScale is no number
+    // `1.0 *` makes NaN if defaultImageTemplateScale is not a number
     xScale = yScale = 1.0 * defaultImageTemplateScale;
   }
 
-  // xScale and yScale can be NaN if opts.defaultImageTemplateScale is string, for example
+  // xScale and yScale can be NaN if defaultImageTemplateScale is string, for example
   if (!xScale || !yScale) {
     return b64Template;
   }
 
-  // Return if the scale is deatul (1.0) value
-  if (xScale === defaultScale && yScale === defaultScale) {
+  // Return if the scale is default (1.0) value
+  if (xScale === DEFAULT_FIX_IMAGE_TEMPLATE_SCALE && yScale === DEFAULT_FIX_IMAGE_TEMPLATE_SCALE) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -12,7 +12,7 @@ const commands = {}, helpers = {}, extensions = {};
 const IMAGE_STRATEGY = '-image';
 const CUSTOM_STRATEGY = '-custom';
 
-// Used to compar ratio and screen width
+// Used to compare ratio and screen width
 // Pixel is basically under 1080 for example. 100K is probably enough fo a while.
 const FLOAT_PRECISION = 100000;
 
@@ -374,21 +374,25 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   const screenAR = screenWidth / screenHeight;
   const shotAR = shotWidth / shotHeight;
   if (Math.round(screenAR * FLOAT_PRECISION) === Math.round(shotAR * FLOAT_PRECISION)) {
-    log.info('Screenshot aspect ratio matched screen aspect ratio');
+    log.info(`Screenshot aspect ratio '${shotAR}' (${shotWidth}x${shotHeight}) matched ` +
+      `screen aspect ratio '${screenAR}' (${screenWidth}x${screenHeight})`);
   } else {
     log.warn(`When trying to find an element, determined that the screen ` +
              `aspect ratio and screenshot aspect ratio are different. Screen ` +
              `is ${screenWidth}x${screenHeight} whereas screenshot is ` +
              `${shotWidth}x${shotHeight}.`);
 
-    // Select smaller ratio
+    // In the case where the x-scale and y-scale are different, we need to decide
+    // which one to respect, otherwise the screenshot and template will end up
+    // being resized in a way that changes its aspect ratio (distorts it). For example, let's say:
     // this.getScreenshot(shotWidth, shotHeight) is 540x397,
     // this.getDeviceSize(screenWidth, screenHeight) is 1080x1920.
-    // The ratio is {xScale: 0.5, yScale: 0.2}.
-    // In this case, we must choose `yScale: 0.2` as scaleFactor.
-    // Because if Appium selects the both ratio, the screenshot will be distorted.
-    // If Appium selects the xScale, height will be bigger than real screenshot size
+    // The ratio would then be {xScale: 0.5, yScale: 0.2}.
+    // In this case, we must should `yScale: 0.2` as scaleFactor, because
+    // if we select the xScale, the height will be bigger than real screenshot size
     // which is used to image comparison by OpenCV as a base image.
+    // All of this is primarily useful when the screenshot is a horizontal slice taken out of the
+    // screen (for example not including top/bottom nav bars)
     const xScale = (1.0 * shotWidth) / screenWidth;
     const yScale = (1.0 * shotHeight) / screenHeight;
     const scaleFactor = xScale >= yScale ? yScale : xScale;

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -404,7 +404,7 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  *
  * @returns {string} base64-encoded scaled template screenshot
  */
-const DEFAULT_FIX_IMAGE_TEMPLATE_SCALE = 1.0;
+const DEFAULT_FIX_IMAGE_TEMPLATE_SCALE = 1;
 helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
   if (!opts) {
     return b64Template;
@@ -432,8 +432,8 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
     xScale *= defaultImageTemplateScale;
     yScale *= defaultImageTemplateScale;
   } else {
-    // `1.0 *` makes NaN if defaultImageTemplateScale is not a number
-    xScale = yScale = 1.0 * defaultImageTemplateScale;
+    // `1 *` makes NaN if defaultImageTemplateScale is not a number
+    xScale = yScale = 1 * defaultImageTemplateScale;
   }
 
   // xScale and yScale can be NaN if defaultImageTemplateScale is string, for example
@@ -442,7 +442,7 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
   }
 
   // Return if the scale is default (1.0) value
-  if (xScale === DEFAULT_FIX_IMAGE_TEMPLATE_SCALE && yScale === DEFAULT_FIX_IMAGE_TEMPLATE_SCALE) {
+  if ((xScale - DEFAULT_FIX_IMAGE_TEMPLATE_SCALE) <= 0 && (yScale - DEFAULT_FIX_IMAGE_TEMPLATE_SCALE) === 0) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -14,7 +14,7 @@ const CUSTOM_STRATEGY = '-custom';
 
 // Used to compar ratio and screen width
 // Pixel is basically under 1080 for example. 100K is probably enough fo a while.
-const FLOAT_PERCISION = 100000;
+const FLOAT_PRECISION = 100000;
 
 // Override the following function for your own driver, and the rest is taken
 // care of!
@@ -367,13 +367,13 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
   // of coordinates returned by the image match algorithm, since we match based
   // on the screenshot coordinates not the device coordinates themselves. There
   // are two potential types of mismatch: aspect ratio mismatch and scale
-  // mismatch. we need to detect and fix both
+  // mismatch. We need to detect and fix both
 
   const scale = {xScale: 1.0, yScale: 1.0};
 
   const screenAR = screenWidth / screenHeight;
   const shotAR = shotWidth / shotHeight;
-  if (Math.round(screenAR * FLOAT_PERCISION) === Math.round(shotAR * FLOAT_PERCISION)) {
+  if (Math.round(screenAR * FLOAT_PRECISION) === Math.round(shotAR * FLOAT_PRECISION)) {
     log.info('Screenshot aspect ratio matched screen aspect ratio');
   } else {
     log.warn(`When trying to find an element, determined that the screen ` +
@@ -478,8 +478,8 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
   }
 
   // Return if the scale is default, 1, value
-  if (Math.round(xScale * FLOAT_PERCISION) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PERCISION)
-      && Math.round(yScale * FLOAT_PERCISION === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PERCISION))) {
+  if (Math.round(xScale * FLOAT_PRECISION) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PRECISION)
+      && Math.round(yScale * FLOAT_PRECISION === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PRECISION))) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -183,7 +183,7 @@ commands.findByCustom = async function (selector, multiple) {
  * image is merely to check staleness. If so we can bypass a lot of logic
  * @property {boolean} [multiple=false] - Whether we are finding one element or
  * multiple
- * @property {boolean} [ignoreDefaultImageTemplateScale=false] - Whether we are
+ * @property {boolean} [ignoreDefaultImageTemplateScale=false] - Whether we
  * ignore defaultImageTemplateScale. It can be used when you would noe like to
  * scale b64Template with defaultImageTemplateScale setting.
  */
@@ -387,9 +387,8 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
  * @property {boolean} fixImageTemplateScale - fixImageTemplateScale in device-settings
  * @property {float} defaultImageTemplateScale - defaultImageTemplateScale in device-settings
  * @property {boolean} ignoreDefaultImageTemplateScale - Ignore defaultImageTemplateScale if it has true.
- *                                                       If b64Template has been scaled to defaultImageTemplateScale
- *                                                       or should ignore the scale, this parameter should be true.
- *                                                       e.e. click in image-element
+ * If b64Template has been scaled to defaultImageTemplateScale or should ignore the scale,
+ * this parameter should be true. e.g. click in image-element module
  */
 /**
  * Get a image that will be used for template maching.

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -385,9 +385,9 @@ helpers.getScreenshotForImageFind = async function (screenWidth, screenHeight) {
     // Because if Appium selects the both ratio, the screenshot will be distorted.
     // If Appium selects the xScale, height will be bigger than real screenshot size
     // which is used to image comparison by OpenCV as a base image.
-    const _xScale = (1.0 * shotWidth) / screenWidth;
-    const _yScale = (1.0 * shotHeight) / screenHeight;
-    const scaleFactor = _xScale >= _yScale ? _yScale : _xScale;
+    const xScale = (1.0 * shotWidth) / screenWidth;
+    const yScale = (1.0 * shotHeight) / screenHeight;
+    const scaleFactor = xScale >= yScale ? yScale : xScale;
 
     log.warn(`Resizing screenshot to ${shotWidth * scaleFactor}x${shotHeight * scaleFactor} to match ` +
              `screen aspect ratio so that image element coordinates have a ` +
@@ -465,12 +465,11 @@ helpers.fixImageTemplateScale = async function (b64Template, opts = {}) {
     xScale *= defaultImageTemplateScale;
     yScale *= defaultImageTemplateScale;
   } else {
-    // `1 *` makes NaN if defaultImageTemplateScale is not a number
     xScale = yScale = 1 * defaultImageTemplateScale;
   }
 
   // xScale and yScale can be NaN if defaultImageTemplateScale is string, for example
-  if (!xScale || !yScale) {
+  if (!parseFloat(xScale) || !parseFloat(yScale)) {
     return b64Template;
   }
 

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -9,7 +9,6 @@ const GET_SIMILARITY_MODE = 'getSimilarity';
 const MATCH_TEMPLATE_MODE = 'matchTemplate';
 
 const DEFAULT_MATCH_THRESHOLD = 0.4;
-const DEFAULT_TEMPLATE_IMAGE_SCALE = 1.0;
 
 /**
  * Performs images comparison using OpenCV framework features.
@@ -58,5 +57,5 @@ commands.compareImages = async function (mode, firstImage, secondImage, options 
 };
 
 Object.assign(extensions, commands, helpers);
-export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE, DEFAULT_TEMPLATE_IMAGE_SCALE };
+export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE };
 export default extensions;

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -9,6 +9,7 @@ const GET_SIMILARITY_MODE = 'getSimilarity';
 const MATCH_TEMPLATE_MODE = 'matchTemplate';
 
 const DEFAULT_MATCH_THRESHOLD = 0.4;
+const DEFAULT_TEMPLATE_IMAGE_SCALE = 1.0;
 
 /**
  * Performs images comparison using OpenCV framework features.
@@ -57,5 +58,5 @@ commands.compareImages = async function (mode, firstImage, secondImage, options 
 };
 
 Object.assign(extensions, commands, helpers);
-export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE };
+export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE, DEFAULT_TEMPLATE_IMAGE_SCALE };
 export default extensions;

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -24,7 +24,14 @@ const GLOBAL_DEFAULT_SETTINGS = {
   //      `width=750 × height=1334` pixels. This setting help to adjust the scale
   //      if a user use `width=750 × height=1334` pixels's base template image.
   fixImageTemplateScale: false,
-  imageTemplateDefaultScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
+
+  // Users might have scaled template image to reduce their storage size.
+  // This setting allows users to scale a template image they send to Appium server
+  // so that Appium server compare actual scale users orginaly have.
+  // e.g. A user have `270 × 32 pixels` image oridinally `1080 × 126 pixels`
+  //      The user set {defaultScaleImageTemplate: 4.0} to scale the small image
+  //      to the original one so that Appium can compare it as the original one.
+  defaultScaleImageTemplate: DEFAULT_TEMPLATE_IMAGE_SCALE,
 
   // whether Appium should re-check that an image element can be matched
   // against the current screenshot before clicking it
@@ -46,7 +53,7 @@ const BASEDRIVER_HANDLED_SETTINGS = [
   'fixImageFindScreenshotDims',
   'fixImageTemplateSize',
   'fixImageTemplateScale',
-  'imageTemplateDefaultScale',
+  'defaultScaleImageTemplate',
   'checkForImageElementStaleness',
   'autoUpdateImageElementPosition',
   'imageElementTapStrategy',

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -27,9 +27,9 @@ const GLOBAL_DEFAULT_SETTINGS = {
 
   // Users might have scaled template image to reduce their storage size.
   // This setting allows users to scale a template image they send to Appium server
-  // so that Appium server compare actual scale users orginaly have.
-  // e.g. A user have `270 × 32 pixels` image oridinally `1080 × 126 pixels`
-  //      The user set {defaultImageTemplateScale: 4.0} to scale the small image
+  // so that the Appium server compares the actual scale users originally had.
+  // e.g. If a user has an image of 270 x 32 pixels which was originally 1080 x 126 pixels,
+  //      the user can set {defaultImageTemplateScale: 4.0} to scale the small image
   //      to the original one so that Appium can compare it as the original one.
   defaultImageTemplateScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
 

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import log from './logger';
-import { DEFAULT_MATCH_THRESHOLD } from './commands/images';
+import { DEFAULT_MATCH_THRESHOLD, DEFAULT_TEMPLATE_IMAGE_SCALE } from './commands/images';
 import { IMAGE_EL_TAP_STRATEGY_W3C } from './image-element';
 
 const GLOBAL_DEFAULT_SETTINGS = {
@@ -24,6 +24,7 @@ const GLOBAL_DEFAULT_SETTINGS = {
   //      `width=750 × height=1334` pixels. This setting help to adjust the scale
   //      if a user use `width=750 × height=1334` pixels's base template image.
   fixImageTemplateScale: false,
+  imageTemplateDefaultScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
 
   // whether Appium should re-check that an image element can be matched
   // against the current screenshot before clicking it
@@ -44,6 +45,8 @@ const BASEDRIVER_HANDLED_SETTINGS = [
   'imageMatchThreshold',
   'fixImageFindScreenshotDims',
   'fixImageTemplateSize',
+  'fixImageTemplateScale',
+  'imageTemplateDefaultScale',
   'checkForImageElementStaleness',
   'autoUpdateImageElementPosition',
   'imageElementTapStrategy',

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -29,9 +29,9 @@ const GLOBAL_DEFAULT_SETTINGS = {
   // This setting allows users to scale a template image they send to Appium server
   // so that Appium server compare actual scale users orginaly have.
   // e.g. A user have `270 × 32 pixels` image oridinally `1080 × 126 pixels`
-  //      The user set {defaultScaleImageTemplate: 4.0} to scale the small image
+  //      The user set {defaultImageTemplateScale: 4.0} to scale the small image
   //      to the original one so that Appium can compare it as the original one.
-  defaultScaleImageTemplate: DEFAULT_TEMPLATE_IMAGE_SCALE,
+  defaultImageTemplateScale: DEFAULT_TEMPLATE_IMAGE_SCALE,
 
   // whether Appium should re-check that an image element can be matched
   // against the current screenshot before clicking it
@@ -53,7 +53,7 @@ const BASEDRIVER_HANDLED_SETTINGS = [
   'fixImageFindScreenshotDims',
   'fixImageTemplateSize',
   'fixImageTemplateScale',
-  'defaultScaleImageTemplate',
+  'defaultImageTemplateScale',
   'checkForImageElementStaleness',
   'autoUpdateImageElementPosition',
   'imageElementTapStrategy',

--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import log from './logger';
-import { DEFAULT_MATCH_THRESHOLD, DEFAULT_TEMPLATE_IMAGE_SCALE } from './commands/images';
-import { IMAGE_EL_TAP_STRATEGY_W3C } from './image-element';
+import { DEFAULT_MATCH_THRESHOLD } from './commands/images';
+import { IMAGE_EL_TAP_STRATEGY_W3C, DEFAULT_TEMPLATE_IMAGE_SCALE } from './image-element';
 
 const GLOBAL_DEFAULT_SETTINGS = {
   // value between 0 and 1 representing match strength, below which an image

--- a/lib/basedriver/image-element.js
+++ b/lib/basedriver/image-element.js
@@ -13,6 +13,7 @@ const IMAGE_TAP_STRATEGIES = [
   IMAGE_EL_TAP_STRATEGY_MJSONWP,
   IMAGE_EL_TAP_STRATEGY_W3C
 ];
+const DEFAULT_TEMPLATE_IMAGE_SCALE = 1.0;
 
 /**
  * @typedef {Object} Rect
@@ -127,7 +128,9 @@ class ImageElement {
       log.info('Checking image element for staleness before clicking');
       try {
         newImgEl = await driver.findByImage(this.template, {
-          shouldCheckStaleness: true
+          shouldCheckStaleness: true,
+          // Set ignoreDefaultImageTemplateScale because this.template already has screenshot scaled template image
+          ignoreDefaultImageTemplateScale: true
         });
       } catch (err) {
         throw new errors.StaleElementReferenceError();
@@ -246,4 +249,5 @@ function getImgElFromArgs (args) {
 export {
   ImageElement, getImgElFromArgs, makeImageElementCache,
   IMAGE_EL_TAP_STRATEGY_MJSONWP, IMAGE_EL_TAP_STRATEGY_W3C,
+  DEFAULT_TEMPLATE_IMAGE_SCALE
 };

--- a/lib/basedriver/image-element.js
+++ b/lib/basedriver/image-element.js
@@ -129,7 +129,8 @@ class ImageElement {
       try {
         newImgEl = await driver.findByImage(this.template, {
           shouldCheckStaleness: true,
-          // Set ignoreDefaultImageTemplateScale because this.template already has screenshot scaled template image
+          // Set ignoreDefaultImageTemplateScale because this.template is device screenshot based image
+          // managed inside Appium after finidng image by template which managed by a user
           ignoreDefaultImageTemplateScale: true
         });
       } catch (err) {

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -152,20 +152,54 @@ describe('finding elements by image', function () {
       await helpers.fixImageTemplateScale(newTemplate, {fixImageTemplateScale: true})
         .should.eventually.eql(newTemplate);
     });
+
     it('should not fix template size scale if it is null', async function () {
       const newTemplate = 'iVBORbaz';
       await helpers.fixImageTemplateScale(newTemplate, null)
         .should.eventually.eql(newTemplate);
     });
+
     it('should not fix template size scale if it is not number', async function () {
       const newTemplate = 'iVBORbaz';
       await helpers.fixImageTemplateScale(newTemplate, 'wrong-scale')
         .should.eventually.eql(newTemplate);
     });
+
     it('should fix template size scale', async function () {
       const actual = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAWElEQVR4AU3BQRWAQAhAwa/PGBsEgrC16AFBKEIPXW7OXO+Rmey9iQjMjHFzrLUwM7qbqmLcHKpKRFBVuDvj4agq3B1VRUQYT2bS3QwRQVUZF/CaGRHB3wc1vSZbHO5+BgAAAABJRU5ErkJggg==';
       await helpers.fixImageTemplateScale(TINY_PNG, {
         fixImageTemplateScale: true, xScale: 1.5, yScale: 1.5
+      }).should.eventually.eql(actual);
+    });
+
+    it('should not fix template size scale because of fixImageTemplateScale is false', async function () {
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        fixImageTemplateScale: false, xScale: 1.5, yScale: 1.5
+      }).should.eventually.eql(TINY_PNG);
+    });
+
+    it('should fix template size scale with default scale', async function () {
+      const actual = 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABwUlEQVR4AaXBPUsrQQCG0SeX+cBdkTjwTpG1NPgLpjY/fW1stt4UYmm2cJqwMCsaw70uJJ3CBc9Z/P3Cl+12S9u2tG1L27bEGLm/v2ez2bDZbJDEd/7wS4YT7z3X19fc3Nxwd3dHXdd47xnHkefnZ8ZxpKoq6rqmqiqMMcwMJ1VV0TQN0zThnOPj44O6rsk503UdkmiahqZpWK1WGGOYGU7quqZpGqy1SCLnTM6Z19dXcs5IYpomrLVI4uLigpnhpKoqVqsVkjgcDjw9PdF1HTlnuq5DEs45JHE4HDgznByPR97e3pimiVIK4zhyPB7x3hNCIITA5eUl3nsWiwVnhpNSCsMwsNvtGIaB/X5PKQVJpJSQxHq9RhLOOc4MJ9M0sdvt2G639H3PTBIxRiQhCUnEGLHWcmY4KaUwDAN93/P4+MhyuSSlhCRSSkjCOYe1FmstZ6bve2YvLy/s93tmy+USSUhCEpIIIfAd8/DwwOz9/Z1SCpJIKSGJ9XqNJJxz/MS0bcvs6uoKScQYkYQkJBFjxFrLT0zbtsxub29JKSGJlBKScM5hrcVay09MzplZjJHPz0+894QQCCHwP/7wS/8A4e6nAg+R8LwAAAAASUVORK5CYII=';
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        defaultImageTemplateScale: 4.0
+      }).should.eventually.eql(actual);
+    });
+
+    it('should fix template size scale with default scale and image scale', async function () {
+      const actual = 'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAACaUlEQVR4AbXBMWvrWBSF0c9BsFPtW91UR1U6+///FKlKKt8qqnyqnMozggkI8xgMj6x1uv+L/6zryrIsrOvKsiys68qyLFwuF87nM5fLhfP5zOVy4Xw+84wXftkLv2ziQBK26b0TEVQVu4jANrvM5Hq9spOEJCQhCUlI4mjiQBK26b1TVewkYRvb7DKTMQaZiW1s01rDNraRxNHEgSRaa1QVO0m01jjKTDKTXe+d3jtVxU4SjyYOJGGbnSRs03snM8lMMpPb7UZmkplEBFXFThK2eTRxIAnbSMI2VcX39zdjDMYYZCaZyRiDMQZVxU4StqkqHk0cSEISf5KZ7DKTMQbLsrCTRGuN3jtVxaOJg6qiqqgqqoqqoqoYY5CZ7GwTEdzvd97f34kIeu/YRhKPJg6qiswkM7ndbmQmmUlmkpnsbBMR2CYimOeZ3ju2kcSjiYOqIjP5+vpi2za2bWPbNo5aa7TW2PXe6b3Te6e1hiQeTRxUFbfbjW3bGGNwvV4ZY2Ab27TWsI1tbGMb27TWsI0kHk0cVBWZybZtXK9XPj8/+fj4YJ5nIoLWGraJCOZ5RhKSkIQkJPFo4qCqyEy2bWOMwefnJ+u6cjqdsM3ONvM8cz6feca0ris/rtcrmcnONhHB/X7n/f2diKD3jm0k8axpWRZ+ZCaZyc42EYFtIoJ5num9YxtJPGta15U/sY1tdm9vb/Te6b1jG0k8a1qWhR+2sU1rjdYatrGNbWxjm9YaknjWtK4rPyKCiKC1hm0igojg9fUVSUhCEpJ41rQsC0e22dkmIrhcLvyNF/7H6XTib73wy174Zf8AJEsePtlPj10AAAAASUVORK5CYII=';
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        defaultImageTemplateScale: 4.0,
+        fixImageTemplateScale: true,
+        xScale: 1.5, yScale: 1.5
+      }).should.eventually.eql(actual);
+    });
+
+    it('should not fix template size scale with default scale and image scale', async function () {
+      const actual = 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABwUlEQVR4AaXBPUsrQQCG0SeX+cBdkTjwTpG1NPgLpjY/fW1stt4UYmm2cJqwMCsaw70uJJ3CBc9Z/P3Cl+12S9u2tG1L27bEGLm/v2ez2bDZbJDEd/7wS4YT7z3X19fc3Nxwd3dHXdd47xnHkefnZ8ZxpKoq6rqmqiqMMcwMJ1VV0TQN0zThnOPj44O6rsk503UdkmiahqZpWK1WGGOYGU7quqZpGqy1SCLnTM6Z19dXcs5IYpomrLVI4uLigpnhpKoqVqsVkjgcDjw9PdF1HTlnuq5DEs45JHE4HDgznByPR97e3pimiVIK4zhyPB7x3hNCIITA5eUl3nsWiwVnhpNSCsMwsNvtGIaB/X5PKQVJpJSQxHq9RhLOOc4MJ9M0sdvt2G639H3PTBIxRiQhCUnEGLHWcmY4KaUwDAN93/P4+MhyuSSlhCRSSkjCOYe1FmstZ6bve2YvLy/s93tmy+USSUhCEpIIIfAd8/DwwOz9/Z1SCpJIKSGJ9XqNJJxz/MS0bcvs6uoKScQYkYQkJBFjxFrLT0zbtsxub29JKSGJlBKScM5hrcVay09MzplZjJHPz0+894QQCCHwP/7wS/8A4e6nAg+R8LwAAAAASUVORK5CYII=';
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        defaultImageTemplateScale: 4.0,
+        fixImageTemplateScale: false,
+        xScale: 1.5, yScale: 1.5
       }).should.eventually.eql(actual);
     });
   });

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -279,9 +279,9 @@ describe('finding elements by image', function () {
       const d = new TestDriver();
       sinon.stub(d, 'getScreenshot').returns(TINY_PNG);
 
-      // try first with portrait screen
+      // try first with portrait screen, screen = 8 x 12
       let screen = [TINY_PNG_DIMS[0] * 2, TINY_PNG_DIMS[1] * 3];
-      let expectedScale = { xScale: 0.67, yScale: 1 };
+      let expectedScale = { xScale: 2.67, yScale: 4 };
 
       const {b64Screenshot, scale} = await d.getScreenshotForImageFind(...screen);
       b64Screenshot.should.not.eql(TINY_PNG);
@@ -291,9 +291,9 @@ describe('finding elements by image', function () {
       scale.xScale.toFixed(2).should.eql(expectedScale.xScale.toString());
       scale.yScale.should.eql(expectedScale.yScale);
 
-      // then with landscape screen
+      // then with landscape screen, screen = 12 x 8
       screen = [TINY_PNG_DIMS[0] * 3, TINY_PNG_DIMS[1] * 2];
-      expectedScale = { xScale: 1, yScale: 0.67 };
+      expectedScale = { xScale: 4, yScale: 2.67 };
 
       const {b64Screenshot: newScreen, scale: newScale} = await d.getScreenshotForImageFind(...screen);
       newScreen.should.not.eql(TINY_PNG);
@@ -303,6 +303,42 @@ describe('finding elements by image', function () {
       newScale.xScale.should.eql(expectedScale.xScale);
       newScale.yScale.toFixed(2).should.eql(expectedScale.yScale.toString());
     });
+
+    it('should return scaled screenshot with different aspect ratio if not matching screen aspect ratio with fixImageTemplateScale', async function () {
+      const d = new TestDriver();
+      sinon.stub(d, 'getScreenshot').returns(TINY_PNG);
+
+      // try first with portrait screen, screen = 8 x 12
+      let screen = [TINY_PNG_DIMS[0] * 2, TINY_PNG_DIMS[1] * 3];
+      let expectedScale = { xScale: 2.67, yScale: 4 };
+
+      const {b64Screenshot, scale} = await d.getScreenshotForImageFind(...screen);
+      b64Screenshot.should.not.eql(TINY_PNG);
+      let screenshotObj = await imageUtil.getJimpImage(b64Screenshot);
+      screenshotObj.bitmap.width.should.eql(screen[0]);
+      screenshotObj.bitmap.height.should.eql(screen[1]);
+      scale.xScale.toFixed(2).should.eql(expectedScale.xScale.toString());
+      scale.yScale.should.eql(expectedScale.yScale);
+      // 8 x 12 stretched TINY_PNG
+      await helpers.fixImageTemplateScale(b64Screenshot, {fixImageTemplateScale: true, scale})
+        .should.eventually.eql('iVBORw0KGgoAAAANSUhEUgAAAAgAAAAMCAYAAABfnvydAAAAJ0lEQVR4AYXBAQEAIACDMKR/p0fTBrKdbZcPCRIkSJAgQYIECRIkPAzBA1TpeNwZAAAAAElFTkSuQmCC');
+
+      // then with landscape screen, screen = 12 x 8
+      screen = [TINY_PNG_DIMS[0] * 3, TINY_PNG_DIMS[1] * 2];
+      expectedScale = { xScale: 4, yScale: 2.67 };
+
+      const {b64Screenshot: newScreen, scale: newScale} = await d.getScreenshotForImageFind(...screen);
+      newScreen.should.not.eql(TINY_PNG);
+      screenshotObj = await imageUtil.getJimpImage(newScreen);
+      screenshotObj.bitmap.width.should.eql(screen[0]);
+      screenshotObj.bitmap.height.should.eql(screen[1]);
+      newScale.xScale.should.eql(expectedScale.xScale);
+      newScale.yScale.toFixed(2).should.eql(expectedScale.yScale.toString());
+      // 12 x 8 stretched TINY_PNG
+      await helpers.fixImageTemplateScale(newScreen, {fixImageTemplateScale: true, scale})
+        .should.eventually.eql('iVBORw0KGgoAAAANSUhEUgAAAAwAAAAICAYAAADN5B7xAAAAI0lEQVR4AZXBAQEAMAyDMI5/T5W2ayB5245AIokkkkgiiST6+W4DTLyo5PUAAAAASUVORK5CYII=');
+    });
+
   });
 });
 

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -113,25 +113,6 @@ describe('finding elements by image', function () {
       sinon.stub(d, 'fixImageTemplateScale').returns(newTemplate);
       d.fixImageTemplateScale.callCount.should.eql(0);
     });
-    it('should not fix template size scale if no scale value', async function () {
-      const newTemplate = 'iVBORbaz';
-      await helpers.fixImageTemplateScale(newTemplate).should.eventually.eql(newTemplate);
-    });
-    it('should not fix template size scale if it is null', async function () {
-      const newTemplate = 'iVBORbaz';
-      await helpers.fixImageTemplateScale(newTemplate, null)
-        .should.eventually.eql(newTemplate);
-    });
-    it('should not fix template size scale if it is not number', async function () {
-      const newTemplate = 'iVBORbaz';
-      await helpers.fixImageTemplateScale(newTemplate, 'wrong-scale')
-        .should.eventually.eql(newTemplate);
-    });
-    it('should fix template size scale', async function () {
-      const actual = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAWElEQVR4AU3BQRWAQAhAwa/PGBsEgrC16AFBKEIPXW7OXO+Rmey9iQjMjHFzrLUwM7qbqmLcHKpKRFBVuDvj4agq3B1VRUQYT2bS3QwRQVUZF/CaGRHB3wc1vSZbHO5+BgAAAABJRU5ErkJggg==';
-      await helpers.fixImageTemplateScale(TINY_PNG, { xScale: 1.5, yScale: 1.5 })
-        .should.eventually.eql(actual);
-    });
 
     it('should throw an error if template match fails', async function () {
       const d = new TestDriver();
@@ -162,6 +143,30 @@ describe('finding elements by image', function () {
       (imgEl instanceof ImageElement).should.be.true;
       d._imgElCache.has(imgEl.id).should.be.false;
       imgEl.rect.should.eql(rect);
+    });
+  });
+
+  describe('fixImageTemplateScale', function () {
+    it('should not fix template size scale if no scale value', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixImageTemplateScale(newTemplate, {fixImageTemplateScale: true})
+        .should.eventually.eql(newTemplate);
+    });
+    it('should not fix template size scale if it is null', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixImageTemplateScale(newTemplate, null)
+        .should.eventually.eql(newTemplate);
+    });
+    it('should not fix template size scale if it is not number', async function () {
+      const newTemplate = 'iVBORbaz';
+      await helpers.fixImageTemplateScale(newTemplate, 'wrong-scale')
+        .should.eventually.eql(newTemplate);
+    });
+    it('should fix template size scale', async function () {
+      const actual = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAWElEQVR4AU3BQRWAQAhAwa/PGBsEgrC16AFBKEIPXW7OXO+Rmey9iQjMjHFzrLUwM7qbqmLcHKpKRFBVuDvj4agq3B1VRUQYT2bS3QwRQVUZF/CaGRHB3wc1vSZbHO5+BgAAAABJRU5ErkJggg==';
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        fixImageTemplateScale: true, xScale: 1.5, yScale: 1.5
+      }).should.eventually.eql(actual);
     });
   });
 

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -281,21 +281,27 @@ describe('finding elements by image', function () {
 
       // try first with portrait screen
       let screen = [TINY_PNG_DIMS[0] * 2, TINY_PNG_DIMS[1] * 3];
+      let expectedScale = { xScale: 0.67, yScale: 1 };
+
       const {b64Screenshot, scale} = await d.getScreenshotForImageFind(...screen);
       b64Screenshot.should.not.eql(TINY_PNG);
       let screenshotObj = await imageUtil.getJimpImage(b64Screenshot);
       screenshotObj.bitmap.width.should.eql(screen[0]);
       screenshotObj.bitmap.height.should.eql(screen[1]);
-      scale.should.eql({ xScale: 2, yScale: 3 });
+      scale.xScale.toFixed(2).should.eql(expectedScale.xScale.toString());
+      scale.yScale.should.eql(expectedScale.yScale);
 
       // then with landscape screen
       screen = [TINY_PNG_DIMS[0] * 3, TINY_PNG_DIMS[1] * 2];
+      expectedScale = { xScale: 1, yScale: 0.67 };
+
       const {b64Screenshot: newScreen, scale: newScale} = await d.getScreenshotForImageFind(...screen);
       newScreen.should.not.eql(TINY_PNG);
       screenshotObj = await imageUtil.getJimpImage(newScreen);
       screenshotObj.bitmap.width.should.eql(screen[0]);
       screenshotObj.bitmap.height.should.eql(screen[1]);
-      newScale.should.eql({ xScale: 3, yScale: 2 });
+      newScale.xScale.should.eql(expectedScale.xScale);
+      newScale.yScale.toFixed(2).should.eql(expectedScale.yScale.toString());
     });
   });
 });

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -202,6 +202,23 @@ describe('finding elements by image', function () {
         xScale: 1.5, yScale: 1.5
       }).should.eventually.eql(actual);
     });
+
+    it('should not fix template size scale because of ignoreDefaultImageTemplateScale', async function () {
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        defaultImageTemplateScale: 4.0,
+        ignoreDefaultImageTemplateScale: true,
+      }).should.eventually.eql(TINY_PNG);
+    });
+
+    it('should ignore defaultImageTemplateScale to fix template size scale because of ignoreDefaultImageTemplateScale', async function () {
+      const actual = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAWElEQVR4AU3BQRWAQAhAwa/PGBsEgrC16AFBKEIPXW7OXO+Rmey9iQjMjHFzrLUwM7qbqmLcHKpKRFBVuDvj4agq3B1VRUQYT2bS3QwRQVUZF/CaGRHB3wc1vSZbHO5+BgAAAABJRU5ErkJggg==';
+      await helpers.fixImageTemplateScale(TINY_PNG, {
+        defaultImageTemplateScale: 4.0,
+        ignoreDefaultImageTemplateScale: true,
+        fixImageTemplateScale: true,
+        xScale: 1.5, yScale: 1.5
+      }).should.eventually.eql(actual);
+    });
   });
 
   describe('ensureTemplateSize', function () {


### PR DESCRIPTION
Fix remaining issue in https://github.com/appium/appium-base-driver/pull/306/files#r261480026 .
In the PR, I fixed a template image had different width/height with device screen, but it can be fixed scaling them up/down upto match to device width/height.

But the ratio issue has also below case.

example:

- A user has a template image which is scaled down from `750 x 1314 pixels` image to `187 x 328 pixels` in order to decrease their storage when he store the template image.
- The user uses the scale downed image as the next test case
    - Then, the scaled image does not match in current find by image logic since Appium cannot determin what ratio should be scaled the template up/down
    - Users must scale them up the image in the user side every time.

To resolve the case, I introduced `defaultImageTemplateScale`. If the user sets `defaultImageTemplateScale: 4` for example, Appium will scale the template image up 4 times by default. Then, users do not need to scale in user side.

It can use with `fixImageTemplateScale` for example. It can help to handle some cases such as I described as https://github.com/appium/appium-base-driver/pull/306

cc @jlipps 