### PR TITLE
feat: add calling chrome devtools endpoint for chromium

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -700,6 +700,12 @@ const METHOD_MAP = {
       },
     }
   },
+
+  // chromium devtools
+  // https://chromium.googlesource.com/chromium/src/+/master/chrome/test/chromedriver/server/http_handler.cc
+  '/session/:sessionId/goog/cdp/execute': {
+    POST: {}
+  },
 };
 
 // driver command names

--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -703,7 +703,7 @@ const METHOD_MAP = {
 
   // chromium devtools
   // https://chromium.googlesource.com/chromium/src/+/master/chrome/test/chromedriver/server/http_handler.cc
-  '/session/:sessionId/goog/cdp/execute': {
+  '/session/:sessionId/:vendor/cdp/execute': {
     POST: {command: 'executeCdp', payloadParams: {required: ['cmd', 'params']}}
   },
 };

--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -704,7 +704,7 @@ const METHOD_MAP = {
   // chromium devtools
   // https://chromium.googlesource.com/chromium/src/+/master/chrome/test/chromedriver/server/http_handler.cc
   '/session/:sessionId/goog/cdp/execute': {
-    POST: {}
+    POST: {command: 'executeCdp', payloadParams: {required: ['cmd', 'params']}}
   },
 };
 

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('86dc6c5b');
+      hash.should.equal('5632be1a');
     });
   });
 

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('5632be1a');
+      hash.should.equal('6b8aac4e');
     });
   });
 

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('6b8aac4e');
+      hash.should.equal('789b5ab2');
     });
   });
 


### PR DESCRIPTION
Chrome browser support `/session/:sessionId/goog/cdp/execute` endpoint.
Selenium bindings, afaik Java, Python and Ruby, have the endpoint.

We also can support it for chromebrowser. Below is an example.

```
> @driver.execute_cdp 'Page.getResourceTree'
=> {"frameTree"=>
  {"frame"=>{"id"=>"39B491DE0055515F0F352E11054854F9", "loaderId"=>"3E11DD1F2E9E020331C94E2E02E608E7", "mimeType"=>"text/plain", "securityOrigin"=>"://", "url"=>"data:,"},
   "resources"=>[{"contentSize"=>0, "mimeType"=>"text/plain", "type"=>"Document", "url"=>"data:,"}]}}
```

https://chromedevtools.github.io/devtools-protocol


Without this change, Appium returns below error.
```
[HTTP] --> POST /wd/hub/session/ba1e624d-d767-4059-a499-18e1aa330651/goog/cdp/execute
[HTTP] {"cmd":"Page.getResourceTree","params":{}}
[debug] [HTTP] No route found. Setting content type to 'text/plain'
[HTTP] <-- POST /wd/hub/session/ba1e624d-d767-4059-a499-18e1aa330651/goog/cdp/execute 404 9 ms - 111
[HTTP]
```