### PR TITLE
Add endpoint that receives a webdriver script for batch command execution

### DIFF
--- a/lib/basedriver/commands/execute-child.js
+++ b/lib/basedriver/commands/execute-child.js
@@ -1,0 +1,128 @@
+import _ from 'lodash';
+import B from 'bluebird';
+import vm from 'vm';
+import log from '../logger';
+import { attach } from 'webdriverio';
+
+// duplicate defining these keys here so we don't need to re-load a huge appium
+// dependency tree into memory just to run a wdio script
+const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
+const MJSONWP_ELEMENT_KEY = 'ELEMENT';
+
+async function runScript (driverOpts, script, timeout) {
+  // set up fake logger
+  const logLevels = ['error', 'warn', 'log'];
+  const logs = {};
+  const consoleFns = {};
+  for (const level of logLevels) {
+    logs[level] = [];
+    consoleFns[level] = (...logMsgs) => logs[level].push(...logMsgs);
+  }
+
+  const driver = attach(driverOpts);
+
+  const fullScript = buildScript(script);
+  // the timeout here will not matter really, but set it anyway to be on the
+  // safe side
+  const vmCtx = vm.runInNewContext(fullScript, {}, {timeout});
+
+  // run the driver script, giving user access to the driver object, a fake
+  // console logger, and a promise library
+  log.info('Running driver script in Node vm');
+  let result = await vmCtx(driver, consoleFns, B);
+
+  log.info('Ensuring driver script result is appropriate type for return');
+  result = coerceScriptResult(result);
+  return {result, logs};
+}
+
+/**
+ * Embed a user-generated script inside a method which takes only the
+ * predetermined objects we specify
+ *
+ * @param {string} script - the javascript to execute
+ *
+ * @return {string} - the full script to execute
+ */
+function buildScript (script) {
+  return `(async function execute (driver, console, Promise) {
+    ${script}
+  })`;
+}
+
+/**
+ * We can get any manner of crazy thing back from a vm executing untrusted
+ * code. We might also get WebdriverIO objects that aren't suitable for JSON
+ * response. So make sure we convert the things we know about to their
+ * appropriate response format, and squash other weird things.
+ *
+ * @param {Object} obj - object to convert and sanitize
+ *
+ * @return {Object} - safely converted object
+ */
+function coerceScriptResult (obj) {
+  // first ensure obj is of a type that can be JSON encoded safely. This will
+  // get rid of custom objects, functions, etc... and turn them into POJOs
+  try {
+    obj = JSON.parse(JSON.stringify(obj));
+  } catch (e) {
+    log.warn('Could not convert executeDriverScript to safe response!' +
+             `Result was: ${obj}. Will make it null`);
+    return null;
+  }
+
+  let res;
+
+  // now we begin our recursive case options
+  if (_.isPlainObject(obj)) {
+    // if we have an object, it's either an element object or something else
+    // webdriverio has no monadic object types other than element and driver,
+    // and we don't want to allow special casing return of driver
+    res = {};
+
+    if (obj[MJSONWP_ELEMENT_KEY] || obj[W3C_ELEMENT_KEY]) {
+      // if it's an element object, clear out anything that's not the key, and
+      // then return the object
+      if (obj[MJSONWP_ELEMENT_KEY]) {
+        res[MJSONWP_ELEMENT_KEY] = obj[MJSONWP_ELEMENT_KEY];
+      }
+
+      if (obj[W3C_ELEMENT_KEY]) {
+        res[W3C_ELEMENT_KEY] = obj[W3C_ELEMENT_KEY];
+      }
+      return res;
+    }
+
+    // otherwise, recurse into the object
+    for (const key of Object.keys(obj)) {
+      res[key] = coerceScriptResult(obj[key]);
+    }
+    return res;
+  }
+
+  // in the cae of an array, just recurse into the items
+  if (_.isArray(obj)) {
+    return obj.map(i => coerceScriptResult(i));
+  }
+
+  // base case, if it's not an object or array, return straightaway
+  return obj;
+}
+
+async function main (driverOpts, script, timeout) {
+  let res;
+  try {
+    res = {success: await runScript(driverOpts, script, timeout)};
+  } catch (error) {
+    res = {error: {message: error.message, stack: error.stack}};
+  }
+  await B.promisify(process.send, {context: process})(res);
+}
+
+if (require.main === module) {
+  log.info('Running driver execution in child process');
+  process.on('message', ({driverOpts, script, timeout}) => {
+    log.info('Parameters received from parent process');
+    main(driverOpts, script, timeout);
+  });
+}

--- a/lib/basedriver/commands/execute-child.js
+++ b/lib/basedriver/commands/execute-child.js
@@ -10,6 +10,10 @@ const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
 const MJSONWP_ELEMENT_KEY = 'ELEMENT';
 
 async function runScript (driverOpts, script, timeout) {
+  if (!_.isNumber(timeout)) {
+    throw new Error('Timeout parameter must be a number');
+  }
+
   // set up fake logger
   const logLevels = ['error', 'warn', 'log'];
   const logs = {};

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -5,7 +5,7 @@ import { attach } from 'webdriverio';
 import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY } from '../../protocol/protocol';
 
 const BASE_PATH = '/wd/hub'; // TODO defining this here is brittle but it is hardcoded in routes, so...
