### PR TITLE
fix: allow prefixed standard capabilities

### DIFF
--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -87,10 +87,17 @@ function stripAppiumPrefixes (caps) {
     // If it's standard capability that was prefixed, add it to an array of incorrectly prefixed capabilities
     if (isStandardCap(strippedCapName)) {
       badPrefixedCaps.push(strippedCapName);
+      if (_.isNil(caps[strippedCapName])) {
+        caps[strippedCapName] = caps[prefixedCap];
+      } else {
+        log.warn(`Ignoring capability '${prefixedCap}=${caps[prefixedCap]}' and ` +
+          `using capability '${strippedCapName}=${caps[strippedCapName]}'`);
+      }
+    } else {
+      caps[strippedCapName] = caps[prefixedCap];
     }
 
     // Strip out the prefix
-    caps[strippedCapName] = caps[prefixedCap];
     delete caps[prefixedCap];
   }
 

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -96,7 +96,7 @@ function stripAppiumPrefixes (caps) {
 
   // If we found standard caps that were incorrectly prefixed, throw an exception (e.g.: don't accept 'appium:platformName', only accept just 'platformName')
   if (badPrefixedCaps.length > 0) {
-    throw new errors.InvalidArgumentError(`The capabilities ${JSON.stringify(badPrefixedCaps)} are standard capabilities and should not have the "appium:" prefix`);
+    log.warn(`The capabilities ${JSON.stringify(badPrefixedCaps)} are standard capabilities and do not require "appium:" prefix`);
   }
 }
 

--- a/lib/basedriver/capabilities.js
+++ b/lib/basedriver/capabilities.js
@@ -198,6 +198,7 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
       }
     } catch (err) {
       log.warn(err.message);
+      validationErrors.push(err.message);
     }
   }
 

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -261,6 +261,12 @@ describe('caps', function () {
         firstMatch: [{'appium:browserName': 'FOO', 'browserName': 'BAR'}],
       }).should.deep.equal({platformName: 'Bar', browserName: 'BAR'});
     });
+    it('should throw exception if duplicates in alwaysMatch and firstMatch', function () {
+      (() => processCapabilities({
+        alwaysMatch: {'platformName': 'Fake', 'appium:fakeCap': 'foobar'},
+        firstMatch: [{'appium:platformName': 'bar'}],
+      })).should.throw(/should not exist on both primary/);
+    });
 
     it('should not throw an exception if presence constraint is not met on a firstMatch capability', function () {
       const caps = processCapabilities({

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -248,11 +248,11 @@ describe('caps', function () {
       }).should.deep.equal({hello: 'world', foo: 'bar'});
     });
 
-    it('should throw an exception if a standard capability (https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities) is prefixed', function () {
-      (() => processCapabilities({
+    it('should still accept prefixed caps even if they are standard capabilities (https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)', function () {
+      processCapabilities({
         alwaysMatch: {'appium:platformName': 'Whatevz'},
         firstMatch: [{'appium:browserName': 'Anything'}],
-      })).should.throw(/standard capabilities/);
+      }).should.deep.equal({platformName: 'Whatevz', browserName: 'Anything'});
     });
 
     it('should not throw an exception if presence constraint is not met on a firstMatch capability', function () {

--- a/test/basedriver/capabilities-specs.js
+++ b/test/basedriver/capabilities-specs.js
@@ -255,6 +255,13 @@ describe('caps', function () {
       }).should.deep.equal({platformName: 'Whatevz', browserName: 'Anything'});
     });
 
+    it('should prefer standard caps that are non-prefixed to prefixed', function () {
+      processCapabilities({
+        alwaysMatch: {'appium:platformName': 'Foo', 'platformName': 'Bar'},
+        firstMatch: [{'appium:browserName': 'FOO', 'browserName': 'BAR'}],
+      }).should.deep.equal({platformName: 'Bar', browserName: 'BAR'});
+    });
+
     it('should not throw an exception if presence constraint is not met on a firstMatch capability', function () {
       const caps = processCapabilities({
         alwaysMatch: {'platformName': 'Fake', 'appium:fakeCap': 'foobar'},


### PR DESCRIPTION
Currently, if we provide W3C capabilities and prefix standard W3C capabilities (platformName, browserName, etc...) it rejects the session. This PR is made, in the spirit of forgiveness, to allow standard capabilities to be prefixed with `appium:` and let the offenders off with a `log.warn`.

Example of session creation caps that will fail in Appium's current state

```
{
	"capabilities": {
		"firstMatch": [{}],
		"alwaysMatch": {
		  "appium:platformName": "iOS",
		  "appium:browserName": "safari",
		  "appium:automationName": "XCUITest",
		  "appium:deviceName": "iPhone Simulator",
		  "appium:platformVersion": "13.4",
		  "sauce:options": {
		    "appiumVersion": "1.16.0"
		  }
		}
	}
}
```