### PR TITLE
feat: add score attribute for image element

### DIFF
--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -231,6 +231,7 @@ helpers.findByImage = async function findByImage (b64Template, {
 
   let rect = null;
   let b64Matched = null;
+  let score = 0;
   const condition = async () => {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
@@ -243,6 +244,7 @@ helpers.findByImage = async function findByImage (b64Template, {
       const comparedImage = await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize});
       rect = comparedImage.rect;
       b64Matched = comparedImage.visualization;
+      score = comparedImage.score;
 
       return true;
     } catch (err) {
@@ -282,7 +284,7 @@ helpers.findByImage = async function findByImage (b64Template, {
   if (b64Matched) {
     log.info(`Matched base64 data: ${b64Matched.substring(0, 200)}...`);
   }
-  const imgEl = new ImageElement(b64Template, rect, b64Matched);
+  const imgEl = new ImageElement(b64Template, rect, score, b64Matched);
 
   // if we're just checking staleness, return straightaway so we don't add
   // a new element to the cache. shouldCheckStaleness does not support multiple

--- a/lib/basedriver/image-element.js
+++ b/lib/basedriver/image-element.js
@@ -50,11 +50,12 @@ class ImageElement {
    *
    * @returns {ImageElement}
    */
-  constructor (b64Template, rect, b64Result = null) {
+  constructor (b64Template, rect, score, b64Result = null) {
     this.template = b64Template;
     this.rect = rect;
     this.id = `${IMAGE_ELEMENT_PREFIX}${util.uuidV4()}`;
     this.b64MatchedImage = b64Result;
+    this.score = score;
   }
 
   /**
@@ -242,10 +243,13 @@ class ImageElement {
         // /session/:sessionId/element/:elementId/attribute/:name
         // /session/:sessionId/element/:elementId/attribute/visual should retun the visual data
         // e.g. ["content-desc","appium-image-element-xxxxx","xxxxx"], ["visual","appium-image-element-xxxxx","xxxxx"]
-        if (args[0] === 'visual') {
-          return imgEl.matchedImage;
-        } else {
-          throw new errors.NotYetImplementedError();
+        switch (args[0]) {
+          case 'visual':
+            return imgEl.matchedImage;
+          case 'score':
+            return imgEl.score;
+          default:
+            throw new errors.NotYetImplementedError();
         }
       default: throw new errors.NotYetImplementedError();
     }

--- a/lib/basedriver/image-element.js
+++ b/lib/basedriver/image-element.js
@@ -45,7 +45,7 @@ class ImageElement {
    * @param {string} b64Template - the base64-encoded image which was used to
    *                               find this ImageElement
    * @param {Rect} rect - bounds of matched image element
-   * @param {float} score The similarity score as a float number in range [0.0, 1.0].
+   * @param {number} score The similarity score as a float number in range [0.0, 1.0].
    * 1.0 is the highest score (means both images are totally equal).
    * @param {?string} b64Result - the base64-encoded image which has matched marks.
    *                              Defaults to null.

--- a/lib/basedriver/image-element.js
+++ b/lib/basedriver/image-element.js
@@ -45,6 +45,8 @@ class ImageElement {
    * @param {string} b64Template - the base64-encoded image which was used to
    *                               find this ImageElement
    * @param {Rect} rect - bounds of matched image element
+   * @param {float} score The similarity score as a float number in range [0.0, 1.0].
+   * 1.0 is the highest score (means both images are totally equal).
    * @param {?string} b64Result - the base64-encoded image which has matched marks.
    *                              Defaults to null.
    *

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-support": "^2.42.0",
+    "appium-support": "^2.43.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.3",

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -44,6 +44,7 @@ describe('finding elements by image', function () {
 
   describe('findByImage', function () {
     const rect = {x: 10, y: 20, width: 30, height: 40};
+    const score = 0.9;
     const size = {width: 100, height: 200};
     const screenshot = 'iVBORfoo';
     const template = 'iVBORbar';
@@ -51,7 +52,7 @@ describe('finding elements by image', function () {
     function basicStub (driver) {
       const sizeStub = sinon.stub(driver, 'getWindowSize').returns(size);
       const screenStub = sinon.stub(driver, 'getScreenshotForImageFind').returns(screenshot);
-      const compareStub = sinon.stub(driver, 'compareImages').returns({rect});
+      const compareStub = sinon.stub(driver, 'compareImages').returns({rect, score});
       return {sizeStub, screenStub, compareStub};
     }
 
@@ -61,6 +62,7 @@ describe('finding elements by image', function () {
       const imgEl = driver._imgElCache.get(imgElId);
       (imgEl instanceof ImageElement).should.be.true;
       imgEl.rect.should.eql(rect);
+      imgEl.score.should.eql(score);
       return imgEl;
     }
 

--- a/test/basedriver/image-element-specs.js
+++ b/test/basedriver/image-element-specs.js
@@ -162,7 +162,7 @@ describe('ImageElement', function () {
 
   describe('#execute', function () {
     // aGFwcHkgdGVzdGluZw== is 'happy testing'
-    const imgEl = new ImageElement(defTemplate, defRect, 'aGFwcHkgdGVzdGluZw==');
+    const imgEl = new ImageElement(defTemplate, defRect, 0, 'aGFwcHkgdGVzdGluZw==');
     const clickStub = sinon.stub(imgEl, 'click');
 
     before(function () {
@@ -202,6 +202,10 @@ describe('ImageElement', function () {
     it('should get rect of element', async function () {
       await ImageElement.execute(driver, 'getElementRect', imgEl.id)
         .should.eventually.eql(defRect);
+    });
+    it('should get score of element', async function () {
+      await ImageElement.execute(driver, 'getAttribute', imgEl.id, 'score')
+        .should.eventually.eql(0);
     });
     it('should get visual of element', async function () {
       await ImageElement.execute(driver, 'getAttribute', imgEl.id, 'visual')


### PR DESCRIPTION
https://github.com/appium/appium/issues/13883

Depends on https://github.com/appium/appium-support/pull/169

After this change, we can get `score` image attribute like below:

- client (Ruby)
```ruby
image_element =  @@driver.find_element_by_image AppiumLibCoreTest.path_of('test/functional/data/test_ios_button.png')
=> #<Selenium::WebDriver::Element:0x4de9c1e10ffa87de id="appium-image-element-e3b9dd5b-0c26-47a7-838a-6d72d61f62e7">
> image_element.score
=> 0.9313163161277771
```

- server
```
[HTTP] --> GET /wd/hub/session/97e811cd-d675-4f2c-a00e-ec79f5b1631b/element/appium-image-element-e3b9dd5b-0c26-47a7-838a-6d72d61f62e7/attribute/score
[HTTP] {}
[debug] [W3C (97e811cd)] Calling AppiumDriver.getAttribute() with args: ["score","appium-image-element-e3b9dd5b-0c26-47a7-838a-6d72d61f62e7","97e811cd-d675-4f2c-a00e-ec79f5b1631b"]
[debug] [XCUITest] Executing command 'getAttribute'
[debug] [W3C (97e811cd)] Responding to client with driver.getAttribute() result: 0.9313163161277771
[HTTP] <-- GET /wd/hub/session/97e811cd-d675-4f2c-a00e-ec79f5b1631b/element/appium-image-element-e3b9dd5b-0c26-47a7-838a-6d72d61f62e7/attribute/score 200 1 ms - 28
[HTTP]
[BaseDriver] Shutting down because we waited 120 seconds for a command
[Appium] Closing session, cause was 'New Command Timeout of 120 seconds expired. Try customizing the timeout using the 'newCommandTimeout' desired capability'
[Appium] Removing session '97e811cd-d675-4f2c-a00e-ec79f5b1631b' from our master session list
[DevCon Factory] Releasing connections for F9F30814-75E5-45DD-98A5-5650B97E63D2 device on any port number
[DevCon Factory] Found cached connections to release: ["F9F30814-75E5-45DD-98A5-5650B97E63D2:8100"]
[debug] [DevCon Factory] Cached connections count: 0
[debug] [XCUITest] Not clearing log files. Use `clearSystemFiles` capability to turn on.
[debug] [IOSSimulatorLog] Stopping iOS log capture
```