### PR TITLE
fix: 10 minute connection timeout is too low for some use cases

### DIFF
--- a/lib/express/server.js
+++ b/lib/express/server.js
@@ -23,7 +23,10 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import { EventEmitter } from 'events';
 
 
-const KEEP_ALIVE_TIMEOUT_MS = 60 * 10 * 1000; // 10 minutes
+// Configure the timeout that the Express web server will apply to its connections. It's set quite
+// high due to the fact that people like to test e.g. what happens when they background their app
+// for 30+ minutes (all of which happens during the course of one request to the Appium server)
+const KEEP_ALIVE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 
 async function server (opts = {}) {


### PR DESCRIPTION
2.0 version of https://github.com/appium/appium-base-driver/pull/443