### PR TITLE
fix: Adjust the error codes for NotImplementedError

### DIFF
--- a/docs/mjsonwp/errors.md
+++ b/docs/mjsonwp/errors.md
@@ -15,8 +15,8 @@ These classes, which are constructed with a string message (defaulting to the "D
 | 11   | `ElementNotVisibleError`         | An element command could not be completed because the element is not visible on the page
 | 12   | `InvalidElementStateError`       | An element command could not be completed because the element is in an invalid state (e.g., attempting to click a disabled element)
 | 13   | `UnknownError`                   | An unknown server-side error occurred while processing the command
-| 13   | `NotYetImplementedError`         | The operation requested is not yet implemented by the driver
-| 13   | `NotImplementedError`            | The operation requested will not be implemented by the driver
+| 405   | `NotYetImplementedError`        | The operation requested is not yet implemented by the driver
+| 405   | `NotImplementedError`           | The operation requested will not be implemented by the driver
 | 15   | `ElementIsNotSelectableError`    | An attempt was made to select an element that cannot be selected
 | 17   | `JavaScriptError`                | An error occurred while executing user supplied JavaScript
 | 19   | `XPathLookupError`               | An error occurred while searching for an element by XPath

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -574,32 +574,15 @@ class InvalidContextError extends ProtocolError {
   }
 }
 
-// This is an alias for UnknownMethodError
-class NotYetImplementedError extends ProtocolError {
-  static code () {
-    return 13;
-  }
-  static w3cStatus () {
-    return HTTPStatusCodes.NOT_FOUND; // W3C equivalent is called 'Unknown Command' (A command could not be executed because the remote end is not aware of it)
-  }
-  static error () {
-    return 'unknown method';
-  }
+// These are aliases for UnknownMethodError
+class NotYetImplementedError extends UnknownMethodError {
   constructor (err) {
-    super(err || 'Method has not yet been implemented',
-      NotYetImplementedError.code(), NotYetImplementedError.w3cStatus(), NotYetImplementedError.error());
+    super(err || 'Method has not yet been implemented');
   }
 }
-
-class NotImplementedError extends ProtocolError {
-  static code () {
-    return 13;
-  }
-  static w3cStatus () {
-    return HTTPStatusCodes.METHOD_NOT_ALLOWED; // W3C equivalent is 'Unknown Method' (The requested command matched a known URL but did not match an method for that URL)
-  }
+class NotImplementedError extends UnknownMethodError {
   constructor (err) {
-    super(err || 'Method is not implemented', NotImplementedError.code(), NotImplementedError.w3cStatus());
+    super(err || 'Method is not implemented');
   }
 }
 

--- a/test/protocol/errors-specs.js
+++ b/test/protocol/errors-specs.js
@@ -202,7 +202,7 @@ let errorsList = [
     errorName: 'NotYetImplementedError',
     errorMsg: 'Method has not yet been implemented',
     error: 'unknown method',
-    errorCode: 13
+    errorCode: 405
   },
   {
     errorName: 'UnknownCommandError',

--- a/test/protocol/protocol-e2e-specs.js
+++ b/test/protocol/protocol-e2e-specs.js
@@ -184,7 +184,7 @@ describe('Protocol', function () {
 
       res.statusCode.should.equal(501);
       res.body.should.eql({
-        status: 13,
+        status: 405,
         value: {
           message: 'Method has not yet been implemented'
         },
@@ -203,7 +203,7 @@ describe('Protocol', function () {
 
       res.statusCode.should.equal(501);
       res.body.should.eql({
-        status: 13,
+        status: 405,
         value: {
           message: 'Method is not implemented'
         },
@@ -484,13 +484,13 @@ describe('Protocol', function () {
           w3cError.should.equal(errors.InvalidArgumentError.error());
         });
 
-        it(`should throw 404 Not Found exception if the command hasn't been implemented yet`, async function () {
+        it(`should throw 405 exception if the command hasn't been implemented yet`, async function () {
           const {statusCode, error} = await request.post(`${sessionUrl}/actions`, {
             json: {
               actions: [],
             }
           }).should.eventually.be.rejected;
-          statusCode.should.equal(404);
+          statusCode.should.equal(405);
 
           const {error: w3cError, message, stacktrace} = error.value;
           message.should.match(/Method has not yet been implemented/);


### PR DESCRIPTION
Selenium client is complaining about the error codes we return from these exceptions. See, for example, https://discuss.appium.io/t/exception-in-thread-main-org-openqa-selenium-unsupportedcommandexception-method-has-not-yet-been-implemented/27958