-const FEAT_FLAG = 'execute-driver-script';
+const FEAT_FLAG = 'execute_driver_script';
 const SCRIPT_TYPE_WDIO = 'webdriverio';
 // TODO add wd script type
 

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -34,6 +34,14 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
                     'is required. This is probably a programming error in the driver');
   }
 
+  const logLevels = ['error', 'warn', 'log'];
+  const logs = {};
+  const consoleFns = {};
+  for (const level of logLevels) {
+    logs[level] = [];
+    consoleFns[level] = (...logMsgs) => logs[level].push(...logMsgs);
+  }
+
   const driver = attach({
     sessionId: this.sessionId,
     protocol: 'http', // Appium won't ever be behind ssl locally
@@ -44,12 +52,13 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
     capabilities: this.caps
   });
   const fullScript = buildScript(script);
-  const result = await vm.runInNewContext(fullScript)(driver);
-  return coerceScriptResult(result);
+  let result = await vm.runInNewContext(fullScript)(driver, consoleFns);
+  result = coerceScriptResult(result);
+  return {result, logs};
 };
 
 function buildScript (script) {
-  return `(async function execute (driver) {
+  return `(async function execute (driver, console) {
     ${script}
   })`;
 }

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -1,13 +1,14 @@
 import _ from 'lodash';
+import path from 'path';
+import cp from 'child_process';
 import log from '../logger';
-import vm from 'vm';
-import { attach } from 'webdriverio';
-import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY } from '../../protocol/protocol';
+import B from 'bluebird';
 
 const BASE_PATH = '/wd/hub'; // TODO defining this here is brittle but it is hardcoded in routes, so...
 const FEAT_FLAG = 'execute_driver_script';
+const DEFAULT_SCRIPT_TIMEOUT = 1000 * 60 * 60; // default to 1 hour timeout
 const SCRIPT_TYPE_WDIO = 'webdriverio';
-// TODO add wd script type
+// TODO add wd script type at some point
 
 let commands = {};
 
@@ -23,7 +24,9 @@ let commands = {};
  * @returns {Object} - a JSONifiable object representing the return value of
  * the script
  */
-commands.executeDriverScript = async function (script, scriptType = 'webdriverio') {
+commands.executeDriverScript = async function (script, scriptType = 'webdriverio',
+  timeout = DEFAULT_SCRIPT_TIMEOUT) {
+
   if (!this.isFeatureEnabled(FEAT_FLAG)) {
     throw new Error(`Execute driver script functionality is not available ` +
                     `unless server is started with --allow-insecure including ` +
@@ -39,15 +42,11 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
                     'is required. This is probably a programming error in the driver');
   }
 
-  const logLevels = ['error', 'warn', 'log'];
-  const logs = {};
-  const consoleFns = {};
-  for (const level of logLevels) {
-    logs[level] = [];
-    consoleFns[level] = (...logMsgs) => logs[level].push(...logMsgs);
+  if (!_.isNumber(timeout)) {
+    throw new Error('Timeout parameter must be a number');
   }
 
-  const driver = attach({
+  const driverOpts = {
     sessionId: this.sessionId,
     protocol: 'http', // Appium won't ever be behind ssl locally
     hostname: this.opts.host,
@@ -56,84 +55,72 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
     isW3C: this.isW3CProtocol(),
     isMobile: true,
     capabilities: this.caps
-  });
-  const fullScript = buildScript(script);
-  let result = await vm.runInNewContext(fullScript)(driver, consoleFns);
-  result = coerceScriptResult(result);
-  return {result, logs};
+  };
+
+
+  // fork the execution script as a child process
+  const childScript = path.join(__dirname, 'execute-child.js');
+  log.info(`Forking process to run webdriver script as child using ${childScript}`);
+  const scriptProc = cp.fork(childScript);
+
+  // keep track of whether we have canceled the script timeout, so we can stop
+  // waiting for it and allow this process to finish gracefully
+  let timeoutCanceled = false;
+
+  try {
+    const timeoutStart = Date.now();
+
+    // promise that deals with the result from the child process
+    const waitForResult = async function () {
+      const resPromise = new B((res) => {
+        scriptProc.on('message', res); // this is node IPC
+      });
+
+      const res = await resPromise;
+      log.info('Received execute driver script result from child process, shutting it down');
+
+      if (res.error) {
+        throw new Error(res.error.message);
+      }
+
+      return res.success;
+    };
+
+    // promise that waits up to the timeout and throws an error if so, or does
+    // nothing if the timeout is canceled because we got a result from the
+    // child script
+    const waitForTimeout = async function () {
+      while (!timeoutCanceled && (Date.now() - timeoutStart) < timeout) {
+        await B.delay(500);
+      }
+
+      if (timeoutCanceled) {
+        return;
+      }
+
+      throw new Error(`Execute driver script timed out after ${timeout}ms. ` +
+                      `You can adjust this with the 'timeout' parameter.`);
+    };
+
+    // now that the child script is alive, send it the data it needs to start
+    // running the driver script
+    log.info('Sending driver and script data to child');
+    scriptProc.send({driverOpts, script, timeout});
+
+    // and set up a race between the response from the child and the timeout
+    return await B.race([waitForResult(), waitForTimeout()]);
+  } catch (err) {
+    throw new Error(`Could not execute driver script. Original error was: ${err}`);
+  } finally {
+    // ensure we always cancel the timeout so that the timeout promise stops
+    // spinning and allows this process to die gracefully
+    timeoutCanceled = true;
+
+    log.info('Disconnecting from and killing driver script child proc');
+    scriptProc.disconnect();
+    scriptProc.kill();
+  }
 };
 
-/**
- * Embed a user-generated script inside a method which takes only the
- * predetermined objects we specify
- *
- * @param {string} script - the javascript to execute
- *
- * @return {string} - the full script to execute
- */
-function buildScript (script) {
-  return `(async function execute (driver, console) {
-    ${script}
-  })`;
-}
-
-/**
- * We can get any manner of crazy thing back from a vm executing untrusted
- * code. We might also get WebdriverIO objects that aren't suitable for JSON
- * response. So make sure we convert the things we know about to their
- * appropriate response format, and squash other weird things.
- *
- * @param {Object} obj - object to convert and sanitize
- *
- * @return {Object} - safely converted object
- */
-function coerceScriptResult (obj) {
-  // first ensure obj is of a type that can be JSON encoded safely. This will
-  // get rid of custom objects, functions, etc... and turn them into POJOs
-  try {
-    obj = JSON.parse(JSON.stringify(obj));
-  } catch (e) {
-    log.warn('Could not convert executeDriverScript to safe response!' +
-             `Result was: ${obj}. Will make it null`);
-    return null;
-  }
-
-  let res;
-
-  // now we begin our recursive case options
-  if (_.isPlainObject(obj)) {
-    // if we have an object, it's either an element object or something else
-    // webdriverio has no monadic object types other than element and driver,
-    // and we don't want to allow special casing return of driver
-    res = {};
-
-    if (obj[MJSONWP_ELEMENT_KEY] || obj[W3C_ELEMENT_KEY]) {
-      // if it's an element object, clear out anything that's not the key, and
-      // then return the object
-      if (obj[MJSONWP_ELEMENT_KEY]) {
-        res[MJSONWP_ELEMENT_KEY] = obj[MJSONWP_ELEMENT_KEY];
-      }
-
-      if (obj[W3C_ELEMENT_KEY]) {
-        res[W3C_ELEMENT_KEY] = obj[W3C_ELEMENT_KEY];
-      }
-      return res;
-    }
-
-    // otherwise, recurse into the object
-    for (const key of Object.keys(obj)) {
-      res[key] = coerceScriptResult(obj[key]);
-    }
-    return res;
-  }
-
-  // in the cae of an array, just recurse into the items
-  if (_.isArray(obj)) {
-    return obj.map(i => coerceScriptResult(i));
-  }
-
-  // base case, if it's not an object or array, return straightaway
-  return obj;
-}
 
 export default commands;

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -24,7 +24,7 @@ let commands = {};
  * the script
  */
 commands.executeDriverScript = async function (script, scriptType = 'webdriverio') {
-  if (!this.allowInsecure || !this.allowInsecure.includes(FEAT_FLAG)) {
+  if (!this.isFeatureEnabled(FEAT_FLAG)) {
     throw new Error(`Execute driver script functionality is not available ` +
                     `unless server is started with --allow-insecure including ` +
                     `the '${FEAT_FLAG}' flag, e.g., --allow-insecure=${FEAT_FLAG}`);

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -37,8 +37,8 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
     throw new Error(`Only the '${SCRIPT_TYPE_WDIO}' script type is currently supported`);
   }
 
-  if (!this.opts.host || !this.opts.port) {
-    throw new Error('Host or port of running server were not defined; this ' +
+  if (!this.opts.address || !this.opts.port) {
+    throw new Error('Address or port of running server were not defined; this ' +
                     'is required. This is probably a programming error in the driver');
   }
 
@@ -49,13 +49,14 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
   const driverOpts = {
     sessionId: this.sessionId,
     protocol: 'http', // Appium won't ever be behind ssl locally
-    hostname: this.opts.host,
+    hostname: this.opts.address,
     port: this.opts.port,
     path: BASE_PATH,
     isW3C: this.isW3CProtocol(),
     isMobile: true,
     capabilities: this.caps
   };
+  log.info(`Constructed webdriverio driver options; W3C mode is ${driverOpts.isW3C ? 'on' : 'off'}`);
 
 
   // fork the execution script as a child process

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -11,12 +11,17 @@ const SCRIPT_TYPE_WDIO = 'webdriverio';
 
 let commands = {};
 
-/*
- * TODO fill out entire docstring
- *
+/**
  * This method takes a string which is executed as javascript in the context of
  * a new nodejs VM, and which has available a webdriverio driver object, having
  * already been attached to the currently running session.
+ *
+ * @param {string} script - the string representing the driver script to run
+ * @param {string} [scriptType='webdriverio'] - the name of the driver script
+ * library (currently only webdriverio is supported)
+ *
+ * @returns {Object} - a JSONifiable object representing the return value of
+ * the script
  */
 commands.executeDriverScript = async function (script, scriptType = 'webdriverio') {
   if (!this.allowInsecure || !this.allowInsecure.includes(FEAT_FLAG)) {
@@ -48,7 +53,8 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
     hostname: this.opts.host,
     port: this.opts.port,
     path: BASE_PATH,
-    isW3C: true, // TODO should probably retrieve client protocol and declare the same one for the script
+    isW3C: this.isW3CProtocol(),
+    isMobile: true,
     capabilities: this.caps
   });
   const fullScript = buildScript(script);
@@ -57,17 +63,29 @@ commands.executeDriverScript = async function (script, scriptType = 'webdriverio
   return {result, logs};
 };
 
+/**
+ * Embed a user-generated script inside a method which takes only the
+ * predetermined objects we specify
+ *
+ * @param {string} script - the javascript to execute
+ *
+ * @return {string} - the full script to execute
+ */
 function buildScript (script) {
   return `(async function execute (driver, console) {
     ${script}
   })`;
 }
 
-/*
+/**
  * We can get any manner of crazy thing back from a vm executing untrusted
  * code. We might also get WebdriverIO objects that aren't suitable for JSON
  * response. So make sure we convert the things we know about to their
  * appropriate response format, and squash other weird things.
+ *
+ * @param {Object} obj - object to convert and sanitize
+ *
+ * @return {Object} - safely converted object
  */
 function coerceScriptResult (obj) {
   // first ensure obj is of a type that can be JSON encoded safely. This will
@@ -85,8 +103,8 @@ function coerceScriptResult (obj) {
   // now we begin our recursive case options
   if (_.isPlainObject(obj)) {
     // if we have an object, it's either an element object or something else
-    // TODO check whether webdriverio has any monadic object types other than
-    // element, for example window
+    // webdriverio has no monadic object types other than element and driver,
+    // and we don't want to allow special casing return of driver
     res = {};
 
     if (obj[MJSONWP_ELEMENT_KEY] || obj[W3C_ELEMENT_KEY]) {

--- a/lib/basedriver/commands/execute.js
+++ b/lib/basedriver/commands/execute.js
@@ -1,0 +1,112 @@
+import _ from 'lodash';
+import log from '../logger';
+import vm from 'vm';
+import { attach } from 'webdriverio';
+import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY } from '../../protocol/protocol';
+
+const BASE_PATH = '/wd/hub'; // TODO defining this here is brittle but it is hardcoded in routes, so...
+const FEAT_FLAG = 'execute-driver-script';
+const SCRIPT_TYPE_WDIO = 'webdriverio';
+// TODO add wd script type
+
+let commands = {};
+
+/*
+ * TODO fill out entire docstring
+ *
+ * This method takes a string which is executed as javascript in the context of
+ * a new nodejs VM, and which has available a webdriverio driver object, having
+ * already been attached to the currently running session.
+ */
+commands.executeDriverScript = async function (script, scriptType = 'webdriverio') {
+  if (!this.allowInsecure || !this.allowInsecure.includes(FEAT_FLAG)) {
+    throw new Error(`Execute driver script functionality is not available ` +
+                    `unless server is started with --allow-insecure including ` +
+                    `the '${FEAT_FLAG}' flag, e.g., --allow-insecure=${FEAT_FLAG}`);
+  }
+
+  if (scriptType !== SCRIPT_TYPE_WDIO) {
+    throw new Error(`Only the '${SCRIPT_TYPE_WDIO}' script type is currently supported`);
+  }
+
+  if (!this.opts.host || !this.opts.port) {
+    throw new Error('Host or port of running server were not defined; this ' +
+                    'is required. This is probably a programming error in the driver');
+  }
+
+  const driver = attach({
+    sessionId: this.sessionId,
+    protocol: 'http', // Appium won't ever be behind ssl locally
+    hostname: this.opts.host,
+    port: this.opts.port,
+    path: BASE_PATH,
+    isW3C: true, // TODO should probably retrieve client protocol and declare the same one for the script
+    capabilities: this.caps
+  });
+  const fullScript = buildScript(script);
+  const result = await vm.runInNewContext(fullScript)(driver);
+  return coerceScriptResult(result);
+};
+
+function buildScript (script) {
+  return `(async function execute (driver) {
+    ${script}
+  })`;
+}
+
+/*
+ * We can get any manner of crazy thing back from a vm executing untrusted
+ * code. We might also get WebdriverIO objects that aren't suitable for JSON
+ * response. So make sure we convert the things we know about to their
+ * appropriate response format, and squash other weird things.
+ */
+function coerceScriptResult (obj) {
+  // first ensure obj is of a type that can be JSON encoded safely. This will
+  // get rid of custom objects, functions, etc... and turn them into POJOs
+  try {
+    obj = JSON.parse(JSON.stringify(obj));
+  } catch (e) {
+    log.warn('Could not convert executeDriverScript to safe response!' +
+             `Result was: ${obj}. Will make it null`);
+    return null;
+  }
+
+  let res;
+
+  // now we begin our recursive case options
+  if (_.isPlainObject(obj)) {
+    // if we have an object, it's either an element object or something else
+    // TODO check whether webdriverio has any monadic object types other than
+    // element, for example window
+    res = {};
+
+    if (obj[MJSONWP_ELEMENT_KEY] || obj[W3C_ELEMENT_KEY]) {
+      // if it's an element object, clear out anything that's not the key, and
+      // then return the object
+      if (obj[MJSONWP_ELEMENT_KEY]) {
+        res[MJSONWP_ELEMENT_KEY] = obj[MJSONWP_ELEMENT_KEY];
+      }
+
+      if (obj[W3C_ELEMENT_KEY]) {
+        res[W3C_ELEMENT_KEY] = obj[W3C_ELEMENT_KEY];
+      }
+      return res;
+    }
+
+    // otherwise, recurse into the object
+    for (const key of Object.keys(obj)) {
+      res[key] = coerceScriptResult(obj[key]);
+    }
+    return res;
+  }
+
+  // in the cae of an array, just recurse into the items
+  if (_.isArray(obj)) {
+    return obj.map(i => coerceScriptResult(i));
+  }
+
+  // base case, if it's not an object or array, return straightaway
+  return obj;
+}
+
+export default commands;

--- a/lib/basedriver/commands/index.js
+++ b/lib/basedriver/commands/index.js
@@ -4,9 +4,11 @@ import timeoutCmds from './timeout';
 import findCmds from './find';
 import logCmds from './log';
 import imagesCmds from './images';
+import executeCmds from './execute';
 
 
 let commands = {};
+
 Object.assign(
   commands,
   sessionCmds,
@@ -15,6 +17,7 @@ Object.assign(
   findCmds,
   logCmds,
   imagesCmds,
+  executeCmds,
   // add other command types here
 );
 

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -35,6 +35,11 @@ class BaseDriver extends Protocol {
     this.caps = null;
     this.helpers = helpers;
 
+    // initialize security modes
+    this.relaxedSecurityEnabled = false;
+    this.allowInsecure = [];
+    this.denyInsecure = [];
+
     // timeout initialization
     this.newCommandTimeoutMs = NEW_COMMAND_TIMEOUT_MS;
     this.implicitWaitMs = 0;
@@ -269,6 +274,22 @@ class BaseDriver extends Protocol {
 
     // if we haven't allowed anything insecure, then reject
     return false;
+  }
+
+  /**
+   * Assert that a given feature is enabled and throw a helpful error if it's
+   * not
+   *
+   * @param {string} name - name of feature/command
+   */
+  ensureFeatureEnabled (name) {
+    if (!this.isFeatureEnabled(name)) {
+      throw new Error(`Potentially insecure feature '${name}' has not been ` +
+                      `enabled. If you want to enable this feature and accept ` +
+                      `the security ramifications, please do so by following ` +
+                      `the documented instructions at https://github.com/appium` +
+                      `/appium/blob/master/docs/en/writing-running-appium/security.md`);
+    }
   }
 
   // This is the main command handler for the driver. It wraps command

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -271,7 +271,7 @@ class BaseDriver extends Protocol {
     }
 
     let res;
