### PR TITLE
fix handling 0 in gsmSignal

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -394,7 +394,7 @@ const METHOD_MAP = {
             'we require one of "signalStrength" or "signalStrengh" params',
         optional: ['signalStrength', 'signalStrengh'],
         // backward-compatible. sonObj.signalStrength can be 0
-        makeArgs: (jsonObj) => [jsonObj.signalStrength !== undefined ? jsonObj.signalStrength : jsonObj.signalStrengh]
+        makeArgs: (jsonObj) => [util.hasValue(jsonObj.signalStrength) ? jsonObj.signalStrength : jsonObj.signalStrengh]
       }
     }
   },

--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -393,8 +393,8 @@ const METHOD_MAP = {
         validate: (jsonObj) => (!util.hasValue(jsonObj.signalStrength) && !util.hasValue(jsonObj.signalStrengh)) &&
             'we require one of "signalStrength" or "signalStrengh" params',
         optional: ['signalStrength', 'signalStrengh'],
-        // backward-compatible
-        makeArgs: (jsonObj) => [jsonObj.signalStrength || jsonObj.signalStrengh]
+        // backward-compatible. sonObj.signalStrength can be 0
+        makeArgs: (jsonObj) => [jsonObj.signalStrength !== undefined ? jsonObj.signalStrength : jsonObj.signalStrengh]
       }
     }
   },


### PR DESCRIPTION
`jsonObj.signalStrength` can be `0`. Then, if appium gets only `signalStrength`, the returned value will be `undefined`.

```
0 || undefined //=> undefined
0 || 0 //=> 0
```

Noticed it in https://github.com/appium/python-client/pull/357...