### PR TITLE
fix: fix the build for Node 12.11.0

### DIFF
--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -418,11 +418,10 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           json: {script},
           simple: false,
         });
-        res.should.eql({
-          sessionId,
-          status: 13,
-          value: {message: 'An unknown server-side error occurred while processing the command. Original error: Could not execute driver script. Original error was: Error: Unexpected token ;'}
-        });
+        res.sessionId.should.eql(sessionId);
+        res.status.should.eql(13);
+        res.value.should.have.property('message');
+        res.value.message.should.match(/An unknown server-side error occurred while processing the command. Original error: Could not execute driver script. Original error was: Error: Unexpected token '?;'?/);
       });
 
       it('should be able to set a timeout on a driver script', async function () {


### PR DESCRIPTION
Node `12.11.0` throws syntax errors slightly differently:
```
$ node
Welcome to Node.js v12.10.0.
Type ".help" for more information.
> }
Thrown:
}
^

SyntaxError: Unexpected token }
>
```
```
$ node
Welcome to Node.js v12.11.0.
Type ".help" for more information.
> }
Thrown:
}
^

SyntaxError: Unexpected token '}'
>
```