### PR TITLE
refactor: Change the setting update validation, so we don't print unnecessary warnings

### DIFF
--- a/lib/basedriver/device-settings.js
+++ b/lib/basedriver/device-settings.js
@@ -73,22 +73,24 @@ class DeviceSettings {
 
   // calls updateSettings from implementing driver every time a setting is changed.
   async update (newSettings) {
-    if (!_.isObject(newSettings)) {
-      throw new Error('Settings update should be called with valid JSON');
+    if (!_.isPlainObject(newSettings)) {
+      throw new Error(`Settings update should be called with valid JSON. Got ` +
+        `${JSON.stringify(newSettings)} instead`);
     }
-    for (let prop of _.keys(newSettings)) {
-      if (_.isUndefined(this._settings[prop])) {
-        log.warn(`Didn't know about setting '${prop}'. Are you sure you ` +
-                 `spelled it correctly? Proceeding anyway. Valid settings: ${_.keys(this._settings)}`);
-      }
-      if (this._settings[prop] !== newSettings[prop]) {
-        // update setting only when there is updateSettings defined.
-        if (this.onSettingsUpdate) {
-          await this.onSettingsUpdate(prop, newSettings[prop], this._settings[prop]);
-          this._settings[prop] = newSettings[prop];
-        } else {
-          log.errorAndThrow('Unable to update settings; onSettingsUpdate method not found');
+    for (const prop of _.keys(newSettings)) {
+      if (!_.isUndefined(this._settings[prop])) {
+        if (this._settings[prop] === newSettings[prop]) {
+          log.debug(`The value of '${prop}' setting did not change. Skipping the update for it`);
+          continue;
         }
+      }
+      // update setting only when there is updateSettings defined.
+      if (_.isFunction(this.onSettingsUpdate)) {
+        await this.onSettingsUpdate(prop, newSettings[prop], this._settings[prop]);
+        this._settings[prop] = newSettings[prop];
+      } else {
+        log.errorAndThrow(`Unable to update settings; ` +
+          `onSettingsUpdate method not found on '${this.constructor.name}'`);
       }
     }
   }


### PR DESCRIPTION
I think such warning messages only make more confusion rather than helping to resolve the problem. I'd rather let the server to decide which setting names are correct and which aren't.
See https://github.com/appium/appium/issues/13681#issuecomment-562089828 for more details.