### PR TITLE
chore: Always destroy active sockets on server shutdown

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -135,7 +135,11 @@ function configureHttp ({httpServer, reject}) {
     // https://github.com/nodejs/node-v0.x-archive/issues/9066#issuecomment-124210576
     serverState.closed = true;
     serverState.notifier.emit('shutdown');
-    httpServer.on('close', resolve);
+    log.info('Waiting until the server is closed');
+    httpServer.on('close', () => {
+      log.info('Received server close event');
+      resolve();
+    });
     close((err) => {
       if (err) reject(err); // eslint-disable-line curly
     });
@@ -158,9 +162,7 @@ function configureHttp ({httpServer, reject}) {
     socket.on('error', reject);
 
     function destroy () {
-      if (socket._openReqCount === 0) {
-        socket.destroy();
-      }
+      socket.destroy();
     }
     socket._openReqCount = 0;
     socket.once('close', () => serverState.notifier.removeListener('shutdown', destroy));

--- a/test/express/server-e2e-specs.js
+++ b/test/express/server-e2e-specs.js
@@ -66,8 +66,8 @@ describe('server', function () {
       port: 8181,
     }).should.be.rejectedWith(/EADDRINUSE/);
   });
-  it('should wait for the server close connections before finishing closing', async function () {
-    let bodyPromise = axios.get('http://localhost:8181/pause');
+  it('should not wait for the server close connections before finishing closing', async function () {
+    let bodyPromise = axios.get('http://localhost:8181/pause').catch(() => {});
 
     // relinquish control so that we don't close before the request is received
     await B.delay(100);
@@ -75,9 +75,9 @@ describe('server', function () {
     let before = Date.now();
     await hwServer.close();
     // expect slightly less than the request waited, since we paused above
-    (Date.now() - before).should.be.above(800);
+    (Date.now() - before).should.not.be.above(800);
 
-    (await bodyPromise).data.should.equal('We have waited!');
+    await bodyPromise;
   });
   it('should error if we try to start on a bad hostname', async function () {
     this.timeout(60000);


### PR DESCRIPTION
This change ensures there will be no unexpected delays when appium process receives SIGINT or SIGTERM