### PR TITLE
added keepalive option to JWProxy

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -24,6 +24,7 @@ class JWProxy {
       base: '/wd/hub',
       sessionId: null,
       timeout: DEFAULT_REQUEST_TIMEOUT,
+      keepAlive: false,
     }, opts);
     this.scheme = this.scheme.toLowerCase();
     this._activeRequests = [];
@@ -128,6 +129,7 @@ class JWProxy {
       },
       resolveWithFullResponse: true,
       timeout: this.timeout,
+      forever: this.keepAlive,
     };
     if (body !== null) {
       if (typeof body !== 'object') {


### PR DESCRIPTION
Added an optional parameter to the JWProxy constructor to allow keeping the connection open as long as it is being used.

For example, enabling it for the connection to iOS' WebDriverAgent increases performance.