### PR TITLE
fix flakey unexpected shutdown test

### DIFF
--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -84,7 +84,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         return 'good status';
       }.bind(d);
       let cmdPromise = d.executeCommand('getStatus');
-      await B.delay(0);
+      await B.delay(10);
       d.startUnexpectedShutdown(new Error('We crashed'));
       await cmdPromise.should.be.rejectedWith(/We crashed/);
       await d.onUnexpectedShutdown.should.be.rejectedWith(/We crashed/);


### PR DESCRIPTION
turns out `B.delay(0)` was not enough to allow the current command to actually spin up and assign its cancel promise method. /cc @imurchie 