### PR TITLE
fix: extract ipa properly

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -1,3 +1,4 @@
+import os from 'os';
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
@@ -6,7 +7,7 @@ import { tempDir, fs, util, zip, net } from 'appium-support';
 import LRU from 'lru-cache';
 import AsyncLock from 'async-lock';
 import axios from 'axios';
-import unzipper from 'unzipper';
+import {Open as OpenZip} from 'unzipper';
 
 const ZIP_EXTS = ['.zip', '.ipa'];
 const ZIP_MIME_TYPES = [
@@ -322,10 +323,12 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
   try {
     logger.debug(`Unzipping '${zipPath}'`);
     // zip.extractAllTo could not unzip Unicode filenames properly by Xcode
-    // because of https://github.com/appium/appium/issues/14100
-    // so here uses unzipper which can handle the case
-    await unzipper.Open.file(zipPath)
-      .then(d => d.extract({path: tmpRoot, concurrency: 5}));
+    // because of https://github.com/appium/appium/issues/14100.
+    // The unzipper does not keep file permissions (should set as option explicitly),
+    // so we use the library only for unzip the app under test instead of
+    // the replacement of zip.extractAllTo internal.
+    const destDir = await OpenZip.file(zipPath);
+    await destDir.extract({path: tmpRoot, concurrency: os.cpus().length});
 
     const allExtractedItems = await fs.glob('**', {cwd: tmpRoot});
     logger.debug(`Extracted ${util.pluralize('item', allExtractedItems.length, true)} from '${zipPath}'`);

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -6,7 +6,7 @@ import { tempDir, fs, util, zip, net } from 'appium-support';
 import LRU from 'lru-cache';
 import AsyncLock from 'async-lock';
 import axios from 'axios';
-
+import unzipper from 'unzipper';
 
 const ZIP_EXTS = ['.zip', '.ipa'];
 const ZIP_MIME_TYPES = [
@@ -321,7 +321,9 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
   const tmpRoot = await tempDir.openDir();
   try {
     logger.debug(`Unzipping '${zipPath}'`);
-    await zip.extractAllTo(zipPath, tmpRoot);
+    await unzipper.Open.file(zipPath)
+      .then(d => d.extract({path: tmpRoot, concurrency: 5}));
+
     const allExtractedItems = await fs.glob('**', {cwd: tmpRoot});
     logger.debug(`Extracted ${util.pluralize('item', allExtractedItems.length, true)} from '${zipPath}'`);
     const allBundleItems = allExtractedItems

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -321,6 +321,9 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
   const tmpRoot = await tempDir.openDir();
   try {
     logger.debug(`Unzipping '${zipPath}'`);
+    // zip.extractAllTo could not unzip Unicode filenames properly by Xcode
+    // because of https://github.com/appium/appium/issues/14100
+    // so here uses unzipper which can handle the case
     await unzipper.Open.file(zipPath)
       .then(d => d.extract({path: tmpRoot, concurrency: 5}));
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "morgan": "^1.9.0",
     "serve-favicon": "^2.4.5",
     "source-map-support": "^0.5.5",
+    "unzipper": "^0.10.11",
     "validate.js": "^0.13.0",
     "webdriverio": "^6.0.2",
     "ws": "^7.0.0"


### PR DESCRIPTION
Tried to fix https://github.com/appium/appium/issues/14100#issuecomment-653733643 without workaround https://github.com/appium/appium/pull/14510

The root cause of the issue is current unzip generates wrong unzipped filenames by Unicode zipped files by Xcode.
When I created a sample app which only added Japanese titled file as a bundled resource, current unzip generated below:

```
$ ls /var/folders/y6/524wp8fx0xj5q1rf6fktjrb00000gn/T/202064-53753-11msanj.01vrk/kazu-sample.app/
Assets.car               Info.plist               _CodeSignature           kazu-sample
Base.lproj               PkgInfo                  embedded.mobileprovision µùÑµ£¼Φ¬₧.png
```

This PR will be:

```
$ ls /var/folders/y6/524wp8fx0xj5q1rf6fktjrb00000gn/T/202064-74785-1yg4iv.4fiis/kazu-sample.app/
Assets.car               Info.plist               _CodeSignature           kazu-sample
Base.lproj               PkgInfo                  embedded.mobileprovision 日本語.png
```

https://github.com/ZJONSSON/node-unzipper#readme

~~I only tested my local ipa, but not for Android and over http yet.~~ <= Tested with our sample apps.

I haven't changed other zip stuff to introduce unzipper from the minimal scope