### PR TITLE
Be more explicit about unrecognized caps

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -194,7 +194,10 @@ class BaseDriver extends Protocol {
                                  _.keys(this._constraints));
     if (extraCaps.length) {
       log.warn(`The following capabilities were provided, but are not ` +
-               `recognized by appium: ${extraCaps.join(', ')}.`);
+               `recognized by Appium:`);
+      for (const cap of extraCaps) {
+        log.warn(`  ${cap}`);
+      }
     }
   }
 


### PR DESCRIPTION
Just a little more clarity about unrecognized capabilities, so they are listed much like the real capabilities, instead of buried.