### PR TITLE
Only get message from error

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -237,7 +237,7 @@ class JWProxy {
       throw new errors.UnknownError(err.message);
     }
     resBody = util.safeJsonParse(resBody);
-    let protocol = this.getProtocolFromResBody(resBody);
+    const protocol = this.getProtocolFromResBody(resBody);
     if (protocol === MJSONWP) {
       // Got response in MJSONWP format
       if (response.statusCode === 200 && resBody.status === 0) {
@@ -246,8 +246,8 @@ class JWProxy {
       const status = parseInt(resBody.status, 10);
       if (!isNaN(status) && status !== 0) {
         let message = resBody.value;
-        if (_.has(resBody.value, 'message')) {
-          message = _.isEmpty(message) ? resBody.value.message : `${message} ${resBody.value.message}`;
+        if (_.has(message, 'message')) {
+          message = message.message;
         }
         throw errorFromMJSONWPStatusCode(status, _.isEmpty(message) ? getSummaryByCode(status) : message);
       }


### PR DESCRIPTION
The current implementation guarantees that we will get `[object Object]` in the logs, since if `resBody.value.message` exists, `_.isEmpty(message)` will always be `false`, and `message` will be an object.