### PR TITLE
Update the logic that determines the session protocol

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -185,6 +185,11 @@ class JWProxy {
         this.downstreamProtocol = this.getProtocolFromResBody(resObj);
         log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}'`);
       } else if (isSessionCreationRequest) {
+        // It might be that we proxy API calls to the downstream driver
+        // without creating a session first
+        // and it responds using the default proto,
+        // but then after createSession request is sent the internal proto is changed
+        // to the other one based on the actually provided caps
         const previousValue = this.downstreamProtocol;
         this.downstreamProtocol = this.getProtocolFromResBody(resObj);
         if (previousValue && previousValue !== this.downstreamProtocol) {

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -177,12 +177,23 @@ class JWProxy {
           length: LOG_OBJ_LENGTH,
         })
       );
-      if (/\/session$/.test(url) && method === 'POST' && res.statusCode === 200) {
+      const isSessionCreationRequest = /\/session$/.test(url) && method === 'POST';
+      if (isSessionCreationRequest && res.statusCode === 200) {
         this.sessionId = resObj.sessionId;
       }
       if (!this.downstreamProtocol) {
         this.downstreamProtocol = this.getProtocolFromResBody(resObj);
-        log.debug(`Determined the downstream protocol for the proxy as '${this.downstreamProtocol}'`);
+        log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}'`);
+      } else if (isSessionCreationRequest) {
+        const previousValue = this.downstreamProtocol;
+        this.downstreamProtocol = this.getProtocolFromResBody(resObj);
+        if (previousValue && previousValue !== this.downstreamProtocol) {
+          log.debug(`Updated the downstream protocol to '${this.downstreamProtocol}' ` +
+            `as per session creation request`);
+        } else {
+          log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}' ` +
+            `per session creation request`);
+        }
       }
       if (res.statusCode < 400 && this.downstreamProtocol === MJSONWP &&
         _.has(resObj, 'status') && parseInt(resObj.status, 10) !== 0) {


### PR DESCRIPTION
It might be that we proxy /status call first to the downstream driver and it responds in W3C style (since this is a default setting), but then after createSession request is sent the photo is changed to JSONWP based on the provided caps. This change should properly handle such scenario.