### PR TITLE
feat: add filtering log events with type (related to #365)

### DIFF
--- a/lib/basedriver/commands/event.js
+++ b/lib/basedriver/commands/event.js
@@ -29,7 +29,7 @@ commands.getLogEvents = function (type = null) {
     type = [type];
   }
 
-  return _.reduce(this._eventHistory, function a (acc, eventTimes, eventType) {
+  return _.reduce(this._eventHistory, (acc, eventTimes, eventType) => {
     if (type.includes(eventType)) {
       acc[eventType] = eventTimes;
     }

--- a/lib/basedriver/commands/event.js
+++ b/lib/basedriver/commands/event.js
@@ -20,18 +20,21 @@ commands.logCustomEvent = function (vendor, event) {
  * It returns all events if the type is not provided or empty string/array.
  * @returns {object} - the event history log object
  */
-commands.getLogEvents = function (type) {
+commands.getLogEvents = function (type = null) {
   if (_.isEmpty(type)) {
     return this._eventHistory;
   }
 
-  const events = {};
-  for (const key of Object.keys(this._eventHistory)) {
-    if (type.includes(key)) {
-      events[key] = this._eventHistory[key];
-    }
+  if (!_.isArray(type)) {
+    type = [type];
   }
-  return events;
+
+  return _.reduce(this._eventHistory, function a (acc, eventTimes, eventType) {
+    if (type.includes(eventType)) {
+      acc[eventType] = eventTimes;
+    }
+    return acc;
+  }, {});
 };
 
 export default commands;

--- a/lib/basedriver/commands/event.js
+++ b/lib/basedriver/commands/event.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 const commands = {};
 
 /**
@@ -14,13 +16,22 @@ commands.logCustomEvent = function (vendor, event) {
 /**
  * Get the event log
  *
- * @param {string} type - currently unused but a placeholder for a future
- * feature where filtering of log events is allowed
+ * @param {?string|Array<string>} type - the event type to filter with.
+ * It returns all events if the type is not provided or empty string/array.
  * @returns {object} - the event history log object
  */
-commands.getLogEvents = function (/*type*/) {
-  // type is currently unused but may be implemented for filtering later on
-  return this._eventHistory;
+commands.getLogEvents = function (type) {
+  if (_.isEmpty(type)) {
+    return this._eventHistory;
+  }
+
+  const events = {};
+  for (const key of Object.keys(this._eventHistory)) {
+    if (type.includes(key)) {
+      events[key] = this._eventHistory[key];
+    }
+  }
+  return events;
 };
 
 export default commands;

--- a/test/basedriver/commands/event-specs.js
+++ b/test/basedriver/commands/event-specs.js
@@ -22,3 +22,41 @@ describe('logging custom events', function () {
     _.keys(events).should.eql(['commands', 'appiumEvent', 'myorg:myevent']);
   });
 });
+
+describe('#getLogEvents', function () {
+  it('should allow to get all events', async function () {
+    const d = new BaseDriver();
+    d._eventHistory.should.eql({commands: []});
+    d._eventHistory.testCommand = ['1', '2', '3'];
+    await d.getLogEvents().should.eql({
+      commands: [], testCommand: ['1', '2', '3']
+    });
+  });
+  it('should filter with testCommand', async function () {
+    const d = new BaseDriver();
+    d._eventHistory.should.eql({commands: []});
+    d._eventHistory.testCommand = ['1', '2', '3'];
+    await d.getLogEvents('testCommand').should.eql({
+      testCommand: ['1', '2', '3']
+    });
+  });
+
+  it('should filter with multiple event keys', async function () {
+    const d = new BaseDriver();
+    d._eventHistory.should.eql({commands: []});
+    d._eventHistory.testCommand = ['1', '2', '3'];
+    d._eventHistory.testCommand2 = ['4', '5'];
+    await d.getLogEvents(['testCommand', 'testCommand2']).should.eql({
+      testCommand: ['1', '2', '3'], testCommand2: ['4', '5']
+    });
+  });
+
+  it('should filter with custom events', async function () {
+    const d = new BaseDriver();
+    d._eventHistory.should.eql({commands: []});
+    d._eventHistory['custom:appiumEvent'] = ['1', '2', '3'];
+    await d.getLogEvents(['custom:appiumEvent']).should.eql({
+      'custom:appiumEvent': ['1', '2', '3']
+    });
+  });
+});

--- a/test/basedriver/commands/event-specs.js
+++ b/test/basedriver/commands/event-specs.js
@@ -32,6 +32,7 @@ describe('#getLogEvents', function () {
       commands: [], testCommand: ['1', '2', '3']
     });
   });
+
   it('should filter with testCommand', async function () {
     const d = new BaseDriver();
     d._eventHistory.should.eql({commands: []});
@@ -39,6 +40,13 @@ describe('#getLogEvents', function () {
     await d.getLogEvents('testCommand').should.eql({
       testCommand: ['1', '2', '3']
     });
+  });
+
+  it('should not filter with wrong but can be a part of the event name', async function () {
+    const d = new BaseDriver();
+    d._eventHistory.should.eql({commands: []});
+    d._eventHistory.testCommand = ['1', '2', '3'];
+    await d.getLogEvents('testCommandDummy').should.eql({});
   });
 
   it('should filter with multiple event keys', async function () {
@@ -58,5 +66,12 @@ describe('#getLogEvents', function () {
     await d.getLogEvents(['custom:appiumEvent']).should.eql({
       'custom:appiumEvent': ['1', '2', '3']
     });
+  });
+
+  it('should not filter with no existed event name', async function () {
+    const d = new BaseDriver();
+    d._eventHistory.should.eql({commands: []});
+    d._eventHistory.testCommand = ['1', '2', '3'];
+    await d.getLogEvents(['noEventName']).should.eql({});
   });
 });


### PR DESCRIPTION
Filter events with `type`.
Is this expected way? @jlipps 

The  usage in Ruby is:

```ruby
@driver.logs.events
#=> {"commands"=>[{"cmd"=>"timeouts", "startTime"=>1573544038106,
#       "endTime"=>1573544038107}, {"cmd"=>"getLogEvents", "startTime"=>1573544041877,
#       "endTime"=>1573544041877}],
#       ...
#       "wdaStartAttempted"=>[1573543998228, 1573544024056],
#       "wdaSessionAttempted"=> [1573543998236, ...1573544027958],
#       "wdaSessionStarted"=>[1573544035902]...}

@driver.logs.events 'wdaStartAttempted'
#=> {"wdaStartAttempted"=>[1573546058909, 1573546084570]}

@driver.logs.events ['wdaStartAttempted']
#=> {"wdaStartAttempted"=>[1573546058909, 1573546084570]}

@driver.logs.events ['wdaStartAttempted', 'wdaStarted']
#=> {"wdaStartAttempted"=>[1573546058909, 1573546084570], "wdaStarted"=>[1573546096204]}
```

---

https://github.com/appium/appium-base-driver/pull/365