### PR TITLE
Improve the logic of proxyReqRes method

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -166,8 +166,8 @@ class JWProxy {
       const res = await this.request(reqOpts);
       // `res.body` might be really big
       // Be careful while handling it to avoid memory leaks
-      const resObj = util.safeJsonParse(res.body);
-      if (!_.isPlainObject(resObj)) {
+      const resBodyObj = util.safeJsonParse(res.body);
+      if (!_.isPlainObject(resBodyObj)) {
         // The response should be a valid JSON object
         // If it cannot be coerced to an object then the response is wrong
         throwProxyError(res.body);
@@ -179,10 +179,10 @@ class JWProxy {
       );
       const isSessionCreationRequest = /\/session$/.test(url) && method === 'POST';
       if (isSessionCreationRequest && res.statusCode === 200) {
-        this.sessionId = resObj.sessionId;
+        this.sessionId = resBodyObj.sessionId;
       }
       if (!this.downstreamProtocol) {
-        this.downstreamProtocol = this.getProtocolFromResBody(resObj);
+        this.downstreamProtocol = this.getProtocolFromResBody(resBodyObj);
         log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}'`);
       } else if (isSessionCreationRequest) {
         // It might be that we proxy API calls to the downstream driver
@@ -191,7 +191,7 @@ class JWProxy {
         // but then after createSession request is sent the internal proto is changed
         // to the other one based on the actually provided caps
         const previousValue = this.downstreamProtocol;
-        this.downstreamProtocol = this.getProtocolFromResBody(resObj);
+        this.downstreamProtocol = this.getProtocolFromResBody(resBodyObj);
         if (previousValue && previousValue !== this.downstreamProtocol) {
           log.debug(`Updated the downstream protocol to '${this.downstreamProtocol}' ` +
             `as per session creation request`);
@@ -201,11 +201,11 @@ class JWProxy {
         }
       }
       if (res.statusCode < 400 && this.downstreamProtocol === MJSONWP &&
-        _.has(resObj, 'status') && parseInt(resObj.status, 10) !== 0) {
+        _.has(resBodyObj, 'status') && parseInt(resBodyObj.status, 10) !== 0) {
         // Some servers, like chromedriver may return response code 200 for non-zero JSONWP statuses
-        throwProxyError(resObj);
+        throwProxyError(resBodyObj);
       }
-      return [res, resObj];
+      return [res, resBodyObj];
     } catch (e) {
       if (util.hasValue(e.error)) {
         log.warn(`Got an unexpected response: ` +
@@ -254,24 +254,24 @@ class JWProxy {
 
   async command (url, method, body = null) {
     let response;
-    let resObj;
+    let resBodyObj;
     try {
-      [response, resObj] = await this.proxyCommand(url, method, body);
+      [response, resBodyObj] = await this.proxyCommand(url, method, body);
     } catch (err) {
       if (isErrorType(err, errors.ProxyRequestError)) {
         throw err.getActualError();
       }
       throw new errors.UnknownError(err.message);
     }
-    const protocol = this.getProtocolFromResBody(resObj);
+    const protocol = this.getProtocolFromResBody(resBodyObj);
     if (protocol === MJSONWP) {
       // Got response in MJSONWP format
-      if (response.statusCode === 200 && resObj.status === 0) {
-        return resObj.value;
+      if (response.statusCode === 200 && resBodyObj.status === 0) {
+        return resBodyObj.value;
       }
-      const status = parseInt(resObj.status, 10);
+      const status = parseInt(resBodyObj.status, 10);
       if (!isNaN(status) && status !== 0) {
-        let message = resObj.value;
+        let message = resBodyObj.value;
         if (_.has(message, 'message')) {
           message = message.message;
         }
@@ -280,17 +280,17 @@ class JWProxy {
     } else if (protocol === W3C) {
       // Got response in W3C format
       if (response.statusCode < 300) {
-        return resObj.value;
+        return resBodyObj.value;
       }
-      if (_.isPlainObject(resObj.value) && resObj.value.error) {
-        throw errorFromW3CJsonCode(resObj.value.error, resObj.value.message, resObj.value.stacktrace);
+      if (_.isPlainObject(resBodyObj.value) && resBodyObj.value.error) {
+        throw errorFromW3CJsonCode(resBodyObj.value.error, resBodyObj.value.message, resBodyObj.value.stacktrace);
       }
     } else if (response.statusCode === 200) {
       // Unknown protocol. Keeping it because of the backward compatibility
-      return resObj;
+      return resBodyObj;
     }
     throw new errors.UnknownError(`Did not know what to do with response code '${response.statusCode}' ` +
-                                  `and response body '${_.truncate(JSON.stringify(resObj), {length: 300})}'`);
+                                  `and response body '${_.truncate(JSON.stringify(resBodyObj), {length: 300})}'`);
   }
 
   getSessionIdFromUrl (url) {
@@ -299,25 +299,28 @@ class JWProxy {
   }
 
   async proxyReqRes (req, res) {
-    let [response, body] = await this.proxyCommand(req.originalUrl, req.method, req.body);
+    const [response, resBodyObj] = await this.proxyCommand(req.originalUrl, req.method, req.body);
 
     res.headers = response.headers;
     res.set('content-type', response.headers['content-type']);
     // if the proxied response contains a sessionId that the downstream
     // driver has generated, we don't want to return that to the client.
     // Instead, return the id from the request or from current session
-    body = util.safeJsonParse(body);
-    if (body && body.sessionId) {
+    let isResBodyModified = false;
+    if (_.has(resBodyObj, 'sessionId')) {
       const reqSessionId = this.getSessionIdFromUrl(req.originalUrl);
       if (reqSessionId) {
-        log.info(`Replacing sessionId ${body.sessionId} with ${reqSessionId}`);
-        body.sessionId = reqSessionId;
+        log.info(`Replacing sessionId ${resBodyObj.sessionId} with ${reqSessionId}`);
+        resBodyObj.sessionId = reqSessionId;
+        isResBodyModified = true;
       } else if (this.sessionId) {
-        log.info(`Replacing sessionId ${body.sessionId} with ${this.sessionId}`);
-        body.sessionId = this.sessionId;
+        log.info(`Replacing sessionId ${resBodyObj.sessionId} with ${this.sessionId}`);
+        resBodyObj.sessionId = this.sessionId;
+        isResBodyModified = true;
       }
     }
-    res.status(response.statusCode).send(JSON.stringify(body));
+    res.status(response.statusCode)
+      .send(isResBodyModified ? JSON.stringify(resBodyObj) : response.body);
   }
 }
 


### PR DESCRIPTION
`proxyCommand` call already returns an object, so there is no need to perform double conversion there. Also, it only makes sense to call stringily if the body object has been modified to save resources.  