### PR TITLE
fix(welcome page): add "viewport" meta tag

### DIFF
--- a/static/test/welcome.html
+++ b/static/test/welcome.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Appium/welcome</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
   <body>
     <h1><%= message %></h1>


### PR DESCRIPTION
### The problem

In simulator safari ios I get incorrect viewport width and height. Moreover it does not changed after rotation. It fixed only if viewport meta tag is set.

### Screenshots
<img width="1661" alt="Screenshot 2020-05-25 at 16 42 53" src="https://user-images.githubusercontent.com/5900697/82818695-c2042500-9ea7-11ea-93f6-aeb3a0e3a575.png">
<img width="1671" alt="Screenshot 2020-05-25 at 16 43 48" src="https://user-images.githubusercontent.com/5900697/82818712-cb8d8d00-9ea7-11ea-96cf-6f726b14b8ab.png">
<img width="1672" alt="Screenshot 2020-05-25 at 16 45 44" src="https://user-images.githubusercontent.com/5900697/82818720-cf211400-9ea7-11ea-9a3c-c80472fd501c.png">
<img width="1672" alt="Screenshot 2020-05-25 at 16 46 11" src="https://user-images.githubusercontent.com/5900697/82818729-d21c0480-9ea7-11ea-9d88-5d57962183c2.png">
