### PR TITLE
chore: Never apply automatic proxy config to JWProxy requests

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -155,6 +155,7 @@ class JWProxy {
         'user-agent': 'appium',
         accept: 'application/json, */*',
       },
+      proxy: false,
       timeout: this.timeout,
       httpAgent: this.httpAgent,
       httpsAgent: this.httpsAgent,


### PR DESCRIPTION
There requests are always made on localhost level, so there's no need to route them to a proxy server