### PR TITLE
Fix WinAppDriver's missing "value" property issue

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -172,6 +172,11 @@ class JWProxy {
         // If it cannot be coerced to an object then the response is wrong
         throwProxyError(res.body);
       }
+      // add 'value' property if missing, to comply with W3C standard
+      // fixes missing 'value' property issue in WinAppDriver: https://github.com/webdriverio/webdriverio/issues/3807
+      if (!_.has(resObj, 'value')) {
+        resObj.value = null;
+      }
       log.debug(`Got response with status ${res.statusCode}: ` +
         _.truncate(_.isString(res.body) ? res.body : JSON.stringify(res.body), {
           length: LOG_OBJ_LENGTH,


### PR DESCRIPTION
Add 'value' property to the response body's JSON, if no 'value' property was received in the original response.