### PR TITLE
fix: Properly log request errors

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -121,8 +121,8 @@ class JWProxy {
   async proxy (url, method, body = null) {
     method = method.toUpperCase();
     const newUrl = this.getUrlForProxy(url);
-    const truncateBody = (bodyStr) => _.truncate(
-      _.isString(bodyStr) ? bodyStr : JSON.stringify(bodyStr),
+    const truncateBody = (content) => _.truncate(
+      _.isString(content) ? content : JSON.stringify(content),
       { length: LOG_OBJ_LENGTH });
     const reqOpts = {
       agent: false,

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -210,11 +210,22 @@ class JWProxy {
       }
       return [res, resBodyObj];
     } catch (e) {
-      if (util.hasValue(e.error)) {
-        log.warn(`Got an unexpected response: ` +
-          _.truncate(_.isString(e.error) ? e.error : JSON.stringify(e.error), {length: LOG_OBJ_LENGTH}));
-      } else {
+      // We only consider an error unexpected if this was not
+      // an async request module error or if the response cannot be cast to
+      // a valid JSON
+      if (!util.hasValue(e.error)) {
+        log.warn(e.message);
         log.debug(e.stack);
+      } else {
+        const truncatedErrorMessage = _.truncate(_.isString(e.error) ? e.error : JSON.stringify(e.error), {
+          length: LOG_OBJ_LENGTH
+        });
+        if (!(_.isPlainObject(e.error) || ['[', '{'].some((x) => `${e.error}`.trim().startsWith(x)))) {
+          log.warn(`Got an unexpected response: ${truncatedErrorMessage}`);
+          log.debug(e.stack);
+        } else {
+          log.debug(`Got response with status ${e.statusCode}: ${truncatedErrorMessage}`);
+        }
       }
       throw new errors.ProxyRequestError(`Could not proxy command to remote server. ` +
         `Original error: ${e.message}`, e.error, e.statusCode);

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -167,10 +167,8 @@ class JWProxy {
     };
     let isResponseLogged = false;
     const truncateResponseBody = (responseBody) => _.truncate(
-      _.isString(responseBody) ? responseBody : JSON.stringify(responseBody), {
-        length: LOG_OBJ_LENGTH,
-      }
-    );
+      _.isString(responseBody) ? responseBody : JSON.stringify(responseBody),
+      { length: LOG_OBJ_LENGTH });
     try {
       const res = await this.request(reqOpts);
       // `res.body` might be really big

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -165,6 +165,12 @@ class JWProxy {
       err.statusCode = 500;
       throw err;
     };
+    let isResponseLogged = false;
+    const truncateResponseBody = (responseBody) => _.truncate(
+      _.isString(responseBody) ? responseBody : JSON.stringify(responseBody), {
+        length: LOG_OBJ_LENGTH,
+      }
+    );
     try {
       const res = await this.request(reqOpts);
       // `res.body` might be really big
@@ -175,11 +181,8 @@ class JWProxy {
         // If it cannot be coerced to an object then the response is wrong
         throwProxyError(res.body);
       }
-      log.debug(`Got response with status ${res.statusCode}: ` +
-        _.truncate(_.isString(res.body) ? res.body : JSON.stringify(res.body), {
-          length: LOG_OBJ_LENGTH,
-        })
-      );
+      log.debug(`Got response with status ${res.statusCode}: ${truncateResponseBody(res.body)}`);
+      isResponseLogged = true;
       const isSessionCreationRequest = /\/session$/.test(url) && method === 'POST';
       if (isSessionCreationRequest && res.statusCode === 200) {
         this.sessionId = resBodyObj.sessionId;
@@ -217,14 +220,12 @@ class JWProxy {
         log.warn(e.message);
         log.debug(e.stack);
       } else {
-        const truncatedErrorMessage = _.truncate(_.isString(e.error) ? e.error : JSON.stringify(e.error), {
-          length: LOG_OBJ_LENGTH
-        });
         if (!(_.isPlainObject(e.error) || ['[', '{'].some((x) => `${e.error}`.trim().startsWith(x)))) {
-          log.warn(`Got an unexpected response: ${truncatedErrorMessage}`);
+          log.warn(`Got an unexpected response: ${truncateResponseBody(e.error)}`);
           log.debug(e.stack);
-        } else {
-          log.debug(`Got response with status ${e.statusCode}: ${truncatedErrorMessage}`);
+        } else if (!isResponseLogged) {
+          log.debug(`Got response with status ${e.statusCode}: ${truncateResponseBody(e.error)}`);
+          isResponseLogged = true;
         }
       }
       throw new errors.ProxyRequestError(`Could not proxy command to remote server. ` +

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -219,7 +219,7 @@ class JWProxy {
         log.warn(e.message);
         log.debug(e.stack);
       } else {
-        if (!(_.isPlainObject(e.error) || ['[', '{'].some((x) => `${e.error}`.trim().startsWith(x)))) {
+        if (!(_.isPlainObject(e.error) || /^\s*\{/.test(e.error))) {
           log.warn(`Got an unexpected response with status ${e.statusCode}: ${truncateBody(e.error)}`);
           log.debug(e.stack);
         } else if (!isResponseLogged) {

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -121,8 +121,8 @@ class JWProxy {
   async proxy (url, method, body = null) {
     method = method.toUpperCase();
     const newUrl = this.getUrlForProxy(url);
-    const truncateBody = (responseBody) => _.truncate(
-      _.isString(responseBody) ? responseBody : JSON.stringify(responseBody),
+    const truncateBody = (bodyStr) => _.truncate(
+      _.isString(bodyStr) ? bodyStr : JSON.stringify(bodyStr),
       { length: LOG_OBJ_LENGTH });
     const reqOpts = {
       agent: false,

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -118,6 +118,28 @@ class JWProxy {
     return proxyBase + remainingUrl;
   }
 
+  syncDownstreamProtocol (resBodyObj, isSessionCreationRequest) {
+    if (!this.downstreamProtocol) {
+      this.downstreamProtocol = this.getProtocolFromResBody(resBodyObj);
+      log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}'`);
+    } else if (isSessionCreationRequest) {
+      // It might be that we proxy API calls to the downstream driver
+      // without creating a session first
+      // and it responds using the default proto,
+      // but then after createSession request is sent the internal proto is changed
+      // to the other one based on the actually provided caps
+      const previousValue = this.downstreamProtocol;
+      this.downstreamProtocol = this.getProtocolFromResBody(resBodyObj);
+      if (previousValue && previousValue !== this.downstreamProtocol) {
+        log.debug(`Updated the downstream protocol to '${this.downstreamProtocol}' ` +
+          `as per session creation request`);
+      } else {
+        log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}' ` +
+          `per session creation request`);
+      }
+    }
+  }
+
   async proxy (url, method, body = null) {
     method = method.toUpperCase();
     const newUrl = this.getUrlForProxy(url);
@@ -182,25 +204,7 @@ class JWProxy {
       if (isSessionCreationRequest && res.statusCode === 200) {
         this.sessionId = resBodyObj.sessionId;
       }
-      if (!this.downstreamProtocol) {
-        this.downstreamProtocol = this.getProtocolFromResBody(resBodyObj);
-        log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}'`);
-      } else if (isSessionCreationRequest) {
-        // It might be that we proxy API calls to the downstream driver
-        // without creating a session first
-        // and it responds using the default proto,
-        // but then after createSession request is sent the internal proto is changed
-        // to the other one based on the actually provided caps
-        const previousValue = this.downstreamProtocol;
-        this.downstreamProtocol = this.getProtocolFromResBody(resBodyObj);
-        if (previousValue && previousValue !== this.downstreamProtocol) {
-          log.debug(`Updated the downstream protocol to '${this.downstreamProtocol}' ` +
-            `as per session creation request`);
-        } else {
-          log.debug(`Determined the downstream protocol as '${this.downstreamProtocol}' ` +
-            `per session creation request`);
-        }
-      }
+      this.syncDownstreamProtocol(resBodyObj, isSessionCreationRequest);
       if (res.statusCode < 400 && this.downstreamProtocol === MJSONWP &&
         _.has(resBodyObj, 'status') && parseInt(resBodyObj.status, 10) !== 0) {
         // Some servers, like chromedriver may return response code 200 for non-zero JSONWP statuses

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -121,6 +121,9 @@ class JWProxy {
   async proxy (url, method, body = null) {
     method = method.toUpperCase();
     const newUrl = this.getUrlForProxy(url);
+    const truncateBody = (responseBody) => _.truncate(
+      _.isString(responseBody) ? responseBody : JSON.stringify(responseBody),
+      { length: LOG_OBJ_LENGTH });
     const reqOpts = {
       agent: false,
       url: newUrl,
@@ -139,9 +142,7 @@ class JWProxy {
         try {
           reqOpts.json = JSON.parse(body);
         } catch (e) {
-          throw new Error('Cannot interpret the request body as valid JSON: ' +
-            _.truncate(_.isString(body) ? body : JSON.stringify(body),
-            {length: LOG_OBJ_LENGTH}));
+          throw new Error(`Cannot interpret the request body as valid JSON: ${truncateBody(body)}`);
         }
       } else {
         reqOpts.json = body;
@@ -154,8 +155,7 @@ class JWProxy {
     }
 
     log.debug(`Proxying [${method} ${url || '/'}] to [${method} ${newUrl}] ` +
-      (body ? `with body: ${_.truncate(_.isString(body) ? body : JSON.stringify(body),
-      {length: LOG_OBJ_LENGTH})}` : 'with no body'));
+      (body ? `with body: ${truncateBody(body)}` : 'with no body'));
 
     const throwProxyError = (error) => {
       const message = `The request to ${url} has failed`;
@@ -166,9 +166,6 @@ class JWProxy {
       throw err;
     };
     let isResponseLogged = false;
-    const truncateResponseBody = (responseBody) => _.truncate(
-      _.isString(responseBody) ? responseBody : JSON.stringify(responseBody),
-      { length: LOG_OBJ_LENGTH });
     try {
       const res = await this.request(reqOpts);
       // `res.body` might be really big
@@ -179,7 +176,7 @@ class JWProxy {
         // If it cannot be coerced to an object then the response is wrong
         throwProxyError(res.body);
       }
-      log.debug(`Got response with status ${res.statusCode}: ${truncateResponseBody(res.body)}`);
+      log.debug(`Got response with status ${res.statusCode}: ${truncateBody(res.body)}`);
       isResponseLogged = true;
       const isSessionCreationRequest = /\/session$/.test(url) && method === 'POST';
       if (isSessionCreationRequest && res.statusCode === 200) {
@@ -219,10 +216,10 @@ class JWProxy {
         log.debug(e.stack);
       } else {
         if (!(_.isPlainObject(e.error) || ['[', '{'].some((x) => `${e.error}`.trim().startsWith(x)))) {
-          log.warn(`Got an unexpected response: ${truncateResponseBody(e.error)}`);
+          log.warn(`Got an unexpected response with status ${e.statusCode}: ${truncateBody(e.error)}`);
           log.debug(e.stack);
         } else if (!isResponseLogged) {
-          log.debug(`Got response with status ${e.statusCode}: ${truncateResponseBody(e.error)}`);
+          log.debug(`Got response with status ${e.statusCode}: ${truncateBody(e.error)}`);
           isResponseLogged = true;
         }
       }

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -220,7 +220,11 @@ class JWProxy {
         log.debug(e.stack);
       } else {
         if (!(_.isPlainObject(e.error) || /^\s*\{/.test(e.error))) {
-          log.warn(`Got an unexpected response with status ${e.statusCode}: ${truncateBody(e.error)}`);
+          if (isResponseLogged) {
+            log.warn('The response has an unknown format');
+          } else {
+            log.warn(`Got an unexpected response with status ${e.statusCode}: ${truncateBody(e.error)}`);
+          }
           log.debug(e.stack);
         } else if (!isResponseLogged) {
           log.debug(`Got response with status ${e.statusCode}: ${truncateBody(e.error)}`);


### PR DESCRIPTION
Previously a warning was always logged if the server was returning 400+ error code. Now we are being smarter about it and only raise a warning if the retrieved response is really broken.