### PR TITLE
chore: do not print full stack traces for connection errors

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -16,6 +16,7 @@ import https from 'https';
 
 const log = logger.getLogger('WD Proxy');
 const DEFAULT_REQUEST_TIMEOUT = 240000;
+const COMPACT_ERROR_PATTERNS = [/\bECONNREFUSED\b/];
 
 const {MJSONWP, W3C} = PROTOCOLS;
 
@@ -213,11 +214,9 @@ class JWProxy {
         }
       } else {
         proxyErrorMsg = `Could not proxy command to the remote server. Original error: ${e.message}`;
-        // A usual system error message looks like `connect ECONNREFUSED 127.0.0.1:8100`
-        if (/\bE[A-Z_]+\b/.test(e.message)) {
+        if (COMPACT_ERROR_PATTERNS.some((p) => p.test(e.message))) {
           log.info(e.message);
         } else {
-          // Only print full stack traces for non-system errors
           log.debug(e.stack);
         }
       }

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -217,7 +217,7 @@ class JWProxy {
         if (COMPACT_ERROR_PATTERNS.some((p) => p.test(e.message))) {
           log.info(e.message);
         } else {
-          log.debug(e.stack);
+          log.info(e.stack);
         }
       }
       throw new errors.ProxyRequestError(proxyErrorMsg, e.response?.data, e.response?.status);

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -213,8 +213,13 @@ class JWProxy {
         }
       } else {
         proxyErrorMsg = `Could not proxy command to the remote server. Original error: ${e.message}`;
-        log.warn(e.message);
-        log.debug(e.stack);
+        // A usual system error message looks like `connect ECONNREFUSED 127.0.0.1:8100`
+        if (/\bE[A-Z_]+\b/.test(e.message)) {
+          log.info(e.message);
+        } else {
+          // Only print full stack traces for non-system errors
+          log.debug(e.stack);
+        }
       }
       throw new errors.ProxyRequestError(proxyErrorMsg, e.response?.data, e.response?.status);
     }


### PR DESCRIPTION
It does not make much sense to have full stack traces for system errors in logs, which look redundant:

```
WARN [07-03-30:969] WD Proxy connect ECONNREFUSED 127.0.0.1:8100
352dbug [07-03-30:979] WD Proxy Error: connect ECONNREFUSED 127.0.0.1:8100
353dbug [07-03-30:979] WD Proxy     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)
```