### PR TITLE
fix: Explicitly set keep-alive server timeout

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -18,6 +18,9 @@ import B from 'bluebird';
 import { DEFAULT_BASE_PATH } from '../protocol';
 
 
+const KEEP_ALIVE_TIMEOUT_MS = 60 * 10 * 1000; // 10 minutes
+
+
 async function server (opts = {}) {
   const {
     routeConfiguringFunction,
@@ -60,7 +63,7 @@ async function server (opts = {}) {
       reject(err);
     });
     httpServer.on('connection', (socket) => {
-      socket.setTimeout(600 * 1000); // 10 minute timeout
+      socket.setTimeout(KEEP_ALIVE_TIMEOUT_MS);
       socket.on('error', reject);
     });
     configureServer(app, routeConfiguringFunction, allowCors, basePath);
@@ -77,6 +80,9 @@ async function server (opts = {}) {
       }
       resolve(httpServer);
     });
+    httpServer.keepAliveTimeout = KEEP_ALIVE_TIMEOUT_MS;
+    // headers timeout must be greater than keepAliveTimeout
+    httpServer.headersTimeout = KEEP_ALIVE_TIMEOUT_MS + 5 * 1000;
   });
 }
 


### PR DESCRIPTION
We were observing Python client throwing random disconnect errors when keepAlive mode on the client side is enabled. This could be happening because the server closes the connection before the client times out. So we need to make sure the default server timeout is greater than the client one and 10 minutes should be enough. See https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/ for more details