### PR TITLE
Make proxy convert /property to /attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "11"
 addons:
   apt:
     sources:

--- a/lib/jsonwp-proxy/protocol-converter.js
+++ b/lib/jsonwp-proxy/protocol-converter.js
@@ -7,7 +7,7 @@ import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY } from '../protocol/protocol';
 const log = logger.getLogger('Protocol Converter');
 
 
-const COMMAND_URLS_CONFLICTS = [
+export const COMMAND_URLS_CONFLICTS = [
   {
     commandNames: ['execute', 'executeAsync'],
     jsonwpConverter: (url) => url.replace(/\/execute.*/,
@@ -35,6 +35,16 @@ const COMMAND_URLS_CONFLICTS = [
         : url.replace(/\/window_handles$/, '/window/handles');
     },
   },
+  {
+    commandNames: ['getProperty'],
+    jsonwpConverter: (w3cUrl) => {
+      const w3cPropertyRegex = /\/element\/([^/]+)\/property\/([^/]+)/;
+      const jsonwpUrl = w3cUrl.replace(w3cPropertyRegex, '/element/$1/attribute/$2');
+      log.info(`Converting W3C '${w3cUrl}' to '${jsonwpUrl}'`);
+      return jsonwpUrl;
+    },
+    w3cConverter: (jsonwpUrl) => jsonwpUrl // Don't convert JSONWP URL to W3C. W3C accepts /attribute and /property
+  }
 ];
 
 const {MJSONWP, W3C} = BaseDriver.DRIVER_PROTOCOL;

--- a/test/jsonwp-proxy/protocol-converter-specs.js
+++ b/test/jsonwp-proxy/protocol-converter-specs.js
@@ -2,7 +2,7 @@
 /* global describe:true, it:true */
 
 import _ from 'lodash';
-import ProtocolConverter from '../../lib/jsonwp-proxy/protocol-converter';
+import ProtocolConverter, {COMMAND_URLS_CONFLICTS} from '../../lib/jsonwp-proxy/protocol-converter';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import BaseDriver from '../../lib/basedriver/driver';
@@ -110,6 +110,27 @@ describe('Protocol Converter', function () {
         text: 'bla',
         value: ['b', 'l', 'a'],
       });
+    });
+  });
+  describe('getProperty', function () {
+    let jsonwpConverter, w3cConverter;
+    before(function () {
+      for (let command of COMMAND_URLS_CONFLICTS) {
+        if (command.commandNames.includes('getProperty')) {
+          jsonwpConverter = command.jsonwpConverter;
+          w3cConverter = command.w3cConverter;
+        }
+      }
+    });
+    it('should convert "property/value" to "attribute/value"', function () {
+      jsonwpConverter("/session/123/element/456/property/value").should.equal("/session/123/element/456/attribute/value");
+    });
+    it('should convert "property/:somePropName" to "attribute/:somePropName"', function () {
+      jsonwpConverter("/session/123/element/456/property/somePropName").should.equal("/session/123/element/456/attribute/somePropName");
+    });
+    it('should not convert from JSONWP to W3C', function () {
+      w3cConverter("/session/123/element/456/attribute/someAttr").should.equal("/session/123/element/456/attribute/someAttr");
+      w3cConverter("/session/123/element/456/property/someProp").should.equal("/session/123/element/456/property/someProp");
     });
   });
 });

--- a/test/jsonwp-proxy/protocol-converter-specs.js
+++ b/test/jsonwp-proxy/protocol-converter-specs.js
@@ -123,14 +123,14 @@ describe('Protocol Converter', function () {
       }
     });
     it('should convert "property/value" to "attribute/value"', function () {
-      jsonwpConverter("/session/123/element/456/property/value").should.equal("/session/123/element/456/attribute/value");
+      jsonwpConverter('/session/123/element/456/property/value').should.equal('/session/123/element/456/attribute/value');
     });
     it('should convert "property/:somePropName" to "attribute/:somePropName"', function () {
-      jsonwpConverter("/session/123/element/456/property/somePropName").should.equal("/session/123/element/456/attribute/somePropName");
+      jsonwpConverter('/session/123/element/456/property/somePropName').should.equal('/session/123/element/456/attribute/somePropName');
     });
     it('should not convert from JSONWP to W3C', function () {
-      w3cConverter("/session/123/element/456/attribute/someAttr").should.equal("/session/123/element/456/attribute/someAttr");
-      w3cConverter("/session/123/element/456/property/someProp").should.equal("/session/123/element/456/property/someProp");
+      w3cConverter('/session/123/element/456/attribute/someAttr').should.equal('/session/123/element/456/attribute/someAttr');
+      w3cConverter('/session/123/element/456/property/someProp').should.equal('/session/123/element/456/property/someProp');
     });
   });
 });


### PR DESCRIPTION
After digging into https://github.com/appium/appium/issues/12218 I think the best solution is to proxy W3C `/property/:prop` commands through to JSONWP as `/attribute/:attr`.

So, for example, if a W3C session has this endpoint called

`GET: /session/123/element/456/property/value`

and it's being proxied to a JSONWP server, it should be proxied as

`GET: /session/123/element/456/attribute/value`