### PR TITLE
fix: remove redundant log line on cached app found

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -46,7 +46,6 @@ function getCachedApplicationPath (link, currentModified) {
 
   const {lastModified, fullPath} = APPLICATIONS_CACHE.get(link);
   if (lastModified && currentModified.getTime() <= lastModified.getTime()) {
-    logger.debug(`Reusing already downloaded application at '${fullPath}'`);
     return fullPath;
   }
   logger.debug(`'Last-Modified' timestamp of '${link}' has been updated. ` +
@@ -83,13 +82,13 @@ async function configureApp (app, supportedAppExtensions) {
       logger.info(`Using downloadable app '${newApp}'`);
       const headers = await retrieveHeaders(newApp);
       if (headers['last-modified']) {
-        logger.debug(`Last-Modified: ${headers['last-modified']}`);
+        logger.debug(`App Last-Modified: ${headers['last-modified']}`);
         currentModified = new Date(headers['last-modified']);
       }
       const cachedPath = getCachedApplicationPath(app, currentModified);
       if (cachedPath) {
         if (await fs.exists(cachedPath)) {
-          logger.info(`Reusing the previously downloaded application at '${cachedPath}'`);
+          logger.info(`Reusing previously downloaded application at '${cachedPath}'`);
           return verifyAppExtension(cachedPath, supportedAppExtensions);
         }
         logger.info(`The application at '${cachedPath}' does not exist anymore. Deleting it from the cache`);


### PR DESCRIPTION
Remove the situation where the app is found in the cache, and we get
```
[BaseDriver] Using downloadable app 'http://appium.s3.amazonaws.com/TestApp10.2.app.zip'
[debug] [BaseDriver] Last-Modified: Thu, 27 Apr 2017 23:29:04 GMT
[debug] [BaseDriver] Reusing already downloaded application at '/var/folders/pq/46v__b_n7tq3ftb5ccnjt6rw0000gn/T/201984-86549-1foenne.m7ix/TestApp.app'
[BaseDriver] Reusing the previously downloaded application at '/var/folders/pq/46v__b_n7tq3ftb5ccnjt6rw0000gn/T/201984-86549-1foenne.m7ix/TestApp.app'
```