### PR TITLE
refactor: make server parameters a hash [breaking change]

### DIFF
--- a/lib/express/README.md
+++ b/lib/express/README.md
@@ -13,7 +13,8 @@ The `appium-express` server comes configured with:
 4. default error handling
 5. fix for invalid content types sent by certain clients
 
-To configure routes, a function that takes an Express server is passed into the server. This function can add whatever routes are wanted.
+To configure routes, a function that takes an Express server is passed into the
+server. This function can add whatever routes are wanted.
 
 
 ### Usage
@@ -34,10 +35,14 @@ function configureRoutes (app) {
   });
 }
 
-let port = 5000;
-let host = 'localhost';
+const port = 5000;
+const host = 'localhost';
 
-let appiumServer = await server(configureRoutes, port, host);
+const appiumServer = await server({
+  routeConfiguringFunction,
+  port,
+  host,
+});
 ```
 
 

--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -16,7 +16,14 @@ import { addWebSocketHandler, removeWebSocketHandler, removeAllWebSocketHandlers
 import B from 'bluebird';
 
 
-async function server (configureRoutes, port, hostname = null, allowCors = true) {
+async function server (opts = {}) {
+  const {
+    routeConfiguringFunction,
+    port,
+    hostname = null,
+    allowCors = true,
+  } = opts;
+
   // create the actual http server
   const app = express();
   let httpServer = http.createServer(app);
@@ -53,7 +60,7 @@ async function server (configureRoutes, port, hostname = null, allowCors = true)
       socket.setTimeout(600 * 1000); // 10 minute timeout
       socket.on('error', reject);
     });
-    configureServer(app, configureRoutes, allowCors);
+    configureServer(app, routeConfiguringFunction, allowCors);
 
     let serverArgs = [port];
     if (hostname) {
@@ -70,7 +77,7 @@ async function server (configureRoutes, port, hostname = null, allowCors = true)
   });
 }
 
-function configureServer (app, configureRoutes, allowCors = true) {
+function configureServer (app, routeConfiguringFunction, allowCors = true) {
   app.use(endLogFormatter);
 
   // set up static assets
@@ -100,7 +107,7 @@ function configureServer (app, configureRoutes, allowCors = true) {
   // set up start logging (which depends on bodyParser doing its thing)
   app.use(startLogFormatter);
 
-  configureRoutes(app);
+  routeConfiguringFunction(app);
 
   // dynamic routes for testing, etc.
   app.all('/welcome', welcome);

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -17,7 +17,10 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
   describe('BaseDriver (e2e)', function () {
     let baseServer, d = new DriverClass(DEFAULT_ARGS);
     before(async function () {
-      baseServer = await server(routeConfiguringFunction(d), DEFAULT_ARGS.port);
+      baseServer = await server({
+        routeConfiguringFunction: routeConfiguringFunction(d),
+        port: DEFAULT_ARGS.port,
+      });
     });
     after(async function () {
       await baseServer.close();

--- a/test/basedriver/websockets-e2e-specs.js
+++ b/test/basedriver/websockets-e2e-specs.js
@@ -19,7 +19,10 @@ describe('Websockets (e2e)', function () {
   before(async function () {
     driver = new FakeDriver();
     driver.sessionId = SESSION_ID;
-    baseServer = await server(routeConfiguringFunction(driver), PORT);
+    baseServer = await server({
+      routeConfiguringFunction: routeConfiguringFunction(driver),
+      port: PORT,
+    });
   });
   after(async function () {
     await baseServer.close();

--- a/test/express/server-e2e-specs.js
+++ b/test/express/server-e2e-specs.js
@@ -33,7 +33,10 @@ describe('server', function () {
         res.status(200).send('We have waited!');
       });
     }
-    hwServer = await server(configureRoutes, 8181);
+    hwServer = await server({
+      routeConfiguringFunction: configureRoutes,
+      port: 8181,
+    });
   });
   after(async function () {
     await hwServer.close();
@@ -59,7 +62,10 @@ describe('server', function () {
       .should.be.rejectedWith(/hahaha/);
   });
   it('should error if we try to start again on a port that is used', async function () {
-    await server(() => {}, 8181).should.be.rejectedWith(/EADDRINUSE/);
+    await server({
+      routeConfiguringFunction () {},
+      port: 8181,
+    }).should.be.rejectedWith(/EADDRINUSE/);
   });
   it('should wait for the server close connections before finishing closing', async function () {
     let bodyPromise = request('http://localhost:8181/pause');
@@ -76,7 +82,15 @@ describe('server', function () {
   });
   it('should error if we try to start on a bad hostname', async function () {
     this.timeout(60000);
-    await server(_.noop, 8181, 'lolcathost').should.be.rejectedWith(/ENOTFOUND|EADDRNOTAVAIL/);
-    await server(_.noop, 8181, '1.1.1.1').should.be.rejectedWith(/EADDRNOTAVAIL/);
+    await server({
+      routeConfiguringFunction: _.noop,
+      port: 8181,
+      hostname: 'lolcathost',
+    }).should.be.rejectedWith(/ENOTFOUND|EADDRNOTAVAIL/);
+    await server({
+      routeConfiguringFunction: _.noop,
+      port: 8181,
+      hostname: '1.1.1.1',
+    }).should.be.rejectedWith(/EADDRNOTAVAIL/);
   });
 });

--- a/test/express/server-specs.js
+++ b/test/express/server-specs.js
@@ -20,10 +20,12 @@ describe('server configuration', function () {
   });
 
   it('should reject if error thrown in configureRoutes parameter', async function () {
-    let configureRoutes = () => {
+    const configureRoutes = () => {
       throw new Error('I am Mr. MeeSeeks look at me!');
     };
-    await server(configureRoutes, 8181).should.be.rejectedWith('MeeSeeks');
+    await server({
+      routeConfiguringFunction: configureRoutes,
+      port: 8181,
+    }).should.be.rejectedWith('MeeSeeks');
   });
 });
-

--- a/test/jsonwp-proxy/proxy-e2e-specs.js
+++ b/test/jsonwp-proxy/proxy-e2e-specs.js
@@ -10,7 +10,10 @@ describe('proxy', function () {
   const jwproxy = new JWProxy();
   let baseServer;
   before(async function () {
-    baseServer = await server(routeConfiguringFunction(new FakeDriver()), 4444);
+    baseServer = await server({
+      routeConfiguringFunction: routeConfiguringFunction(new FakeDriver()),
+      port: 4444,
+    });
   });
   after(async function () {
     await baseServer.close();

--- a/test/protocol/protocol-e2e-specs.js
+++ b/test/protocol/protocol-e2e-specs.js
@@ -37,7 +37,10 @@ describe('Protocol', function () {
     before(async function () {
       driver = new FakeDriver();
       driver.sessionId = 'foo';
-      mjsonwpServer = await server(routeConfiguringFunction(driver), serverPort);
+      mjsonwpServer = await server({
+        routeConfiguringFunction: routeConfiguringFunction(driver),
+        port: serverPort,
+      });
     });
 
     after(async function () {
@@ -805,7 +808,10 @@ describe('Protocol', function () {
     let mjsonwpServer;
 
     before(async function () {
-      mjsonwpServer = await server(routeConfiguringFunction(driver), serverPort);
+      mjsonwpServer = await server({
+        routeConfiguringFunction: routeConfiguringFunction(driver),
+        port: serverPort,
+      });
     });
 
     after(async function () {
@@ -921,7 +927,10 @@ describe('Protocol', function () {
       driver.proxyActive = () => { return true; };
       driver.canProxy = () => { return true; };
 
-      mjsonwpServer = await server(routeConfiguringFunction(driver), serverPort);
+      mjsonwpServer = await server({
+        routeConfiguringFunction: routeConfiguringFunction(driver),
+        port: serverPort,
+      });
     });
 
     afterEach(async function () {


### PR DESCRIPTION
The parameters for starting the server are beginning to get long, so switch to a hash.

If #346 is a made into a breaking change, this can piggy-back onto that, and only need a single major release of the package.