-    if (this.isCommandsQueueEnabled) {
+    if (this.isCommandsQueueEnabled && cmd !== 'executeDriverScript') {
       // What we're doing here is pretty clever. this.curCommand is always
       // a promise representing the command currently being executed by the
       // driver, or the last command executed by the driver (it starts off as
@@ -317,6 +317,11 @@ class BaseDriver extends Protocol {
       this.curCommand = nextCommand.catch(() => {});
       res = await nextCommand;
     } else {
+      // If we've gotten here because we're running executeDriverScript, we
+      // never want to add the command to the queue. This is because it runs
+      // other commands _inside_ it, so those commands would never start if we
+      // were waiting for executeDriverScript to finish. So it is a special
+      // case.
       if (this.shutdownUnexpectedly) {
         throw new errors.NoSuchDriverError('The driver was unexpectedly shut down!');
       }

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -243,6 +243,34 @@ class BaseDriver extends Protocol {
       BaseDriver.DRIVER_PROTOCOL.MJSONWP;
   }
 
+  /**
+   * Check whether a given feature is enabled via its name
+   *
+   * @param {string} name - name of feature/command
+   *
+   * @returns {Boolean}
+   */
+  isFeatureEnabled (name) {
+    // if we have explicitly denied this feature, return false immediately
+    if (this.denyInsecure && _.includes(this.denyInsecure, name)) {
+      return false;
+    }
+
+    // if we specifically have allowed the feature, return true
+    if (this.allowInsecure && _.includes(this.allowInsecure, name)) {
+      return true;
+    }
+
+    // otherwise, if we've globally allowed insecure features and not denied
+    // this one, return true
+    if (this.relaxedSecurityEnabled) {
+      return true;
+    }
+
+    // if we haven't allowed anything insecure, then reject
+    return false;
+  }
+
   // This is the main command handler for the driver. It wraps command
   // execution with timeout logic, checking that we have a valid session,
   // and ensuring that we execute commands one at a time. This method is called

--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -567,6 +567,9 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/receive_async_response': {
     POST: {command: 'receiveAsyncResponse', payloadParams: {required: ['response']}}
   },
+  '/wd/hub/session/:sessionId/appium/execute_driver': {
+    POST: {command: 'executeDriverScript', payloadParams: {required: ['script'], optional: ['type']}}
+  },
 
 
   /*

--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -568,7 +568,7 @@ const METHOD_MAP = {
     POST: {command: 'receiveAsyncResponse', payloadParams: {required: ['response']}}
   },
   '/wd/hub/session/:sessionId/appium/execute_driver': {
-    POST: {command: 'executeDriverScript', payloadParams: {required: ['script'], optional: ['type']}}
+    POST: {command: 'executeDriverScript', payloadParams: {required: ['script'], optional: ['type', 'timeout']}}
   },
 
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "source-map-support": "^0.5.5",
     "uuid-js": "^0.7.5",
     "validate.js": "^0.13.0",
-    "webdriverio": "^5.9.6",
+    "webdriverio": "^5.10.9",
     "ws": "^7.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "source-map-support": "^0.5.5",
     "uuid-js": "^0.7.5",
     "validate.js": "^0.13.0",
+    "webdriverio": "^5.9.6",
     "ws": "^7.0.0"
   },
   "scripts": {

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -8,7 +8,7 @@ import B from 'bluebird';
 
 const should = chai.should();
 const DEFAULT_ARGS = {
-  host: 'localhost',
+  address: 'localhost',
   port: 8181
 };
 chai.use(chaiAsPromised);

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -310,7 +310,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         });
         const expectedTimeouts = {command: 250, implicit: 0};
         const expectedStatus = {};
-        res.value.should.eql([expectedTimeouts, expectedStatus]);
+        res.value.result.should.eql([expectedTimeouts, expectedStatus]);
         await endSession(sessionId);
       });
 
@@ -335,7 +335,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           method: 'POST',
           json: {script},
         });
-        res.value.should.eql({
+        res.value.result.should.eql({
           [W3C_ELEMENT_KEY]: 'element-id-1',
           [MJSONWP_ELEMENT_KEY]: 'element-id-1'
         });
@@ -357,7 +357,25 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           [W3C_ELEMENT_KEY]: 'element-id-1',
           [MJSONWP_ELEMENT_KEY]: 'element-id-1'
         };
-        res.value.should.eql({element: elObj, elements: [elObj, elObj]});
+        res.value.result.should.eql({element: elObj, elements: [elObj, elObj]});
+        await endSession(sessionId);
+      });
+
+      it('should store and return logs to the user', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `
+          console.log("foo");
+          console.log("foo2");
+          console.warn("bar");
+          console.error("baz");
+          return null;
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script},
+        });
+        res.value.logs.should.eql({log: ['foo', 'foo2'], warn: ['bar'], error: ['baz']});
         await endSession(sessionId);
       });
 

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -401,7 +401,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         res.should.eql({
           sessionId,
           status: 13,
-          value: {message: 'An unknown server-side error occurred while processing the command. Original error: not found'}
+          value: {message: 'An unknown server-side error occurred while processing the command. Original error: Could not execute driver script. Original error was: Error: not found'}
         });
       });
 
@@ -418,8 +418,22 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         res.should.eql({
           sessionId,
           status: 13,
-          value: {message: 'An unknown server-side error occurred while processing the command. Original error: SyntaxError: Unexpected token ;'}
+          value: {message: 'An unknown server-side error occurred while processing the command. Original error: Could not execute driver script. Original error was: Error: Unexpected token ;'}
         });
+      });
+
+      it('should be able to set a timeout on a driver script', async function () {
+        const script = `
+          await Promise.delay(1000);
+          return true;
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script, timeout: 50},
+          simple: false,
+        });
+        res.value.message.should.match(/.+50.+timeout.+/);
       });
     });
   });

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -1,18 +1,23 @@
 import _ from 'lodash';
-import { server, routeConfiguringFunction, DeviceSettings } from '../..';
+import { server, routeConfiguringFunction, DeviceSettings, errors } from '../..';
+import { W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY } from '../../lib/protocol/protocol';
 import request from 'request-promise';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 
 const should = chai.should();
+const DEFAULT_ARGS = {
+  host: 'localhost',
+  port: 8181
+};
 chai.use(chaiAsPromised);
 
 function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
   describe('BaseDriver (e2e)', function () {
-    let baseServer, d = new DriverClass();
+    let baseServer, d = new DriverClass(DEFAULT_ARGS);
     before(async function () {
-      baseServer = await server(routeConfiguringFunction(d), 8181);
+      baseServer = await server(routeConfiguringFunction(d), DEFAULT_ARGS.port);
     });
     after(async function () {
       await baseServer.close();
@@ -77,20 +82,31 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
     });
 
     describe('command timeouts', function () {
+      let originalFindElement, originalFindElements;
       function startTimeoutSession (timeout) {
         let caps = _.clone(defaultCaps);
         caps.newCommandTimeout = timeout;
         return startSession(caps);
       }
 
-      d.findElement = function () {
-        return 'foo';
-      }.bind(d);
+      before(function () {
+        originalFindElement = d.findElement;
+        d.findElement = function () {
+          return 'foo';
+        }.bind(d);
 
-      d.findElements = async function () {
-        await B.delay(200);
-        return ['foo'];
-      }.bind(d);
+        originalFindElements = d.findElements;
+        d.findElements = async function () {
+          await B.delay(200);
+          return ['foo'];
+        }.bind(d);
+      });
+
+      after(function () {
+        d.findElement = originalFindElement;
+        d.findElements = originalFindElements;
+      });
+
 
       it('should set a default commandTimeout', async function () {
         let newSession = await startTimeoutSession();
@@ -222,6 +238,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         res.status.should.equal(13);
         res.value.message.should.contain('Crashytimes');
         await d.onUnexpectedShutdown.should.be.rejectedWith('Crashytimes');
+        d.getStatus = d._oldGetStatus;
       });
     });
 
@@ -242,6 +259,144 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         res.events.newSessionRequested[0].should.be.a('number');
         res.events.newSessionStarted[0].should.be.a('number');
         await endSession(session.sessionId);
+      });
+    });
+
+    describe('execute driver script', function () {
+      // mock some methods on BaseDriver that aren't normally there except in
+      // a fully blown driver
+      let originalFindElement;
+      before(function () {
+        d.allowInsecure = ['execute-driver-script'];
+        originalFindElement = d.findElement;
+        d.findElement = (function (strategy, selector) {
+          if (strategy === 'accessibility id' && selector === 'amazing') {
+            return {[W3C_ELEMENT_KEY]: 'element-id-1'};
+          }
+
+          throw new errors.NoSuchElementError('not found');
+        }).bind(d);
+      });
+
+      after(function () {
+        d.findElement = originalFindElement;
+      });
+
+      it('should not work unless the allowInsecure feature flag is set', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        d._allowInsecure = d.allowInsecure;
+        d.allowInsecure = [];
+        const script = `return 'foo'`;
+        await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script, type: 'wd'},
+        }).should.eventually.be.rejectedWith(/allow-insecure/);
+        await endSession(sessionId);
+        d.allowInsecure = d._allowInsecure;
+      });
+
+      it('should execute a webdriverio script in the context of session', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `
+          const timeouts = await driver.getTimeouts();
+          const status = await driver.status();
+          return [timeouts, status];
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script, type: 'webdriverio'},
+        });
+        const expectedTimeouts = {command: 250, implicit: 0};
+        const expectedStatus = {};
+        res.value.should.eql([expectedTimeouts, expectedStatus]);
+        await endSession(sessionId);
+      });
+
+      it('should fail with any script type other than webdriverio currently', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `return 'foo'`;
+        await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script, type: 'wd'},
+        }).should.eventually.be.rejectedWith(/script type/);
+        await endSession(sessionId);
+      });
+
+      it('should execute a webdriverio script that returns elements correctly', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `
+          return await driver.$("~amazing");
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script},
+        });
+        res.value.should.eql({
+          [W3C_ELEMENT_KEY]: 'element-id-1',
+          [MJSONWP_ELEMENT_KEY]: 'element-id-1'
+        });
+        await endSession(sessionId);
+      });
+
+      it('should execute a webdriverio script that returns elements in deep structure', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `
+          const el = await driver.$("~amazing");
+          return {element: el, elements: [el, el]};
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script},
+        });
+        const elObj = {
+          [W3C_ELEMENT_KEY]: 'element-id-1',
+          [MJSONWP_ELEMENT_KEY]: 'element-id-1'
+        };
+        res.value.should.eql({element: elObj, elements: [elObj, elObj]});
+        await endSession(sessionId);
+      });
+
+      it('should correctly handle errors that happen in a webdriverio script', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `
+          return await driver.$("~notfound");
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script},
+          simple: false,
+        });
+        res.should.eql({
+          sessionId,
+          status: 13,
+          value: {message: 'An unknown server-side error occurred while processing the command. Original error: not found'}
+        });
+        await endSession(sessionId);
+      });
+
+      it('should correctly handle errors that happen when a script cannot be compiled', async function () {
+        let {sessionId} = await startSession(defaultCaps);
+        const script = `
+          return {;
+        `;
+        const res = await request({
+          url: `http://localhost:8181/wd/hub/session/${sessionId}/appium/execute_driver`,
+          method: 'POST',
+          json: {script},
+          simple: false,
+        });
+        res.should.eql({
+          sessionId,
+          status: 13,
+          value: {message: 'An unknown server-side error occurred while processing the command. Original error: SyntaxError: Unexpected token ;'}
+        });
+        await endSession(sessionId);
       });
     });
 

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -267,7 +267,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
       // a fully blown driver
       let originalFindElement, sessionId;
       before(function () {
-        d.allowInsecure = ['execute-driver-script'];
+        d.allowInsecure = ['execute_driver_script'];
         originalFindElement = d.findElement;
         d.findElement = (function (strategy, selector) {
           if (strategy === 'accessibility id' && selector === 'amazing') {

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -487,6 +487,51 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       d1._settings.should.not.eql(d2._settings);
     });
   });
+
+  describe('.isFeatureEnabled', function () {
+    const d = new DriverClass();
+
+    afterEach(function () {
+      d.denyInsecure = null;
+      d.allowInsecure = null;
+      d.relaxedSecurityEnabled = null;
+    });
+
+    it('should say a feature is enabled when it is explicitly allowed', function () {
+      d.allowInsecure = ['foo', 'bar'];
+      d.isFeatureEnabled('foo').should.be.true;
+      d.isFeatureEnabled('bar').should.be.true;
+      d.isFeatureEnabled('baz').should.be.false;
+    });
+
+    it('should say a feature is not enabled if it is not enabled', function () {
+      d.allowInsecure = [];
+      d.isFeatureEnabled('foo').should.be.false;
+    });
+
+    it('should prefer denyInsecure to allowInsecure', function () {
+      d.allowInsecure = ['foo', 'bar'];
+      d.denyInsecure = ['foo'];
+      d.isFeatureEnabled('foo').should.be.false;
+      d.isFeatureEnabled('bar').should.be.true;
+      d.isFeatureEnabled('baz').should.be.false;
+    });
+
+    it('should allow global setting for insecurity', function () {
+      d.relaxedSecurityEnabled = true;
+      d.isFeatureEnabled('foo').should.be.true;
+      d.isFeatureEnabled('bar').should.be.true;
+      d.isFeatureEnabled('baz').should.be.true;
+    });
+
+    it('global setting should be overrideable', function () {
+      d.relaxedSecurityEnabled = true;
+      d.denyInsecure = ['foo', 'bar'];
+      d.isFeatureEnabled('foo').should.be.false;
+      d.isFeatureEnabled('bar').should.be.false;
+      d.isFeatureEnabled('baz').should.be.true;
+    });
+  });
 }
 
 export default baseDriverUnitTests;

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('45227bff');
+      hash.should.equal('14d87e3b');
     });
   });
 

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('8275cc4e');
+      hash.should.equal('45227bff');
     });
   });
 


### PR DESCRIPTION
The [batch command proposal](https://github.com/appium/appium/issues/11021) has been under discussion for some time. To summarize, the original proposal was for a new API that would essentially allow encoding of any Appium command in JSON format, including the use of magic values like `{{<element}}` to refer to an element found in a previous command. This original proposal had several drawbacks:

1. Quite a lot of code would need to be written on both client and server to support the feature. Most of the code would just be encoding/decoding commands from a JSON format.
2. This method interacts poorly with proxying, which is quite common in Appium tests. Say that a batched command set came in involving a context switch, such that subsequent commands in the batch are supposed to target chromedriver. The problem is that the batch command itself would be written on the driver, which can only awkwardly proxy it on.
3. Use of backreferences is just one example of all kinds of logic that users might wish to encode in batch commands, and be unable to. How would we handle conditionals, loops, and the like? We'd need to draw a line somewhere or invent a Turing complete mini language to support all the use cases!

This PR takes a much more radical approach. Basically, it asks that the user send in not a formatted list of commands, but rather a script (written in a supported library, in this case webdriverio). This script is run in a NodeJS VM with access to a driver object representing the current session. This proposal has a number of advantages:

1. Access to a full webdriver client
2. Access to a full programming language (JS) for use of logic
3. Very little code needing to be written on the client side (the Appium Java client would just assume someone will write a webdriverio script as a string. Or, the Java client could go crazy and implement a code transformation feature that outputs valid webdriverio code. Either way).
4. Very little code needing to be written on the server side. I think this PR is all that's necessary!

The main disadvantages of this new proposal are:

1. Theoretical security concerns running untrusted code. However, the code is sandboxed in a VM, and has no access to e.g. the `require` function. I'm having trouble thinking how a malicious user could abuse this feature, but it's possible I suppose.
2. We bring in a webdriver client (webdriverio) as a production dep. Thankfully it's not too big. In the future, this feature and its deps could be developed as a plugin/extension rather than part of Appium core.

I think this is pretty sweet, what do you all think?