### PR TITLE
[wip] feat: remove mjsonwp from responses

### DIFF
--- a/lib/basedriver/commands/execute-child.js
+++ b/lib/basedriver/commands/execute-child.js
@@ -7,7 +7,6 @@ import { attach } from 'webdriverio';
 // duplicate defining these keys here so we don't need to re-load a huge appium
 // dependency tree into memory just to run a wdio script
 const W3C_ELEMENT_KEY = 'element-6066-11e4-a52e-4f735466cecf';
-const MJSONWP_ELEMENT_KEY = 'ELEMENT';
 
 async function runScript (driverOpts, script, timeout) {
   if (!_.isNumber(timeout)) {
@@ -83,17 +82,8 @@ function coerceScriptResult (obj) {
     // webdriverio has no monadic object types other than element and driver,
     // and we don't want to allow special casing return of driver
     res = {};
-
-    if (obj[MJSONWP_ELEMENT_KEY] || obj[W3C_ELEMENT_KEY]) {
-      // if it's an element object, clear out anything that's not the key, and
-      // then return the object
-      if (obj[MJSONWP_ELEMENT_KEY]) {
-        res[MJSONWP_ELEMENT_KEY] = obj[MJSONWP_ELEMENT_KEY];
-      }
-
-      if (obj[W3C_ELEMENT_KEY]) {
-        res[W3C_ELEMENT_KEY] = obj[W3C_ELEMENT_KEY];
-      }
+    if (obj[W3C_ELEMENT_KEY]) {
+      res[W3C_ELEMENT_KEY] = obj[W3C_ELEMENT_KEY];
       return res;
     }
 

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -2,7 +2,7 @@ import {
   Protocol, errors, determineProtocol
 } from '../protocol';
 import {
-  MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY, PROTOCOLS, DEFAULT_BASE_PATH,
+  W3C_ELEMENT_KEY, PROTOCOLS, DEFAULT_BASE_PATH,
 } from '../constants';
 import os from 'os';
 import commands from './commands';
@@ -506,8 +506,7 @@ class BaseDriver extends Protocol {
 
   registerImageElement (imgEl) {
     this._imgElCache.set(imgEl.id, imgEl);
-    const protoKey = this.isW3CProtocol() ? W3C_ELEMENT_KEY : MJSONWP_ELEMENT_KEY;
-    return imgEl.asElement(protoKey);
+    return imgEl.asElement(W3C_ELEMENT_KEY);
   }
 }
 

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -319,13 +319,10 @@ class JWProxy {
     // Instead, return the id from the request or from current session
     const reqSessionId = this.getSessionIdFromUrl(req.originalUrl);
     if (_.has(resBodyObj, 'sessionId')) {
-      if (reqSessionId) {
-        log.info(`Replacing sessionId ${resBodyObj.sessionId} with ${reqSessionId}`);
-        resBodyObj.sessionId = reqSessionId;
-      } else if (this.sessionId) {
-        log.info(`Replacing sessionId ${resBodyObj.sessionId} with ${this.sessionId}`);
-        resBodyObj.sessionId = this.sessionId;
-      }
+      delete resBodyObj.sessionId;
+    }
+    if (_.has(resBodyObj, 'status')) {
+      delete resBodyObj.status;
     }
     resBodyObj.value = formatResponseValue(resBodyObj.value);
     formatStatus(resBodyObj, res.statusCode, SESSIONS_CACHE.getProtocol(reqSessionId));

--- a/lib/protocol/helpers.js
+++ b/lib/protocol/helpers.js
@@ -31,12 +31,7 @@ function formatResponseValue (resValue) {
  * @returns {Object} The fixed response body
  */
 function formatStatus (responseBody) {
-  if (!_.isPlainObject(responseBody)) {
-    return responseBody;
-  }
-  if (_.has(responseBody, 'status')) {
-    delete responseBody.status;
-  }
+  // TODO: remove
   return responseBody;
 }
 

--- a/lib/protocol/helpers.js
+++ b/lib/protocol/helpers.js
@@ -1,9 +1,6 @@
 import _ from 'lodash';
 import { duplicateKeys } from '../basedriver/helpers';
-import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY, PROTOCOLS } from '../constants';
-
-const JSONWP_SUCCESS_STATUS_CODE = 0;
-const JSONWP_UNKNOWN_ERROR_STATUS_CODE = 13;
+import { MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY } from '../constants';
 
 /**
  * Preprocesses the resulting value for API responses,
@@ -21,31 +18,23 @@ function formatResponseValue (resValue) {
   }
   // If the MJSONWP element key format (ELEMENT) was provided, add a duplicate key (element-6066-11e4-a52e-4f735466cecf)
   // If the W3C element key format (element-6066-11e4-a52e-4f735466cecf) was provided, add a duplicate key (ELEMENT)
+  // TODO: Remove 'MJSONWP_ELEMENT_KEY'
   return duplicateKeys(resValue, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY);
 }
 
 /**
  * Properly formats the status for API responses,
- * so they are correct for both W3C and JSONWP protocols.
+ * so they are correct for W3C protocols.
  * This method DOES mutate the `responseBody` argument if needed
  *
  * @param {Object} responseBody
- * @param {number} responseCode the HTTP response code
- * @param {?string} protocol The name of the protocol, either
- * `PROTOCOLS.W3C` or `PROTOCOLS.MJSONWP`
  * @returns {Object} The fixed response body
  */
-function formatStatus (responseBody, responseCode = 200, protocol = null) {
+function formatStatus (responseBody) {
   if (!_.isPlainObject(responseBody)) {
     return responseBody;
   }
-  const isError = _.has(responseBody.value, 'error') || responseCode >= 400;
-  if ((protocol === PROTOCOLS.MJSONWP && !_.isInteger(responseBody.status))
-    || (!protocol && !_.has(responseBody, 'status'))) {
-    responseBody.status = isError
-      ? JSONWP_UNKNOWN_ERROR_STATUS_CODE
-      : JSONWP_SUCCESS_STATUS_CODE;
-  } else if (protocol === PROTOCOLS.W3C && _.has(responseBody, 'status')) {
+  if (_.has(responseBody, 'status')) {
     delete responseBody.status;
   }
   return responseBody;
@@ -53,6 +42,5 @@ function formatStatus (responseBody, responseCode = 200, protocol = null) {
 
 
 export {
-  MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY, formatResponseValue,
-  JSONWP_SUCCESS_STATUS_CODE, formatStatus,
+  MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY, formatResponseValue, formatStatus,
 };

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -376,23 +376,11 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
           .debug(`Encountered internal error running command: ${errMsg}`);
       }
 
-      if (currentProtocol === PROTOCOLS.W3C) {
-        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
-      } else if (currentProtocol === PROTOCOLS.MJSONWP) {
+      if (currentProtocol === PROTOCOLS.MJSONWP) {
+        // TODO: Leave log
         [httpStatus, httpResBody] = getResponseForJsonwpError(actualErr);
       } else {
-        // If it's unknown what the protocol is (like if it's `getStatus` prior to `createSession`), merge the responses
-        // together to be protocol-agnostic
-        let jsonwpRes = getResponseForJsonwpError(actualErr);
-        let w3cRes = getResponseForW3CError(actualErr);
-
-        httpResBody = {
-          ...jsonwpRes[1],
-          ...w3cRes[1],
-        };
-
-        // Use the JSONWP status code (which is usually 500)
-        httpStatus = jsonwpRes[0];
+        [httpStatus, httpResBody] = getResponseForW3CError(actualErr);
       }
     }
 
@@ -401,19 +389,13 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       res.status(httpStatus).send(httpResBody);
     } else {
       if (newSessionId) {
-        if (currentProtocol === PROTOCOLS.W3C) {
-          httpResBody.value.sessionId = newSessionId;
-        } else {
-          httpResBody.sessionId = newSessionId;
-        }
+        httpResBody.value.sessionId = newSessionId;
       } else {
-        httpResBody.sessionId = req.params.sessionId || null;
-      }
-      // Don't include sessionId in W3C responses
-      if (currentProtocol === PROTOCOLS.W3C) {
-        delete httpResBody.sessionId;
+        httpResBody.value.sessionId = req.params.sessionId || null;
       }
 
+      // Don't include sessionId in W3C responses
+      delete httpResBody.sessionId;
       httpResBody = formatStatus(httpResBody, httpStatus, currentProtocol);
       res.status(httpStatus).json(httpResBody);
     }

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { BaseDriver, ImageElement } from '../../..';
 import { IMAGE_STRATEGY, CUSTOM_STRATEGY, helpers } from '../../../lib/basedriver/commands/find';
 import { imageUtil } from 'appium-support';
+import { W3C_ELEMENT_KEY } from '../../../lib/constants';
 
 
 const should = chai.should();
@@ -57,7 +58,7 @@ describe('finding elements by image', function () {
     }
 
     function basicImgElVerify (imgElProto, driver) {
-      const imgElId = imgElProto.ELEMENT;
+      const imgElId = imgElProto[W3C_ELEMENT_KEY];
       driver._imgElCache.has(imgElId).should.be.true;
       const imgEl = driver._imgElCache.get(imgElId);
       (imgEl instanceof ImageElement).should.be.true;

--- a/test/jsonwp-proxy/proxy-e2e-specs.js
+++ b/test/jsonwp-proxy/proxy-e2e-specs.js
@@ -22,7 +22,6 @@ describe('proxy', function () {
   it('should proxy status straight', async function () {
     let [res, resBody] = await jwproxy.proxy('/status', 'GET');
     res.statusCode.should.equal(200);
-    resBody.status.should.equal(0);
     resBody.value.should.equal(`I'm fine`);
   });
   it('should proxy status as command', async function () {

--- a/test/jsonwp-proxy/proxy-specs.js
+++ b/test/jsonwp-proxy/proxy-specs.js
@@ -166,32 +166,32 @@ describe('proxy', function () {
       await j.proxyReqRes(req, res);
       res.headers['content-type'].should.equal('application/json; charset=utf-8');
       res.sentCode.should.equal(200);
-      res.sentBody.should.eql({status: 0, value: {foo: 'bar'}});
+      res.sentBody.should.eql({value: {foo: 'bar'}});
     });
     it('should rewrite the inner session id so it doesnt change', async function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/element/200/value', 'GET');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({status: 0, value: 'foobar', sessionId: '123'});
+      res.sentBody.should.eql({value: 'foobar', sessionId: '123'});
     });
     it('should rewrite the inner session id with sessionId in url', async function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/session/456/element/200/value', 'POST');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({status: 0, value: 'foobar', sessionId: '456'});
+      res.sentBody.should.eql({value: 'foobar', sessionId: '456'});
     });
     it('should pass through urls that do not require session IDs', async function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/status', 'GET');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({status: 0, value: {'foo': 'bar'}});
+      res.sentBody.should.eql({value: {'foo': 'bar'}});
     });
     it('should proxy strange responses', async function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/nochrome', 'GET');
       await j.proxyReqRes(req, res);
       res.sentCode.should.equal(100);
-      res.sentBody.should.eql({status: 0, value: {message: 'chrome not reachable'}});
+      res.sentBody.should.eql({value: {message: 'chrome not reachable'}});
     });
   });
 });

--- a/test/jsonwp-proxy/proxy-specs.js
+++ b/test/jsonwp-proxy/proxy-specs.js
@@ -172,13 +172,13 @@ describe('proxy', function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/element/200/value', 'GET');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({value: 'foobar', sessionId: '123'});
+      res.sentBody.should.eql({value: 'foobar'});
     });
     it('should rewrite the inner session id with sessionId in url', async function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/session/456/element/200/value', 'POST');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({value: 'foobar', sessionId: '456'});
+      res.sentBody.should.eql({value: 'foobar'});
     });
     it('should pass through urls that do not require session IDs', async function () {
       let j = mockProxy({sessionId: '123'});

--- a/test/protocol/protocol-e2e-specs.js
+++ b/test/protocol/protocol-e2e-specs.js
@@ -51,19 +51,6 @@ describe('Protocol', function () {
       await mjsonwpServer.close();
     });
 
-    it('should proxy to driver and return valid jsonwp response', async function () {
-      const {data} = await axios({
-        url: `${baseUrl}/session/foo/url`,
-        method: 'POST',
-        data: {url: 'http://google.com'}
-      });
-      data.should.eql({
-        status: 0,
-        value: 'Navigated to: http://google.com',
-        sessionId: 'foo'
-      });
-    });
-
     it('should assume requests without a Content-Type are json requests', async function () {
       const {data} = await axios({
         url: `${baseUrl}/session/foo/url`,
@@ -71,9 +58,7 @@ describe('Protocol', function () {
         data: {url: 'http://google.com'},
       });
       data.should.eql({
-        status: 0,
         value: 'Navigated to: http://google.com',
-        sessionId: 'foo'
       });
     });
 
@@ -89,9 +74,7 @@ describe('Protocol', function () {
         }),
       });
       data.should.eql({
-        status: 0,
         value: 'Navigated to: http://google.com',
-        sessionId: 'foo'
       });
     });
 
@@ -102,9 +85,7 @@ describe('Protocol', function () {
         data: {},
       });
       data.should.eql({
-        status: 0,
         value: 'foo',
-        sessionId: 'foo'
       });
     });
 
@@ -150,9 +131,7 @@ describe('Protocol', function () {
         data: {url: 'http://google.com'}
       });
       data.should.eql({
-        status: 0,
         value: 'Navigated to: http://google.com',
-        sessionId: 'foo'
       });
 
     });
