### PR TITLE
fix: do not stop with an error in cacheResponse

### DIFF
--- a/lib/express/idempotency.js
+++ b/lib/express/idempotency.js
@@ -32,7 +32,7 @@ process.on('exit', () => {
 });
 
 
-function cacheResponse (key, req, res) {
+function cacheResponse (key, req, res, next, rerouteCachedResponse) {
   const responseStateListener = new EventEmitter();
   IDEMPOTENT_RESPONSES.set(key, {
     method: req.method,
@@ -66,6 +66,7 @@ function cacheResponse (key, req, res) {
       responseListener.end();
     }
   });
+
   responseListener.once('close', () => {
     if (res.socket?.write === patchedWriter) {
       res.socket.write = originalSocketWriter;
@@ -94,6 +95,12 @@ function cacheResponse (key, req, res) {
     IDEMPOTENT_RESPONSES.get(key).response = tmpFile;
     responseStateListener.emit('ready', tmpFile);
   });
+
+  responseStateListener.once('error', () => {
+    res.emit('close');
+    next();
+  });
+  responseStateListener.once('ready', rerouteCachedResponse);
 }
 
 async function handleIdempotency (req, res, next) {
@@ -107,9 +114,19 @@ async function handleIdempotency (req, res, next) {
     return next();
   }
 
+  const rerouteCachedResponse = async (cachedResPath) => {
+    if (!await fs.exists(cachedResPath)) {
+      IDEMPOTENT_RESPONSES.del(key);
+      log.warn(`Could not read the cached response identified by key '${key}'`);
+      log.warn('The temporary storage is not accessible anymore');
+      return next();
+    }
+    fs.createReadStream(cachedResPath).pipe(res.socket);
+  };
+
   log.debug(`Request idempotency key: ${key}`);
   if (!IDEMPOTENT_RESPONSES.has(key)) {
-    cacheResponse(key, req, res);
+    cacheResponse(key, req, res, next, rerouteCachedResponse);
     return next();
   }
 
@@ -124,16 +141,6 @@ async function handleIdempotency (req, res, next) {
     log.warn('Is the client generating idempotency keys properly?');
     return next();
   }
-
-  const rerouteCachedResponse = async (cachedResPath) => {
-    if (!await fs.exists(cachedResPath)) {
-      IDEMPOTENT_RESPONSES.del(key);
-      log.warn(`Could not read the cached response identified by key '${key}'`);
-      log.warn('The temporary storage is not accessible anymore');
-      return next();
-    }
-    fs.createReadStream(cachedResPath).pipe(res.socket);
-  };
 
   if (response) {
     log.info(`The same request with the idempotency key '${key}' has been already processed`);


### PR DESCRIPTION
Below error occurred and appium server stopped.

```
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET https://localhost:10100/status] with no body
[WD Proxy] connect ECONNREFUSED 127.0.0.1:10100
[HTTP] <-- POST /wd/hub/session - - ms - -
[HTTP]
[HTTP] Could not cache the response identified by 'c7bed216-d28f-430b-ad82-666d87cbd155', because it has not been completed
[HTTP] Does the client terminate connections too early?
uncaughtException: Could not cache the response identified by 'c7bed216-d28f-430b-ad82-666d87cbd155', because it has not been completed
Error: Could not cache the response identified by 'c7bed216-d28f-430b-ad82-666d87cbd155', because it has not been completed
    at WriteStream.<anonymous> (/Users/kazuaki/.nodebrew/node/v14.3.0/lib/node_modules/appium/node_modules/appium-base-driver/lib/express/idempotency.js:91:50)
    at Object.onceWrapper (events.js:421:28)
    at WriteStream.emit (events.js:315:20)
    at emitCloseNT (internal/streams/destroy.js:81:10)
    at processTicksAndRejections (internal/process/task_queues.js:83:21)
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET https://localhost:10100/status] with no body
[WD Proxy] connect ECONNREFUSED 127.0.0.1:10100
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET https://localhost:10100/status] with no body
[WD Proxy] connect ECONNREFUSED 127.0.0.1:10100
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET https://localhost:10100/status] with no body
[WD Proxy] connect ECONNREFUSED 127.0.0.1:10100
kazuaki@kazus-MB-pro appium %
```

This happened when a client disconnected the new session request in the middle of `cacheResponse` method since `error` and `ready ` were not defined in `cacheResponse` then.

I don't know this change was the correct way to fix this server crash, but this change (defined `error` and `ready`) prevent crashing the appium server process.

Could you help this @mykola-mokhnach or if you have a good idea to fix this, then it also would be great :)