### PR TITLE
feat: Allow CORS for receiving async responses

### DIFF
--- a/lib/express/middleware.js
+++ b/lib/express/middleware.js
@@ -18,6 +18,16 @@ function allowCrossDomain (req, res, next) {
   next();
 }
 
+function allowCrossDomainAsyncExecute (req, res, next) {
+  // there are two paths for async responses, so cover both
+  // https://regex101.com/r/txYiEz/1
+  const receiveAsyncResponseRegExp = new RegExp(`(/wd/hub)?/session/[a-f0-9-]+/(appium/)?receive_async_response`);
+  if (!receiveAsyncResponseRegExp.test(req.url)) {
+    return next();
+  }
+  allowCrossDomain(req, res, next);
+}
+
 function fixPythonContentType (req, res, next) {
   // hack because python client library gives us wrong content-type
   if (/^\/wd/.test(req.path) && /^Python/.test(req.headers['user-agent'])) {
@@ -69,4 +79,8 @@ function catch404Handler (req, res) {
   res.status(404).send(`The URL '${req.originalUrl}' did not map to a valid resource`);
 }
 
-export { allowCrossDomain, fixPythonContentType, defaultToJSONContentType, catchAllHandler, catch404Handler, catch4XXHandler };
+export {
+  allowCrossDomain, fixPythonContentType, defaultToJSONContentType,
+  catchAllHandler, catch404Handler, catch4XXHandler,
+  allowCrossDomainAsyncExecute,
+};

--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -7,7 +7,8 @@ import methodOverride from 'method-override';
 import log from './logger';
 import { startLogFormatter, endLogFormatter } from './express-logging';
 import { allowCrossDomain, fixPythonContentType, defaultToJSONContentType,
-         catchAllHandler, catch404Handler, catch4XXHandler } from './middleware';
+         catchAllHandler, catch404Handler, catch4XXHandler,
+         allowCrossDomainAsyncExecute} from './middleware';
 import { guineaPig, guineaPigScrollable, guineaPigAppBanner, welcome, STATIC_DIR } from './static';
 import { produceError, produceCrash } from './crash';
 import { addWebSocketHandler, removeWebSocketHandler, removeAllWebSocketHandlers,
@@ -17,7 +18,7 @@ import B from 'bluebird';
 
 async function server (configureRoutes, port, hostname = null, allowCors = true) {
   // create the actual http server
-  let app = express();
+  const app = express();
   let httpServer = http.createServer(app);
   httpServer.addWebSocketHandler = addWebSocketHandler;
   httpServer.removeWebSocketHandler = removeWebSocketHandler;
@@ -26,7 +27,7 @@ async function server (configureRoutes, port, hostname = null, allowCors = true)
 
   // http.Server.close() only stops new connections, but we need to wait until
   // all connections are closed and the `close` event is emitted
-  let close = httpServer.close.bind(httpServer);
+  const close = httpServer.close.bind(httpServer);
   httpServer.close = async () => {
     return await new B((resolve, reject) => {
       httpServer.on('close', resolve);
@@ -83,6 +84,8 @@ function configureServer (app, configureRoutes, allowCors = true) {
   // add middlewares
   if (allowCors) {
     app.use(allowCrossDomain);
+  } else {
+    app.use(allowCrossDomainAsyncExecute);
   }
   app.use(fixPythonContentType);
   app.use(defaultToJSONContentType);


### PR DESCRIPTION
Last fall CORS was turned off by default for the Appium server. This was a good thing, security-wise. However, it meant that async script execution in web contexts would fail unless it was turned on _everywhere_.