### PR TITLE
fix: catchall handler should be added after plugin application

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -50,6 +50,11 @@ async function server (opts = {}) {
       configureServer({app, addRoutes: routeConfiguringFunction, allowCors, basePath, plugins});
       await configureServerPlugins({app, httpServer, plugins});
 
+      // once all configurations and plugins have been applied, make sure to set up a catchall
+      // handler so that anything unknown 404s. But do this after everything else since we don't
+      // want to block plugins' ability to add routes if they want.
+      app.all('*', catch404Handler);
+
       await startServer({httpServer, hostname, port});
       resolve(httpServer);
     } catch (err) {
@@ -112,7 +117,6 @@ function configureServer ({
   app.all('/test/guinea-pig', guineaPig);
   app.all('/test/guinea-pig-scrollable', guineaPigScrollable);
   app.all('/test/guinea-pig-app-banner', guineaPigAppBanner);
-  app.all('*', catch404Handler);
 }
 
 function configureHttp ({httpServer, reject}) {

--- a/test/express/server-specs.js
+++ b/test/express/server-specs.js
@@ -52,7 +52,7 @@ describe('server configuration', function () {
     const configureRoutes = () => {};
     configureServer({app, addRoutes: configureRoutes});
     app.use.callCount.should.equal(14);
-    app.all.callCount.should.equal(5);
+    app.all.callCount.should.equal(4);
   });
 
   it('should apply new methods in plugins to the standard method map', function () {


### PR DESCRIPTION
somewhere along the way plugins were broken. Maybe a change in Express? Anyway, need to put the catchall handler at the very end, after any plugin might be registered.