### PR TITLE
fix: Fix session identifier retrieval for W3C protocol

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -202,7 +202,7 @@ class JWProxy {
       isResponseLogged = true;
       const isSessionCreationRequest = /\/session$/.test(url) && method === 'POST';
       if (isSessionCreationRequest && res.statusCode === 200) {
-        this.sessionId = resBodyObj.sessionId;
+        this.sessionId = resBodyObj.sessionId || (resBodyObj.value || {}).sessionId;
       }
       this.syncDownstreamProtocol(resBodyObj, isSessionCreationRequest);
       if (res.statusCode < 400 && this.downstreamProtocol === MJSONWP &&

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -324,8 +324,8 @@ class JWProxy {
     // if the proxied response contains a sessionId that the downstream
     // driver has generated, we don't want to return that to the client.
     // Instead, return the id from the request or from current session
+    const reqSessionId = this.getSessionIdFromUrl(req.originalUrl);
     if (_.has(resBodyObj, 'sessionId')) {
-      const reqSessionId = this.getSessionIdFromUrl(req.originalUrl);
       if (reqSessionId) {
         log.info(`Replacing sessionId ${resBodyObj.sessionId} with ${reqSessionId}`);
         resBodyObj.sessionId = reqSessionId;
@@ -335,7 +335,7 @@ class JWProxy {
       }
     }
     resBodyObj.value = formatResponseValue(resBodyObj.value);
-    formatStatus(resBodyObj, SESSIONS_CACHE.getProtocol(resBodyObj.sessionId));
+    formatStatus(resBodyObj, SESSIONS_CACHE.getProtocol(reqSessionId));
     res.status(response.statusCode).send(JSON.stringify(resBodyObj));
   }
 }


### PR DESCRIPTION
W3C protocol requires the session identifier to be returned as one of `value` keys:

https://travis-ci.org/appium/appium-chromedriver/jobs/574990616#L563