### PR TITLE
refactor: Prefer event emitting to promises cancelation

### DIFF
--- a/lib/basedriver/README.md
+++ b/lib/basedriver/README.md
@@ -31,6 +31,6 @@ Appium Base driver has some properties that all drivers share:
 - `driver.jwpProxyAvoid` - used by mjsonwp module. You can specify what REST api routes which you want to SKIP the automatic proxy to another server (which is optional) and instead be handled by your driver.
 
 
-Base driver exposes a promise called `onUnexpectedShutdown` which is a promise which your driver must reject in cases where an unexpected error occurs and you want to signal to the appium server at large that your driver is now shutting down.
+Base driver exposes an event called `onUnexpectedShutdown` which is called when the driver is shut down unexpectedly (usually after invocation of the `startUnexpectedShutdown` method).
 
 Your driver should also implement a startUnexpectedShutdown method?

--- a/lib/basedriver/commands/session.js
+++ b/lib/basedriver/commands/session.js
@@ -78,10 +78,6 @@ commands.createSession = async function createSession (jsonwpDesiredCapabilities
     this.newCommandTimeoutMs = (this.caps.newCommandTimeout * 1000);
   }
 
-  // We need to ininitialize one onUnexpectedShutdow promise per session
-  // to avoid the promise fulfilment being propagated between sessions.
-  this.resetOnUnexpectedShutdown();
-
   log.info(`Session created with session id: ${this.sessionId}`);
 
   return [this.sessionId, caps];

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -102,12 +102,12 @@ class BaseDriver extends Protocol {
    * when the driver is shut down unexpectedly. Multiple calls to this method
    * will cause the handler to be executed mutiple times
    *
-   * @param {Function} hanlder The code to be executed on unexpected shutdown.
+   * @param {Function} handler The code to be executed on unexpected shutdown.
    * The function may accept one argument, which is the actual error instance, which
    * caused the driver to shut down.
    */
-  onUnexpectedShutdown (hanlder) {
-    return this.eventEmitter.on(ON_UNEXPECTED_SHUTDOWN_EVENT, hanlder);
+  onUnexpectedShutdown (handler) {
+    this.eventEmitter.on(ON_UNEXPECTED_SHUTDOWN_EVENT, handler);
   }
 
   /**

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -12,6 +12,7 @@ import _ from 'lodash';
 import { util } from 'appium-support';
 import { ImageElement, makeImageElementCache, getImgElFromArgs } from './image-element';
 import AsyncLock from 'async-lock';
+import { EventEmitter } from 'events';
 
 
 B.config({
@@ -24,6 +25,7 @@ const EVENT_SESSION_INIT = 'newSessionRequested';
 const EVENT_SESSION_START = 'newSessionStarted';
 const EVENT_SESSION_QUIT_START = 'quitSessionRequested';
 const EVENT_SESSION_QUIT_DONE = 'quitSessionFinished';
+const ON_UNEXPECTED_SHUTDOWN_EVENT = 'onUnexpectedShutdown';
 
 class BaseDriver extends Protocol {
 
@@ -75,8 +77,6 @@ class BaseDriver extends Protocol {
     // the settings functionality itself
     this.settings = new DeviceSettings({}, _.noop);
 
-    this.resetOnUnexpectedShutdown();
-
     // keeping track of initial opts
     this.initialOpts = _.cloneDeep(this.opts);
 
@@ -91,7 +91,21 @@ class BaseDriver extends Protocol {
     // cache the image elements
     this._imgElCache = makeImageElementCache();
 
+    // used to handle driver events
+    this.eventEmitter = new EventEmitter();
+
+    // TODO: remove this line before committing the PR to master
+    this.onUnexpectedShutdown = B.resolve();
+
     this.protocol = null;
+  }
+
+  on (eventName, hanlder) {
+    this.eventEmitter.on(eventName, hanlder);
+  }
+
+  once (eventName, hanlder) {
+    this.eventEmitter.once(eventName, hanlder);
   }
 
   /**
@@ -154,22 +168,6 @@ class BaseDriver extends Protocol {
    */
   async getStatus () { // eslint-disable-line require-await
     return {};
-  }
-
-  /*
-   * Initialize a new onUnexpectedShutdown promise, cancelling existing one.
-   */
-  resetOnUnexpectedShutdown () {
-    if (this.onUnexpectedShutdown && !this.onUnexpectedShutdown.isFulfilled()) {
-      this.onUnexpectedShutdown.cancel();
-    }
-    this.onUnexpectedShutdown = new B((resolve, reject, onCancel) => {
-      onCancel(() => reject(new B.CancellationError()));
-      this.unexpectedShutdownDeferred = {resolve, reject};
-    });
-    this.unexpectedShutdownDeferred.promise = this.onUnexpectedShutdown;
-    // noop handler to avoid warning.
-    this.onUnexpectedShutdown.catch(() => {});
   }
 
   // we only want subclasses to ever extend the contraints
@@ -325,7 +323,10 @@ class BaseDriver extends Protocol {
 
     const commandExecutor = async () => imgElId
       ? await ImageElement.execute(this, cmd, imgElId, ...args)
-      : await B.race([this[cmd](...args), this.unexpectedShutdownDeferred.promise]);
+      : await B.race([
+        this[cmd](...args),
+        new B((resolve, reject) => void this.eventEmitter.once(ON_UNEXPECTED_SHUTDOWN_EVENT, reject))
+      ]);
     const res = this.isCommandsQueueEnabled && cmd !== 'executeDriverScript'
       ? await this.commandsQueueGuard.acquire(BaseDriver.name, commandExecutor)
       : await commandExecutor();
@@ -354,7 +355,7 @@ class BaseDriver extends Protocol {
   }
 
   async startUnexpectedShutdown (err = new errors.NoSuchDriverError('The driver was unexpectedly shut down!')) {
-    this.unexpectedShutdownDeferred.reject(err); // allow others to listen for this
+    this.eventEmitter.emit(ON_UNEXPECTED_SHUTDOWN_EVENT, err); // allow others to listen for this
     this.shutdownUnexpectedly = true;
     try {
       await this.deleteSession(this.sessionId);

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -94,18 +94,20 @@ class BaseDriver extends Protocol {
     // used to handle driver events
     this.eventEmitter = new EventEmitter();
 
-    // TODO: remove this line before committing the PR to master
-    this.onUnexpectedShutdown = B.resolve();
-
     this.protocol = null;
   }
 
-  on (eventName, hanlder) {
-    this.eventEmitter.on(eventName, hanlder);
-  }
-
-  once (eventName, hanlder) {
-    this.eventEmitter.once(eventName, hanlder);
+  /**
+   * Set a callback handler if needed to execute a custom piece of code
+   * when the driver is shut down unexpectedly. Multiple calls to this method
+   * will cause the handler to be executed mutiple times
+   *
+   * @param {Function} hanlder The code to be executed on unexpected shutdown.
+   * The function may accept one argument, which is the actual error instance, which
+   * caused the driver to shut down.
+   */
+  onUnexpectedShutdown (hanlder) {
+    return this.eventEmitter.on(ON_UNEXPECTED_SHUTDOWN_EVENT, hanlder);
   }
 
   /**
@@ -325,7 +327,7 @@ class BaseDriver extends Protocol {
       ? await ImageElement.execute(this, cmd, imgElId, ...args)
       : await B.race([
         this[cmd](...args),
-        new B((resolve, reject) => void this.eventEmitter.once(ON_UNEXPECTED_SHUTDOWN_EVENT, reject))
+        new B((resolve, reject) => this.eventEmitter.on(ON_UNEXPECTED_SHUTDOWN_EVENT, reject))
       ]);
     const res = this.isCommandsQueueEnabled && cmd !== 'executeDriverScript'
       ? await this.commandsQueueGuard.acquire(BaseDriver.name, commandExecutor)

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -241,8 +241,8 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         res.status.should.equal(13);
         res.value.message.should.contain('Crashytimes');
         await new B((resolve, reject) => {
-          setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
-          d.once('onUnexpectedShutdown', resolve);
+          setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
+          d.onUnexpectedShutdown(resolve);
         });
         d.getStatus = d._oldGetStatus;
       });

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -236,14 +236,15 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         });
         // make sure that the request gets to the server before our shutdown
         await B.delay(100);
+        const shutdownEventPromise = new B((resolve, reject) => {
+          setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
+          d.onUnexpectedShutdown(resolve);
+        });
         d.startUnexpectedShutdown(new Error('Crashytimes'));
         let res = await p;
         res.status.should.equal(13);
         res.value.message.should.contain('Crashytimes');
-        await new B((resolve, reject) => {
-          setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
-          d.onUnexpectedShutdown(resolve);
-        });
+        await shutdownEventPromise;
         d.getStatus = d._oldGetStatus;
       });
     });
@@ -321,7 +322,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           json: {script, type: 'webdriverio'},
         });
         const expectedTimeouts = {command: 250, implicit: 0};
-        const expectedStatus = {};
+        const expectedStatus = null;
         res.value.result.should.eql([expectedTimeouts, expectedStatus]);
       });
 

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -322,7 +322,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           json: {script, type: 'webdriverio'},
         });
         const expectedTimeouts = {command: 250, implicit: 0};
-        const expectedStatus = null;
+        const expectedStatus = {};
         res.value.result.should.eql([expectedTimeouts, expectedStatus]);
       });
 

--- a/test/basedriver/driver-e2e-tests.js
+++ b/test/basedriver/driver-e2e-tests.js
@@ -240,7 +240,10 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         let res = await p;
         res.status.should.equal(13);
         res.value.message.should.contain('Crashytimes');
-        await d.onUnexpectedShutdown.should.be.rejectedWith('Crashytimes');
+        await new B((resolve, reject) => {
+          setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
+          d.once('onUnexpectedShutdown', resolve);
+        });
         d.getStatus = d._oldGetStatus;
       });
     });

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -88,11 +88,8 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       d.startUnexpectedShutdown(new Error('We crashed'));
       await cmdPromise.should.be.rejectedWith(/We crashed/);
       await new B((resolve, reject) => {
-        setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
-        d.once('onUnexpectedShutdown', (e) => {
-          /We crashed/.test(e.message).should.be.true;
-          resolve();
-        });
+        setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
+        d.onUnexpectedShutdown(resolve);
       });
     });
 
@@ -107,11 +104,8 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       await d.createSession(caps);
       d.startUnexpectedShutdown(new Error('We crashed'));
       await new B((resolve, reject) => {
-        setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
-        d.once('onUnexpectedShutdown', (e) => {
-          /We crashed/.test(e.message).should.be.true;
-          resolve();
-        });
+        setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
+        d.onUnexpectedShutdown(resolve);
       });
       await d.executeCommand('getSession').should.be.rejectedWith(/shut down/);
     });
@@ -128,11 +122,8 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       await d.createSession(caps);
       d.startUnexpectedShutdown(new Error('We crashed'));
       await new B((resolve, reject) => {
-        setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
-        d.once('onUnexpectedShutdown', (e) => {
-          /We crashed/.test(e.message).should.be.true;
-          resolve();
-        });
+        setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
+        d.onUnexpectedShutdown(resolve);
       });
 
       await d.executeCommand('getSession').should.be.rejectedWith(/shut down/);

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -85,12 +85,13 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       }.bind(d);
       let cmdPromise = d.executeCommand('getStatus');
       await B.delay(10);
-      d.startUnexpectedShutdown(new Error('We crashed'));
-      await cmdPromise.should.be.rejectedWith(/We crashed/);
-      await new B((resolve, reject) => {
+      const p = new B((resolve, reject) => {
         setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
         d.onUnexpectedShutdown(resolve);
       });
+      d.startUnexpectedShutdown(new Error('We crashed'));
+      await cmdPromise.should.be.rejectedWith(/We crashed/);
+      await p;
     });
 
     it('should not allow commands in middle of unexpected shutdown', async function () {
@@ -102,11 +103,12 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       }.bind(d);
       let caps = _.clone(defaultCaps);
       await d.createSession(caps);
-      d.startUnexpectedShutdown(new Error('We crashed'));
-      await new B((resolve, reject) => {
+      const p = new B((resolve, reject) => {
         setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
         d.onUnexpectedShutdown(resolve);
       });
+      d.startUnexpectedShutdown(new Error('We crashed'));
+      await p;
       await d.executeCommand('getSession').should.be.rejectedWith(/shut down/);
     });
 
@@ -120,11 +122,12 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
 
       let caps = _.clone(defaultCaps);
       await d.createSession(caps);
-      d.startUnexpectedShutdown(new Error('We crashed'));
-      await new B((resolve, reject) => {
+      const p = new B((resolve, reject) => {
         setTimeout(() => reject(new Error('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout')), 5000);
         d.onUnexpectedShutdown(resolve);
       });
+      d.startUnexpectedShutdown(new Error('We crashed'));
+      await p;
 
       await d.executeCommand('getSession').should.be.rejectedWith(/shut down/);
       await B.delay(500);

--- a/test/basedriver/driver-tests.js
+++ b/test/basedriver/driver-tests.js
@@ -87,7 +87,13 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       await B.delay(10);
       d.startUnexpectedShutdown(new Error('We crashed'));
       await cmdPromise.should.be.rejectedWith(/We crashed/);
-      await d.onUnexpectedShutdown.should.be.rejectedWith(/We crashed/);
+      await new B((resolve, reject) => {
+        setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
+        d.once('onUnexpectedShutdown', (e) => {
+          /We crashed/.test(e.message).should.be.true;
+          resolve();
+        });
+      });
     });
 
     it('should not allow commands in middle of unexpected shutdown', async function () {
@@ -100,7 +106,13 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       let caps = _.clone(defaultCaps);
       await d.createSession(caps);
       d.startUnexpectedShutdown(new Error('We crashed'));
-      await d.onUnexpectedShutdown.should.be.rejectedWith(/We crashed/);
+      await new B((resolve, reject) => {
+        setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
+        d.once('onUnexpectedShutdown', (e) => {
+          /We crashed/.test(e.message).should.be.true;
+          resolve();
+        });
+      });
       await d.executeCommand('getSession').should.be.rejectedWith(/shut down/);
     });
 
@@ -115,7 +127,13 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       let caps = _.clone(defaultCaps);
       await d.createSession(caps);
       d.startUnexpectedShutdown(new Error('We crashed'));
-      await d.onUnexpectedShutdown.should.be.rejectedWith(/We crashed/);
+      await new B((resolve, reject) => {
+        setTimeout(() => reject('onUnexpectedShutdown event is expected to be fired within 5 seconds timeout'), 5000);
+        d.once('onUnexpectedShutdown', (e) => {
+          /We crashed/.test(e.message).should.be.true;
+          resolve();
+        });
+      });
 
       await d.executeCommand('getSession').should.be.rejectedWith(/shut down/);
       await B.delay(500);


### PR DESCRIPTION
According to https://github.com/appium/appium/issues/13631 we still have memory leaks due to weird promise cancelation logic. IMHO promise cancelation itself is evil in its current implementation and I would rather avoid using it. 

BREAKING CHANGE: The current refactoring is breaking and changes `onUnexpectedShutdown` to a normal event, which is emitted by the driver when it is shut down unexpectedly. I've also checked the depending drivers and it looks like only the umbrella driver uses this promise, so we'll have to change that implementation after the major version bump