### PR TITLE
Handle Content-Type with parameter

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -110,7 +110,7 @@ async function configureApp (app, supportedAppExtensions) {
       if (headers['content-type']) {
         logger.debug(`Content-Type: ${headers['content-type']}`);
         // the filetype may not be obvious for certain urls, so check the mime type too
-        if (ZIP_MIME_TYPES.includes(headers['content-type'])) {
+        if (ZIP_MIME_TYPES.some(mimeType => new RegExp(`\\b${_.escapeRegExp(mimeType)}\\b`).test(headers['content-type']))) {
           if (!fileName) {
             fileName = `${DEFAULT_BASENAME}.zip`;
           }


### PR DESCRIPTION
Hey there,

I figured out HockeyApp responds with `Content-Type: application/zip; charset=utf-8` (which I agree makes no sense). I suggest we relax the Content-Type header test to handle such cases.