### PR TITLE
Fix the error which is thrown on download failure

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -204,41 +204,35 @@ async function configureApp (app, supportedAppExtensions) {
 }
 
 async function downloadApp (app, targetPath) {
-  let appUrl;
+  const {href} = url.parse(app);
+  const started = process.hrtime();
   try {
-    appUrl = url.parse(app);
-  } catch (err) {
-    throw new Error(`Invalid App URL (${app})`);
-  }
-
-  try {
-    const started = process.hrtime();
     // don't use request-promise here, we need streams
     await new B((resolve, reject) => {
-      request(appUrl.href)
+      request(href)
         .on('error', reject) // handle real errors, like connection errors
         .on('response', (res) => {
           // handle responses that fail, like 404s
           if (res.statusCode >= 400) {
-            return reject(`Error downloading file: ${res.statusCode}`);
+            return reject(new Error(`${res.statusCode} - ${res.statusMessage}`));
           }
         })
         .pipe(_fs.createWriteStream(targetPath))
         .on('close', resolve);
     });
-    const [seconds, ns] = process.hrtime(started);
-    const secondsElapsed = seconds + ns / 1E09;
-    const {size} = await fs.stat(targetPath);
-    logger.debug(`'${appUrl.href}' (${util.toReadableSizeString(size)}) ` +
-      `has been downloaded to '${targetPath}' in ${secondsElapsed.toFixed(3)}s`);
-    if (secondsElapsed >= 2) {
-      const bytesPerSec = Math.floor(size / secondsElapsed);
-      logger.debug(`Approximate download speed: ${util.toReadableSizeString(bytesPerSec)}/s`);
-    }
-    return targetPath;
   } catch (err) {
-    throw new Error(`Problem downloading app from url ${appUrl.href}: ${err.message}`);
+    throw new Error(`Problem downloading app from url ${href}: ${err.message}`);
   }
+  const [seconds, ns] = process.hrtime(started);
+  const secondsElapsed = seconds + ns / 1e09;
+  const {size} = await fs.stat(targetPath);
+  logger.debug(`'${href}' (${util.toReadableSizeString(size)}) ` +
+    `has been downloaded to '${targetPath}' in ${secondsElapsed.toFixed(3)}s`);
+  if (secondsElapsed >= 2) {
+    const bytesPerSec = Math.floor(size / secondsElapsed);
+    logger.debug(`Approximate download speed: ${util.toReadableSizeString(bytesPerSec)}/s`);
+  }
+  return targetPath;
 }
 
 async function walkDir (dir) {


### PR DESCRIPTION
The `reject` argument is expected to be a valid error object