### PR TITLE
fix: 10 minute connection timeout is too low for some use cases

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -23,7 +23,7 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import { EventEmitter } from 'events';
 
 
-const KEEP_ALIVE_TIMEOUT_MS = 60 * 10 * 1000; // 10 minutes
+const KEEP_ALIVE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 
 async function server (opts = {}) {
@@ -33,7 +33,8 @@ async function server (opts = {}) {
     hostname = null,
     allowCors = true,
     basePath = DEFAULT_BASE_PATH,
-    plugins = []
+    plugins = [],
+    keepAliveTimeout = KEEP_ALIVE_TIMEOUT_MS,
   } = opts;
 
   // create the actual http server
@@ -46,7 +47,7 @@ async function server (opts = {}) {
     // way we resolve it is to use an async function here but to wrap all the inner logic in
     // try/catch so any errors can be passed to reject.
     try {
-      configureHttp({httpServer, reject});
+      configureHttp({httpServer, reject, keepAliveTimeout});
       configureServer({app, addRoutes: routeConfiguringFunction, allowCors, basePath, plugins});
       await configureServerPlugins({app, httpServer, plugins});
 
@@ -55,7 +56,7 @@ async function server (opts = {}) {
       // want to block plugins' ability to add routes if they want.
       app.all('*', catch404Handler);
 
-      await startServer({httpServer, hostname, port});
+      await startServer({httpServer, hostname, port, keepAliveTimeout});
       resolve(httpServer);
     } catch (err) {
       reject(err);
@@ -119,7 +120,7 @@ function configureServer ({
   app.all('/test/guinea-pig-app-banner', guineaPigAppBanner);
 }
 
-function configureHttp ({httpServer, reject}) {
+function configureHttp ({httpServer, reject, keepAliveTimeout}) {
   const serverState = {
     notifier: new EventEmitter(),
     closed: false,
@@ -159,7 +160,7 @@ function configureHttp ({httpServer, reject}) {
   });
 
   httpServer.on('connection', (socket) => {
-    socket.setTimeout(KEEP_ALIVE_TIMEOUT_MS);
+    socket.setTimeout(keepAliveTimeout);
     socket.on('error', reject);
 
     function destroy () {
@@ -199,7 +200,7 @@ async function configureServerPlugins ({plugins, app, httpServer}) {
   }
 }
 
-async function startServer ({httpServer, port, hostname}) {
+async function startServer ({httpServer, port, hostname, keepAliveTimeout}) {
   const serverArgs = [port];
   if (hostname) {
     // If the hostname is omitted, the server will accept
@@ -207,9 +208,9 @@ async function startServer ({httpServer, port, hostname}) {
     serverArgs.push(hostname);
   }
   const startPromise = B.promisify(httpServer.listen, {context: httpServer})(...serverArgs);
-  httpServer.keepAliveTimeout = KEEP_ALIVE_TIMEOUT_MS;
+  httpServer.keepAliveTimeout = keepAliveTimeout;
   // headers timeout must be greater than keepAliveTimeout
-  httpServer.headersTimeout = KEEP_ALIVE_TIMEOUT_MS + 5 * 1000;
+  httpServer.headersTimeout = keepAliveTimeout + 5 * 1000;
   await startPromise;
 }
 


### PR DESCRIPTION
Someone reported a bug where they tried to background the app for 30 minutes and it didn't work. Now we know why!