### PR TITLE
fix: remove test/ build/test for notarization to fix a warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lib",
     "static",
     "build/index.js",
-    "build/lib",
+    "build/lib"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
     "index.js",
     "lib",
     "static",
-    "test/basedriver",
     "build/index.js",
     "build/lib",
-    "build/test/basedriver"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,13 @@
     "index.js",
     "lib",
     "static",
+    "test/basedriver",
+    "!test/basedriver/fixtures",
     "build/index.js",
-    "build/lib"
+    "build/lib",
+    "build/test/basedriver",
+    "!build/test/basedriver/fixtures"
+
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",


### PR DESCRIPTION
Another macOS notarization warning.
`BadZippedApp.zip` in test fixture has `Couldn't read PKZip signature` warning message. We can remove `test` stuff from the package, simply.