### PR TITLE
chore: Tune logging for applications cache items disposal

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -18,7 +18,7 @@ const ZIP_MIME_TYPES = [
   'application/x-zip-compressed',
   'multipart/x-zip',
 ];
-const CACHED_APPS_MAX_AGE = 1000 * 60 * 60 * 24;
+const CACHED_APPS_MAX_AGE = 1000 * 60 * 60 * 24; // ms
 const APPLICATIONS_CACHE = new LRU({
   maxAge: CACHED_APPS_MAX_AGE, // expire after 24 hours
   updateAgeOnGet: true,
@@ -27,8 +27,7 @@ const APPLICATIONS_CACHE = new LRU({
       return;
     }
 
-    logger.info(`The application '${app}' cached at '${fullPath}' ` +
-      `has expired after ${CACHED_APPS_MAX_AGE}ms`);
+    logger.info(`The application '${app}' cached at '${fullPath}' has expired`);
     await fs.rimraf(fullPath);
   },
   noDisposeOnSet: true,

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -23,11 +23,13 @@ const APPLICATIONS_CACHE = new LRU({
   maxAge: CACHED_APPS_MAX_AGE, // expire after 24 hours
   updateAgeOnGet: true,
   dispose: async (app, {fullPath}) => {
+    if (!await fs.exists(fullPath)) {
+      return;
+    }
+
     logger.info(`The application '${app}' cached at '${fullPath}' ` +
       `has expired after ${CACHED_APPS_MAX_AGE}ms`);
-    if (await fs.exists(fullPath)) {
-      await fs.rimraf(fullPath);
-    }
+    await fs.rimraf(fullPath);
   },
   noDisposeOnSet: true,
 });
@@ -39,10 +41,9 @@ process.on('exit', () => {
   if (!APPLICATIONS_CACHE.length) {
     return;
   }
+
   const appPaths = APPLICATIONS_CACHE.values()
     .map(({fullPath}) => fullPath);
-  APPLICATIONS_CACHE.reset();
-
   logger.debug(`Performing cleanup of ${appPaths.length} cached ` +
     `application${appPaths.length === 1 ? '' : 's'}`);
   for (const appPath of appPaths) {


### PR DESCRIPTION
The `dispose` handler is called each time an entry is removed from LRU cache, which might create some excessive logging on process exit. The PR changes the logic to only print the log when necessary to not confuse users.