### PR TITLE
fix: Properly assign connection pools for JW proxy

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -39,6 +39,14 @@ class JWProxy {
     this._activeRequests = [];
     this._reqCancelSource = axios.CancelToken.source();
     this._downstreamProtocol = null;
+    const agentOpts = {
+      keepAlive: this.keepAlive,
+      maxSockets: 30,
+      maxFreeSockets: 10,
+      timeout: 60000,
+    };
+    this.httpAgent = new http.Agent(agentOpts);
+    this.httpsAgent = new https.Agent(agentOpts);
     this.protocolConverter = new ProtocolConverter(this.proxy.bind(this));
   }
 
@@ -149,8 +157,8 @@ class JWProxy {
         accept: 'application/json, */*',
       },
       timeout: this.timeout,
-      httpAgent: new http.Agent({ keepAlive: this.keepAlive }),
-      httpsAgent: new https.Agent({ keepAlive: this.keepAlive }),
+      httpAgent: this.httpAgent,
+      httpsAgent: this.httpsAgent,
       cancelToken: this._reqCancelSource.token,
     };
     // GET methods shouldn't have any body. Most servers are OK with this, but WebDriverAgent throws 400 errors

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -33,14 +33,13 @@ class JWProxy {
       reqBasePath: DEFAULT_BASE_PATH,
       sessionId: null,
       timeout: DEFAULT_REQUEST_TIMEOUT,
-      keepAlive: true,
     });
     this.scheme = this.scheme.toLowerCase();
     this._activeRequests = [];
     this._reqCancelSource = axios.CancelToken.source();
     this._downstreamProtocol = null;
     const agentOpts = {
-      keepAlive: this.keepAlive,
+      keepAlive: opts.keepAlive ?? true,
       maxSockets: 30,
       maxFreeSockets: 10,
       timeout: 60000,


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/14416

Previously we were creating a separate connections pool for each request, which is bad. The connections pool must be shared in scope of a single JWProxy instance