### PR TITLE
fix: when parsing cap array, pass array through

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -354,6 +354,10 @@ function duplicateKeys (input, firstKey, secondKey) {
  * @param {string|Array<String>} cap A desired capability
  */
 function parseCapsArray (cap) {
+  if (_.isArray(cap)) {
+    return cap;
+  }
+
   let parsedCaps;
   try {
     parsedCaps = JSON.parse(cap);

--- a/test/basedriver/helpers-specs.js
+++ b/test/basedriver/helpers-specs.js
@@ -98,11 +98,14 @@ describe('parseCapsArray', function () {
   it('should parse string into array', function () {
     parseCapsArray('/tmp/my/app.zip').should.eql(['/tmp/my/app.zip']);
   });
-  it('should parse array into array', function () {
+  it('should parse array as string into array', function () {
     parseCapsArray('["/tmp/my/app.zip"]').should.eql(['/tmp/my/app.zip']);
     parseCapsArray('["/tmp/my/app.zip","/tmp/my/app2.zip"]').should.eql([
       '/tmp/my/app.zip',
       '/tmp/my/app2.zip'
     ]);
+  });
+  it('should return an array without change', function () {
+    parseCapsArray(['a', 'b']).should.eql(['a', 'b']);
   });
 });

--- a/test/jsonwp-proxy/protocol-converter-specs.js
+++ b/test/jsonwp-proxy/protocol-converter-specs.js
@@ -1,6 +1,3 @@
-// transpile:mocha
-/* global describe:true, it:true */
-
 import _ from 'lodash';
 import { PROTOCOLS } from '../../lib/protocol';
 import ProtocolConverter, {COMMAND_URLS_CONFLICTS} from '../../lib/jsonwp-proxy/protocol-converter';

--- a/test/jsonwp-proxy/proxy-specs.js
+++ b/test/jsonwp-proxy/proxy-specs.js
@@ -1,5 +1,4 @@
 // transpile:mocha
-/* global describe:true, it:true */
 
 import { JWProxy } from '../..';
 import request from './mock-request';

--- a/test/jsonwp-proxy/url-specs.js
+++ b/test/jsonwp-proxy/url-specs.js
@@ -1,5 +1,4 @@
 // transpile:mocha
-/* global describe:true, it:true */
 
 import { JWProxy } from '../..';
 import chai from 'chai';

--- a/test/jsonwp-status/status-specs.js
+++ b/test/jsonwp-status/status-specs.js
@@ -1,6 +1,3 @@
-// transpile:mocha
-/* global describe:true, it:true */
-
 import _ from 'lodash';
 import { statusCodes, getSummaryByCode } from '../..';
 import chai from 'chai';


### PR DESCRIPTION
If `parseCapsArray` is passed an array, it ought to just pass it back as is.