### PR TITLE
fix: Perform synchronous removal of applications cache

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -81,7 +81,7 @@ function getCachedApplicationPath (link, currentModified) {
     return fullPath;
   }
   logger.debug(`'Last-Modified' timestamp of '${link}' has been updated. ` +
-    `An updated copy of the application is going to be downloaded.`);
+    `The fresh copy of the application is going to be downloaded.`);
   return null;
 }
 

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -44,7 +44,7 @@ process.on('exit', () => {
   APPLICATIONS_CACHE.reset();
 
   logger.debug(`Performing cleanup of ${appPaths.length} cached ` +
-    `application${appPaths.length > 1 ? 's' : ''}`);
+    `application${appPaths.length === 1 ? '' : 's'}`);
   for (const appPath of appPaths) {
     try {
       // Asynchronous calls are not supported in onExit handler

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -81,7 +81,7 @@ function getCachedApplicationPath (link, currentModified) {
     return fullPath;
   }
   logger.debug(`'Last-Modified' timestamp of '${link}' has been updated. ` +
-    `The fresh copy of the application is going to be downloaded.`);
+    `A fresh copy of the application is going to be downloaded.`);
   return null;
 }
 

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -10,6 +10,7 @@ import asyncRequest from 'request-promise';
 import LRU from 'lru-cache';
 import AsyncLock from 'async-lock';
 import sanitize from 'sanitize-filename';
+import rimraf from 'rimraf';
 
 const ZIP_EXTS = ['.zip', '.ipa'];
 const ZIP_MIME_TYPES = [
@@ -35,31 +36,27 @@ const SANITIZE_REPLACEMENT = '-';
 const DEFAULT_BASENAME = 'appium-app';
 
 
-async function cleanupCachedApps () {
+function cleanupCachedApps () {
   if (!APPLICATIONS_CACHE.length) {
     return;
   }
+  const appPaths = APPLICATIONS_CACHE.values()
+    .map(({fullPath}) => fullPath);
+  APPLICATIONS_CACHE.reset();
 
-  logger.debug('Performing cleanup of the applications cache');
-  const cleanupPromises = [];
-  for (const {fullPath} of APPLICATIONS_CACHE.values()) {
-    cleanupPromises.push((async () => {
-      if (await fs.exists(fullPath)) {
-        await fs.rimraf(fullPath);
-      }
-    })());
-  }
-  try {
-    await B.all(cleanupPromises);
-  } catch (e) {
-    logger.error(e);
-  } finally {
-    APPLICATIONS_CACHE.reset();
+  logger.debug(`Performing cleanup of ${appPaths.length} cached ` +
+    `application${appPaths.length > 1 ? 's' : ''}`);
+  for (const appPath of appPaths) {
+    try {
+      // Asynchronous calls are not supported in onExit handler
+      rimraf.sync(appPath);
+    } catch (e) {
+      logger.warn(e);
+    }
   }
 }
 
 process.on('exit', cleanupCachedApps);
-process.on('SIGINT', cleanupCachedApps);
 
 
 async function retrieveHeaders (link) {

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -51,7 +51,7 @@ function cleanupCachedApps () {
       // Asynchronous calls are not supported in onExit handler
       rimraf.sync(appPath);
     } catch (e) {
-      logger.warn(e);
+      logger.warn(e.message);
     }
   }
 }

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -35,8 +35,7 @@ const APPLICATIONS_CACHE_GUARD = new AsyncLock();
 const SANITIZE_REPLACEMENT = '-';
 const DEFAULT_BASENAME = 'appium-app';
 
-
-function cleanupCachedApps () {
+process.on('exit', () => {
   if (!APPLICATIONS_CACHE.length) {
     return;
   }
@@ -54,9 +53,7 @@ function cleanupCachedApps () {
       logger.warn(e.message);
     }
   }
-}
-
-process.on('exit', cleanupCachedApps);
+});
 
 
 async function retrieveHeaders (link) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "morgan": "^1.9.0",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
+    "rimraf": "^3.0.0",
     "sanitize-filename": "^1.6.1",
     "serve-favicon": "^2.4.5",
     "source-map-support": "^0.5.5",


### PR DESCRIPTION
Asynchronous calls in onExit handler are not supported., since the event loop does not exist anymore. See https://nodejs.org/api/process.html#process_event_exit