### PR TITLE
fix: Fix the request options for different keepAlive values

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -125,7 +125,6 @@ class JWProxy {
       _.isString(content) ? content : JSON.stringify(content),
       { length: LOG_OBJ_LENGTH });
     const reqOpts = {
-      agent: false,
       url: newUrl,
       method,
       headers: {
@@ -135,8 +134,12 @@ class JWProxy {
       },
       resolveWithFullResponse: true,
       timeout: this.timeout,
-      forever: this.keepAlive,
     };
+    if (this.keepAlive) {
+      reqOpts.forever = true;
+    } else {
+      reqOpts.agent = false;
+    }
     if (util.hasValue(body)) {
       if (typeof body !== 'object') {
         try {

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -137,7 +137,13 @@ class JWProxy {
     };
     if (this.keepAlive) {
       reqOpts.forever = true;
+      // Setting `forever` option to `true` implicitly assigns
+      // `agent` option to `http(s).Agent({keepAlive:true})`
     } else {
+      // Setting `agent` option to `false` prevents the requests
+      // module from using any connection pools, which enforces
+      // new socket creation for each HTTP(S) request
+      // (the default HTTP 1.0 behavior)
       reqOpts.agent = false;
     }
     if (util.hasValue(body)) {


### PR DESCRIPTION
The documentation states that setting `forever` is equal to setting the `agent` to `http(s).Agent({keepAlive:true})`. This means we should not set `agent` to `false` if `forever` is `true`