### PR TITLE
fix: put full date on the static guinea pig pages

### DIFF
--- a/lib/express/static.js
+++ b/lib/express/static.js
@@ -13,11 +13,11 @@ if (_.isNull(path.resolve(__dirname).match(/build[/\\]lib[/\\]express$/))) {
 }
 
 async function guineaPigTemplate (req, res, page) {
-  let delay = parseInt(req.params.delay || req.query.delay || 0, 10);
-  let throwError = req.params.throwError || req.query.throwError || '';
+  const delay = parseInt(req.params.delay || req.query.delay || 0, 10);
+  const throwError = req.params.throwError || req.query.throwError || '';
   let params = {
     throwError,
-    serverTime: parseInt(Date.now() / 1000, 10),
+    serverTime: new Date(),
     userAgent: req.headers['user-agent'],
     comment: 'None'
   };

--- a/static/test/guinea-pig-app-banner.html
+++ b/static/test/guinea-pig-app-banner.html
@@ -71,7 +71,7 @@ I am some page content
   <br/>
 
   <p>Server time: <span id="servertime"><%= serverTime %></span></p>
-  <p>Client time: <span id="clienttime"><%= parseInt(new Date().getTime() / 1000, 10) %></span></p>
+  <p>Client time: <span id="clienttime"><%= new Date() %></span></p>
   <script type="text/javascript">
     var uuid;
     try {uuid = window.location.toString().match(/\?(.*)$/)[1]; } catch (ign) {}

--- a/static/test/guinea-pig-scrollable.html
+++ b/static/test/guinea-pig-scrollable.html
@@ -122,7 +122,7 @@ I am some page content
   <br/>
 
   <p>Server time: <span id="servertime"><%= serverTime %></span></p>
-  <p>Client time: <span id="clienttime"><%= parseInt(new Date().getTime() / 1000, 10) %></span></p>
+  <p>Client time: <span id="clienttime"><%= new Date() %></span></p>
   <script type="text/javascript">
     var uuid;
     try {uuid = window.location.toString().match(/\?(.*)$/)[1]; } catch (ign) {}

--- a/static/test/guinea-pig.html
+++ b/static/test/guinea-pig.html
@@ -30,7 +30,6 @@ I am some page content
 <div id="popuplink" onclick="setTimeout(function() { window.open('/test/guinea-pig2.html', 'popupwin'); }, 500);">i cause a popup window</div>
 <div id="guinea pig 5 popup link" onclick="setTimeout(function() { window.open('/test/guinea-pig5.html', 'popupwin'); }, 500);">i cause a popup window with page 5</div>
 <div id="invisible div" style="display:none;">i am invisible</div>
-<div>
   <a id="alert1" href="javascript:void(0);" onclick="alert('I am an alert')">I cause an alert</a>
   <a id="prompt1" href="javascript:void(0);" onclick="$('#promptVal').val(prompt('Do you like javascript?'));">I cause a prompt</a>
   <input type="text" value="" id="promptVal" /></div>
@@ -78,7 +77,7 @@ I am some page content
   <br/>
 
   <p>Server time: <span id="servertime"><%= serverTime %></span></p>
-  <p>Client time: <span id="clienttime"><%= parseInt(new Date().getTime() / 1000, 10) %></span></p>
+  <p>Client time: <span id="clienttime"><%= new Date() %></span></p>
   <script type="text/javascript">
     var uuid;
     try {uuid = window.location.toString().match(/\?(.*)$/)[1]; } catch (ign) {}


### PR DESCRIPTION
This has bugged me for a while. Our guinea pig pages put the date as a number. Move to a human-readable date.