### PR TITLE
fix: terminate socket on DELETE session and NoSuchDriverError

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -245,10 +245,13 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
     let newSessionId;
     let currentProtocol = extractProtocol(driver, req.params.sessionId);
 
+    let terminateSocket = false;
+
     try {
       // if this is a session command but we don't have a session,
       // error out early (especially before proxying)
       if (isSessCmd && !driver.sessionExists(req.params.sessionId)) {
+        terminateSocket = true;
         throw new errors.NoSuchDriverError();
       }
 
@@ -340,6 +343,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // delete should not return anything even if successful
       if (spec.command === DELETE_SESSION_COMMAND) {
+        terminateSocket = true;
         SESSIONS_CACHE.getLogger(req.params.sessionId, currentProtocol)
           .debug(`Received response: ${_.truncate(JSON.stringify(driverRes), {length: LOG_OBJ_LENGTH})}`);
         SESSIONS_CACHE.getLogger(req.params.sessionId, currentProtocol).debug('But deleting session, so not returning');
@@ -423,8 +427,13 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       httpResBody = formatStatus(httpResBody, httpStatus, currentProtocol);
-
       res.status(httpStatus).json(httpResBody);
+
+      // in certain situations the socket should not be kept alive
+      if (terminateSocket) {
+        SESSIONS_CACHE.getLogger(req.params.sessionId || newSessionId, currentProtocol).debug(`Destroying socket connection`);
+        res.socket.destroy();
+      }
     }
   };
   // add the method to the app


### PR DESCRIPTION
In the case of ending sessions, and when a request is for a session that does not exist, the connection should not remain alive.