### PR TITLE
Update bluebird

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -295,12 +295,14 @@ class BaseDriver extends Protocol {
           const cancelPromise = new B(function (_, _reject) { // eslint-disable-line no-unused-vars
             reject = _reject;
           });
+
           // if one of the args is an image element, handle it separately
-          if (imgElId) {
-            return ImageElement.execute(this, cmd, imgElId);
-          }
-          return B.race([this[cmd](...args), cancelPromise]);
+          return B.race([
+            imgElId ? ImageElement.execute(this, cmd, imgElId) : this[cmd](...args),
+            cancelPromise,
+          ]);
         });
+        // override the B#cancel function, which just turns off listeners
         this.curCommandCancellable.cancel = function cancel (err) {
           if (reject) {
             reject(err);

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -12,6 +12,10 @@ import { util } from 'appium-support';
 import { ImageElement, makeImageElementCache, getImgElFromArgs } from './image-element';
 
 
+B.config({
+  cancellation: true,
+});
+
 const NEW_COMMAND_TIMEOUT_MS = 60 * 1000;
 
 const EVENT_SESSION_INIT = 'newSessionRequested';
@@ -45,8 +49,8 @@ class BaseDriver extends Protocol {
                        os.tmpdir();
 
     // base-driver internals
-    this.curCommand = new B((r) => { r(); }); // see note in execute
-    this.curCommandCancellable = new B((r) => { r(); }); // see note in execute
+    this.curCommand = B.resolve(); // see note in execute
+    this.curCommandCancellable = B.resolve(); // see note in execute
     this.shutdownUnexpectedly = false;
     this.noCommandTimer = null;
     this.shouldValidateCaps = shouldValidateCaps;
@@ -145,9 +149,10 @@ class BaseDriver extends Protocol {
     if (this.onUnexpectedShutdown && !this.onUnexpectedShutdown.isFulfilled()) {
       this.onUnexpectedShutdown.cancel();
     }
-    this.onUnexpectedShutdown = new B((resolve, reject) => {
+    this.onUnexpectedShutdown = new B((resolve, reject, onCancel) => {
+      onCancel(() => reject(new B.CancellationError()));
       this.unexpectedShutdownDeferred = {resolve, reject};
-    }).cancellable();
+    }).catch(B.Promise.CancellationError, () => {});
     // noop handler to avoid warning.
     this.onUnexpectedShutdown.catch(() => {});
   }
@@ -274,7 +279,7 @@ class BaseDriver extends Protocol {
       // ignoring any rejections), so that if another command comes into the
       // server, it gets tacked on to the end of nextCommand. Thus we create
       // a chain of promises that acts as a queue with single concurrency.
-      let nextCommand = this.curCommand.then(() => { // eslint-disable-line promise/prefer-await-to-then
+      const nextCommand = this.curCommand.then(() => { // eslint-disable-line promise/prefer-await-to-then
         // if we unexpectedly shut down, we need to reject every command in
         // the queue before we actually try to run it
         if (this.shutdownUnexpectedly) {
@@ -283,13 +288,24 @@ class BaseDriver extends Protocol {
         // We also need to turn the command into a cancellable promise so if we
         // have an unexpected shutdown event, for example, we can cancel it from
         // outside, rejecting the current command immediately
+        let reject;
         this.curCommandCancellable = B.resolve().then(() => { // eslint-disable-line promise/prefer-await-to-then
+          // in order to abort the promise, we need to have it in a race
+          // with one we can reject from outside
+          const cancelPromise = new B(function (_, _reject) { // eslint-disable-line no-unused-vars
+            reject = _reject;
+          });
           // if one of the args is an image element, handle it separately
           if (imgElId) {
             return ImageElement.execute(this, cmd, imgElId);
           }
-          return this[cmd](...args);
-        }).cancellable();
+          return B.race([this[cmd](...args), cancelPromise]);
+        });
+        this.curCommandCancellable.cancel = function cancel (err) {
+          if (reject) {
+            reject(err);
+          }
+        };
         return this.curCommandCancellable;
       });
       this.curCommand = nextCommand.catch(() => {});
@@ -313,7 +329,7 @@ class BaseDriver extends Protocol {
     }
 
     // log timing information about this command
-    let endTime = Date.now();
+    const endTime = Date.now();
     this._eventHistory.commands.push({cmd, startTime, endTime});
     if (cmd === 'createSession') {
       this.logEvent(EVENT_SESSION_START);

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -152,7 +152,7 @@ class BaseDriver extends Protocol {
     this.onUnexpectedShutdown = new B((resolve, reject, onCancel) => {
       onCancel(() => reject(new B.CancellationError()));
       this.unexpectedShutdownDeferred = {resolve, reject};
-    }).catch(B.Promise.CancellationError, () => {});
+    });
     // noop handler to avoid warning.
     this.onUnexpectedShutdown.catch(() => {});
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "appium-support": "^2.24.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
-    "bluebird": "^2.10.2",
+    "bluebird": "^3.5.3",
     "body-parser": "^1.18.2",
     "colors": "^1.1.2",
     "es6-error": "^4.1.1",
@@ -97,8 +97,6 @@
     "sinon": "^7.2.3"
   },
   "greenkeeper": {
-    "ignore": [
-      "bluebird"
-    ]
+    "ignore": []
   }
 }

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -81,6 +81,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       // make a command that will wait a bit so we can crash while it's running
       d.getStatus = async function () {
         await B.delay(100);
+        return 'good status';
       }.bind(d);
       let cmdPromise = d.executeCommand('getStatus');
       await B.delay(0);


### PR DESCRIPTION
This is the last package to be using `bluebird@2`. We did not upgrade because of the change in the cancellable semantics: the effective handling of unexpected errors relies on cancelling promises _aborting_ them, while `bluebird@3` changed it to simply nullifying listeners.

This PR rolls a simple abort-cancel, so the functionality remains the same.