### PR TITLE
feat: accept text for setValueImmediate and replaceValue as W3C

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -555,10 +555,26 @@ const METHOD_MAP = {
     POST: {command: 'getStrings', payloadParams: {optional: ['language', 'stringFile']}}
   },
   '/wd/hub/session/:sessionId/appium/element/:elementId/value': {
-    POST: {command: 'setValueImmediate', payloadParams: {required: ['value']}}
+    POST: {command: 'setValueImmediate', payloadParams: {
+      validate: (jsonObj) => (!util.hasValue(jsonObj.value) && !util.hasValue(jsonObj.text)) &&
+          'we require one of "text" or "value" params',
+      optional: ['value', 'text'],
+      // We want to either a value (old JSONWP) or a text (new W3C) parameter,
+      // but only send one of them to the command (not both).
+      // Prefer 'value' since it's more backward-compatible.
+      makeArgs: (jsonObj) => [jsonObj.value || jsonObj.text],
+    }}
   },
   '/wd/hub/session/:sessionId/appium/element/:elementId/replace_value': {
-    POST: {command: 'replaceValue', payloadParams: {required: ['value']}}
+    POST: {command: 'replaceValue', payloadParams: {
+      validate: (jsonObj) => (!util.hasValue(jsonObj.value) && !util.hasValue(jsonObj.text)) &&
+          'we require one of "text" or "value" params',
+      optional: ['value', 'text'],
+      // We want to either a value (old JSONWP) or a text (new W3C) parameter,
+      // but only send one of them to the command (not both).
+      // Prefer 'value' since it's more backward-compatible.
+      makeArgs: (jsonObj) => [jsonObj.value || jsonObj.text],
+    }}
   },
   '/wd/hub/session/:sessionId/appium/settings': {
     POST: {command: 'updateSettings', payloadParams: {required: ['settings']}},

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('14d87e3b');
+      hash.should.equal('009052aa');
     });
   });
 


### PR DESCRIPTION
Will update param in https://github.com/appium/appium/blob/0500ce828789f0bc0e91e39183db7189195c8ec9/commands-yml/commands/element/attributes/replace-value.yml later (and setValueImmediate)

As `sendKeys`, we can accept both value and text as MJSONWP and W3C.
We also can accept them in replaceValue and setValueImmediate like https://github.com/appium/appium-espresso-driver/pull/484