@@ -180,11 +159,9 @@ describe('Protocol', function () {
 
       status.should.equal(501);
       data.should.eql({
-        status: 405,
         value: {
           message: 'Method has not yet been implemented'
-        },
-        sessionId: 'foo'
+        }
       });
     });
 
@@ -198,11 +175,9 @@ describe('Protocol', function () {
 
       status.should.equal(501);
       data.should.eql({
-        status: 405,
         value: {
           message: 'Method has not yet been implemented'
-        },
-        sessionId: 'foo'
+        }
       });
     });
 
@@ -245,12 +220,10 @@ describe('Protocol', function () {
       });
       status.should.equal(500);
       data.should.eql({
-        status: 13,
         value: {
           message: 'An unknown server-side error occurred while processing ' +
                    'the command. Original error: Mishandled Driver Error'
-        },
-        sessionId: 'foo'
+        }
       });
     });
 
@@ -587,9 +560,7 @@ describe('Protocol', function () {
           it('should work if a proxied request returns a response with status 200', async function () {
             app.post('/session/:sessionId/perform-actions', (req, res) => {
               res.json({
-                sessionId: req.params.sessionId,
-                value: req.body,
-                status: 0,
+                value: req.body
               });
             });
 
@@ -604,9 +575,7 @@ describe('Protocol', function () {
           it('should return error if a proxied request returns a MJSONWP error response', async function () {
             app.post('/session/:sessionId/perform-actions', (req, res) => {
               res.status(500).json({
-                sessionId,
-                status: 6,
-                value: 'A problem occurred',
+                value: 'A problem occurred'
               });
             });
             const {status, data} = await axios({
@@ -645,9 +614,7 @@ describe('Protocol', function () {
           it('should return error if a proxied request returns a MJSONWP error response but HTTP status code is 200', async function () {
             app.post('/session/:sessionId/perform-actions', (req, res) => {
               res.status(200).json({
-                sessionId: 'Fake Session Id',
-                status: 7,
-                value: 'A problem occurred',
+                value: 'A problem occurred'
               });
             });
             const {status, data} = await axios({
@@ -724,9 +691,7 @@ describe('Protocol', function () {
         method: 'POST',
       });
       data.should.eql({
-        status: 0,
-        value: null,
-        sessionId: 'foo'
+        value: null
       });
     });
 
@@ -735,9 +700,7 @@ describe('Protocol', function () {
         url: `${baseUrl}/session/foo/element/bar/text`,
       });
       data.should.eql({
-        status: 0,
-        value: '',
-        sessionId: 'foo'
+        value: ''
       });
     });
 
@@ -750,12 +713,10 @@ describe('Protocol', function () {
 
       status.should.equal(500);
       data.should.eql({
-        status: 13,
         value: {
           message: 'An unknown server-side error occurred while processing ' +
                    'the command. Original error: Too Fresh!'
-        },
-        sessionId: 'foo'
+        }
       });
     });
 
@@ -767,11 +728,9 @@ describe('Protocol', function () {
 
       status.should.equal(404);
       data.should.eql({
-        status: 6,
         value: {
           message: 'A session is either terminated or not started'
-        },
-        sessionId: 'foo'
+        }
       });
     });
   });
@@ -860,12 +819,10 @@ describe('Protocol', function () {
 
       status.should.equal(500);
       data.should.eql({
-        status: 13,
         value: {
           message: 'An unknown server-side error occurred while processing ' +
                    'the command. Original error: Too Fresh!'
-        },
-        sessionId
+        }
       });
     });
 
@@ -914,13 +871,11 @@ describe('Protocol', function () {
 
       status.should.equal(500);
       data.should.eql({
-        status: 13,
         value: {
           message: 'An unknown server-side error occurred while processing ' +
                    'the command. Original error: Trying to proxy to a JSONWP ' +
                    'server but driver is unable to proxy'
-        },
-        sessionId
+        }
       });
     });
 
@@ -937,13 +892,11 @@ describe('Protocol', function () {
 
       status.should.equal(500);
       data.should.eql({
-        status: 13,
         value: {
           message: 'An unknown server-side error occurred while processing ' +
                    'the command. Original error: Could not proxy. Proxy ' +
                    'error: foo'
-        },
-        sessionId
+        }
       });
     });
 
@@ -961,11 +914,9 @@ describe('Protocol', function () {
 
       status.should.equal(500);
       data.should.eql({
-        status: 35,
         value: {
           message: 'No such context found.'
-        },
-        sessionId: 'foo'
+        }
       });
     });
 
@@ -993,9 +944,7 @@ describe('Protocol', function () {
 
       status.should.equal(200);
       data.should.eql({
-        status: 0,
-        value: 'Navigated to: http://google.com',
-        sessionId
+        value: 'Navigated to: http://google.com'
       });
     });
 
@@ -1033,9 +982,7 @@ describe('Protocol', function () {
 
       status.should.equal(200);
       data.should.eql({
-        status: 0,
-        value: "I'm fine",
-        sessionId: null
+        value: "I'm fine"
       });
     });
 


### PR DESCRIPTION
Part of _remove support for non-w3c sessions_ https://github.com/appium/appium/projects/2#card-41526139

- Do not add `MJSONWP_ELEMENT_KEY` as responses
- Do not add `status` as responses

So far, this PR keeps `duplicateKeys` in a case the backend is MJSONWP like chromedriver.