### PR TITLE
chore: Print a compact message for 'socket hang up' error

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -16,7 +16,10 @@ import https from 'https';
 
 const log = logger.getLogger('WD Proxy');
 const DEFAULT_REQUEST_TIMEOUT = 240000;
-const COMPACT_ERROR_PATTERNS = [/\bECONNREFUSED\b/];
+const COMPACT_ERROR_PATTERNS = [
+  /\bECONNREFUSED\b/,
+  /socket hang up/,
+];
 
 const {MJSONWP, W3C} = PROTOCOLS;
 


### PR DESCRIPTION
It does not make much sense to show a full stack trace there, since it does not contain any useful info. See https://dev.azure.com/AppiumCI/7a2a2919-d2b4-4720-a6c3-3a639f9bb2e0/_apis/build/builds/9842/logs/35 for more details