### PR TITLE
feat: Support multiple image match in findByImage

### DIFF
--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -229,7 +229,7 @@ helpers.findByImage = async function findByImage (b64Template, {
       screenHeight);
   }
 
-  let results = [];
+  const results = [];
   const condition = async () => {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
@@ -240,7 +240,7 @@ helpers.findByImage = async function findByImage (b64Template, {
       });
 
       if (multiple) {
-        results = await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple});
+        results.push.apply(results, await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple}));
       } else {
         results.push(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple}));
       }

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -2,7 +2,7 @@ import log from '../logger';
 import { logger, imageUtil } from 'appium-support';
 import _ from 'lodash';
 import { errors } from '../../..';
-import { MATCH_TEMPLATE_MODE } from './images';
+import { MATCH_TEMPLATE_MODE, MATCH_TEMPLATE_MULTIPLE_MODE } from './images';
 import { ImageElement, DEFAULT_TEMPLATE_IMAGE_SCALE } from '../image-element';
 
 
@@ -229,9 +229,7 @@ helpers.findByImage = async function findByImage (b64Template, {
       screenHeight);
   }
 
-  let rect = null;
-  let b64Matched = null;
-  let score = 0;
+  let results = [];
   const condition = async () => {
     try {
       const {b64Screenshot, scale} = await this.getScreenshotForImageFind(screenWidth, screenHeight);
@@ -241,12 +239,13 @@ helpers.findByImage = async function findByImage (b64Template, {
         fixImageTemplateScale, ...scale
       });
 
-      const comparedImage = await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize});
-      rect = comparedImage.rect;
-      b64Matched = comparedImage.visualization;
-      score = comparedImage.score;
-
+      if (multiple) {
+        results = await this.compareImages(MATCH_TEMPLATE_MULTIPLE_MODE, b64Screenshot, b64Template, {threshold, visualize});
+      } else {
+        results.push(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize}));
+      }
       return true;
+
     } catch (err) {
       // if compareImages fails, we'll get a specific error, but we should
       // retry, so trap that and just return false to trigger the next round of
@@ -273,29 +272,33 @@ helpers.findByImage = async function findByImage (b64Template, {
     }
   }
 
-  if (!rect) {
+  if (results.length === 0) {
     if (multiple) {
       return [];
     }
     throw new errors.NoSuchElementError();
   }
 
-  log.info(`Image template matched: ${JSON.stringify(rect)}`);
-  if (b64Matched) {
-    log.info(`Matched base64 data: ${b64Matched.substring(0, 200)}...`);
-  }
-  const imgEl = new ImageElement(b64Template, rect, score, b64Matched);
+  const elements = results.map((result) => {
+    log.info(`Image template matched: ${JSON.stringify(result.rect)}`);
+    const b64Matched = result.visualization;
+    if (b64Matched) {
+      log.info(`Matched base64 data: ${b64Matched.substring(0, 200)}...`);
+    }
+    return new ImageElement(b64Template, result.rect, result.score, b64Matched);
+  });
 
   // if we're just checking staleness, return straightaway so we don't add
   // a new element to the cache. shouldCheckStaleness does not support multiple
   // elements, since it is a purely internal mechanism
   if (shouldCheckStaleness) {
-    return imgEl;
+    return elements[0];
   }
 
-  const protocolEl = this.registerImageElement(imgEl);
+  const registeredElements = elements.map((imgEl) => this.registerImageElement(imgEl));
+  log.info(`Registered elements: ${JSON.stringify(registeredElements)}`);
 
-  return multiple ? [protocolEl] : protocolEl;
+  return multiple ? registeredElements : registeredElements[0];
 };
 
 /**

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -240,9 +240,15 @@ helpers.findByImage = async function findByImage (b64Template, {
       });
 
       if (multiple) {
-        results.push(...(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple})));
+        results.push(...(await this.compareImages(MATCH_TEMPLATE_MODE,
+                                                  b64Screenshot,
+                                                  b64Template,
+                                                  {threshold, visualize, multiple})));
       } else {
-        results.push(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple}));
+        results.push(await this.compareImages(MATCH_TEMPLATE_MODE,
+                                              b64Screenshot,
+                                              b64Template,
+                                              {threshold, visualize, multiple}));
       }
       return true;
 

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -240,7 +240,7 @@ helpers.findByImage = async function findByImage (b64Template, {
       });
 
       if (multiple) {
-        results.push.apply(results, await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple}));
+        results.push(...(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple})));
       } else {
         results.push(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple}));
       }

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -281,11 +281,7 @@ helpers.findByImage = async function findByImage (b64Template, {
 
   const elements = results.map((result) => {
     log.info(`Image template matched: ${JSON.stringify(result.rect)}`);
-    const b64Matched = result.visualization;
-    if (b64Matched) {
-      log.debug(`Matched base64 data: ${b64Matched.substring(0, 200)}...`);
-    }
-    return new ImageElement(b64Template, result.rect, result.score, b64Matched);
+    return new ImageElement(b64Template, result.rect, result.score, result.visualization);
   });
 
   // if we're just checking staleness, return straightaway so we don't add

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -2,7 +2,7 @@ import log from '../logger';
 import { logger, imageUtil } from 'appium-support';
 import _ from 'lodash';
 import { errors } from '../../..';
-import { MATCH_TEMPLATE_MODE, MATCH_TEMPLATE_MULTIPLE_MODE } from './images';
+import { MATCH_TEMPLATE_MODE } from './images';
 import { ImageElement, DEFAULT_TEMPLATE_IMAGE_SCALE } from '../image-element';
 
 
@@ -240,9 +240,9 @@ helpers.findByImage = async function findByImage (b64Template, {
       });
 
       if (multiple) {
-        results = await this.compareImages(MATCH_TEMPLATE_MULTIPLE_MODE, b64Screenshot, b64Template, {threshold, visualize});
+        results = await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple});
       } else {
-        results.push(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize}));
+        results.push(await this.compareImages(MATCH_TEMPLATE_MODE, b64Screenshot, b64Template, {threshold, visualize, multiple}));
       }
       return true;
 
@@ -283,7 +283,7 @@ helpers.findByImage = async function findByImage (b64Template, {
     log.info(`Image template matched: ${JSON.stringify(result.rect)}`);
     const b64Matched = result.visualization;
     if (b64Matched) {
-      log.info(`Matched base64 data: ${b64Matched.substring(0, 200)}...`);
+      log.debug(`Matched base64 data: ${b64Matched.substring(0, 200)}...`);
     }
     return new ImageElement(b64Template, result.rect, result.score, b64Matched);
   });
@@ -296,7 +296,6 @@ helpers.findByImage = async function findByImage (b64Template, {
   }
 
   const registeredElements = elements.map((imgEl) => this.registerImageElement(imgEl));
-  log.info(`Registered elements: ${JSON.stringify(registeredElements)}`);
 
   return multiple ? registeredElements : registeredElements[0];
 };

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -272,7 +272,7 @@ helpers.findByImage = async function findByImage (b64Template, {
     }
   }
 
-  if (results.length === 0) {
+  if (_.isEmpty(results)) {
     if (multiple) {
       return [];
     }

--- a/lib/basedriver/commands/find.js
+++ b/lib/basedriver/commands/find.js
@@ -285,9 +285,9 @@ helpers.findByImage = async function findByImage (b64Template, {
     throw new errors.NoSuchElementError();
   }
 
-  const elements = results.map((result) => {
-    log.info(`Image template matched: ${JSON.stringify(result.rect)}`);
-    return new ImageElement(b64Template, result.rect, result.score, result.visualization);
+  const elements = results.map(({rect, score, visualization}) => {
+    log.info(`Image template matched: ${JSON.stringify(rect)}`);
+    return new ImageElement(b64Template, rect, score, visualization);
   });
 
   // if we're just checking staleness, return straightaway so we don't add

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -80,6 +80,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
 
 /**
  * base64 encodes the visualization part of the result
+ * (if necessary)
  *
  * @param {OccurenceResult} element - occurrence result
  *

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -60,7 +60,6 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
     case MATCH_TEMPLATE_MODE.toLowerCase():
       // firstImage/img1 is the full image and secondImage/img2 is the partial one
       result = await imageUtil.getImageOccurrence(img1, img2, options);
-      convertVisualizationToBase64(result);
 
       if (options.multiple) {
         for (const element of result.multiple) {
@@ -75,6 +74,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
         `Only ${JSON.stringify([MATCH_FEATURES_MODE, GET_SIMILARITY_MODE, MATCH_TEMPLATE_MODE])} modes are supported.`);
   }
 
+  convertVisualizationToBase64(result);
   return result;
 };
 

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -7,7 +7,6 @@ const commands = {}, helpers = {}, extensions = {};
 const MATCH_FEATURES_MODE = 'matchFeatures';
 const GET_SIMILARITY_MODE = 'getSimilarity';
 const MATCH_TEMPLATE_MODE = 'matchTemplate';
-const MATCH_TEMPLATE_MULTIPLE_MODE = 'matchTemplateMultiple';
 
 const DEFAULT_MATCH_THRESHOLD = 0.4;
 
@@ -35,36 +34,37 @@ const DEFAULT_MATCH_THRESHOLD = 0.4;
 commands.compareImages = async function compareImages (mode, firstImage, secondImage, options = {}) {
   const img1 = Buffer.from(firstImage, 'base64');
   const img2 = Buffer.from(secondImage, 'base64');
-  let results = [];
+  let result = null;
 
   switch (_.toLower(mode)) {
     case MATCH_FEATURES_MODE.toLowerCase():
-      results.push(await imageUtil.getImagesMatches(img1, img2, options));
+      result = await imageUtil.getImagesMatches(img1, img2, options);
       break;
     case GET_SIMILARITY_MODE.toLowerCase():
-      results.push(await imageUtil.getImagesSimilarity(img1, img2, options));
+      result = await imageUtil.getImagesSimilarity(img1, img2, options);
       break;
     case MATCH_TEMPLATE_MODE.toLowerCase():
       // firstImage/img1 is the full image and secondImage/img2 is the partial one
-      results.push(await imageUtil.getImageOccurrence(img1, img2, options));
-      break;
-    case MATCH_TEMPLATE_MULTIPLE_MODE.toLowerCase():
-      // firstImage/img1 is the full image and secondImage/img2 is the partial one
-      results = await imageUtil.getImageOccurrences(img1, img2, options);
+      result = await imageUtil.getImageOccurrence(img1, img2, options);
+
+      if (options.multiple) {
+        for (const element of result.multiple) {
+          if (!_.isEmpty(element.visualization)) {
+            element.visualization = element.visualization.toString('base64');
+          }
+        }
+
+        return result.multiple;
+      }
       break;
     default:
       throw new errors.InvalidArgumentError(`'${mode}' images comparison mode is unknown. ` +
-        `Only ${JSON.stringify([MATCH_FEATURES_MODE, GET_SIMILARITY_MODE, MATCH_TEMPLATE_MODE, MATCH_TEMPLATE_MULTIPLE_MODE])} modes are supported.`);
+        `Only ${JSON.stringify([MATCH_FEATURES_MODE, GET_SIMILARITY_MODE, MATCH_TEMPLATE_MODE])} modes are supported.`);
   }
 
-  for (const result of results) {
-    if (!_.isEmpty(result.visualization)) {
-      result.visualization = result.visualization.toString('base64');
-    }
-  }
-  return (results.length === 1) ? results[0] : results;
+  return result;
 };
 
 Object.assign(extensions, commands, helpers);
-export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE, MATCH_TEMPLATE_MULTIPLE_MODE };
+export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE };
 export default extensions;

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -35,6 +35,7 @@ const DEFAULT_MATCH_THRESHOLD = 0.4;
  *                              determine the number of pixels within
  *                              which to consider a pixel as part of the
  *                              same match result
+ *                              (default: 10)
  * See the documentation in the `appium-support`
  * module for more details.
  * @returns {Object} The content of the resulting dictionary depends

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -62,11 +62,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
       result = await imageUtil.getImageOccurrence(img1, img2, options);
 
       if (options.multiple) {
-        for (const element of result.multiple) {
-          convertVisualizationToBase64(element);
-        }
-
-        return result.multiple;
+        return result.multiple.map(convertVisualizationToBase64);
       }
       break;
     default:
@@ -74,8 +70,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
         `Only ${JSON.stringify([MATCH_FEATURES_MODE, GET_SIMILARITY_MODE, MATCH_TEMPLATE_MODE])} modes are supported.`);
   }
 
-  convertVisualizationToBase64(result);
-  return result;
+  return convertVisualizationToBase64(result);
 };
 
 /**
@@ -89,6 +84,8 @@ function convertVisualizationToBase64 (element) {
   if (_.isString(element.visualization)) {
     element.visualization = element.visualization.toString('base64');
   }
+
+  return element;
 }
 
 Object.assign(extensions, commands, helpers);

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -22,7 +22,20 @@ const DEFAULT_MATCH_THRESHOLD = 0.4;
  * @param {string} secondImage - Base64-encoded image file.
  * All image formats, that OpenCV library itself accepts, are supported.
  * @param {?Object} options [{}] - The content of this dictionary depends
- * on the actual `mode` value. See the documentation on `appium-support`
+ * on the actual `mode` value.
+ * For MATCH_TEMPLATE_MODE:
+ *   - visualize: include the visualization of the match in the result
+ *                (default: false)
+ *   - threshold: the image match threshold, higher values
+ *                require a closer image similarity to match
+ *                (default: 0.5)
+ *   - multiple: return multiple matches in the image
+ *               (default: false)
+ *   - matchNeighbourThreshold: if multiple is specified,
+ *                              determine the number of pixels within
+ *                              which to consider a pixel as part of the
+ *                              same match result
+ * See the documentation in the `appium-support`
  * module for more details.
  * @returns {Object} The content of the resulting dictionary depends
  * on the actual `mode` and `options` values. See the documentation on

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -86,7 +86,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
  *
  **/
 function convertVisualizationToBase64 (element) {
-  if (!_.isEmpty(element.visualization)) {
+  if (_.isString(element.visualization) {
     element.visualization = element.visualization.toString('base64');
   }
   return;

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -46,12 +46,11 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
     case MATCH_TEMPLATE_MODE.toLowerCase():
       // firstImage/img1 is the full image and secondImage/img2 is the partial one
       result = await imageUtil.getImageOccurrence(img1, img2, options);
+      convertVisualizationToBase64(result);
 
       if (options.multiple) {
         for (const element of result.multiple) {
-          if (!_.isEmpty(element.visualization)) {
-            element.visualization = element.visualization.toString('base64');
-          }
+          convertVisualizationToBase64(element);
         }
 
         return result.multiple;
@@ -64,6 +63,19 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
 
   return result;
 };
+
+/**
+ * base64 encodes the visualization part of the result
+ *
+ * @param {OccurenceResult} element - occurrence result
+ *
+ **/
+function convertVisualizationToBase64 (element) {
+  if (!_.isEmpty(element.visualization)) {
+    element.visualization = element.visualization.toString('base64');
+  }
+  return;
+}
 
 Object.assign(extensions, commands, helpers);
 export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE };

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -86,7 +86,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
  *
  **/
 function convertVisualizationToBase64 (element) {
-  if (_.isString(element.visualization) {
+  if (_.isString(element.visualization)) {
     element.visualization = element.visualization.toString('base64');
   }
 }

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -89,7 +89,6 @@ function convertVisualizationToBase64 (element) {
   if (_.isString(element.visualization) {
     element.visualization = element.visualization.toString('base64');
   }
-  return;
 }
 
 Object.assign(extensions, commands, helpers);

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -7,6 +7,7 @@ const commands = {}, helpers = {}, extensions = {};
 const MATCH_FEATURES_MODE = 'matchFeatures';
 const GET_SIMILARITY_MODE = 'getSimilarity';
 const MATCH_TEMPLATE_MODE = 'matchTemplate';
+const MATCH_TEMPLATE_MULTIPLE_MODE = 'matchTemplateMultiple';
 
 const DEFAULT_MATCH_THRESHOLD = 0.4;
 
@@ -34,28 +35,36 @@ const DEFAULT_MATCH_THRESHOLD = 0.4;
 commands.compareImages = async function compareImages (mode, firstImage, secondImage, options = {}) {
   const img1 = Buffer.from(firstImage, 'base64');
   const img2 = Buffer.from(secondImage, 'base64');
-  let result = {};
+  let results = [];
+
   switch (_.toLower(mode)) {
     case MATCH_FEATURES_MODE.toLowerCase():
-      result = await imageUtil.getImagesMatches(img1, img2, options);
+      results.push(await imageUtil.getImagesMatches(img1, img2, options));
       break;
     case GET_SIMILARITY_MODE.toLowerCase():
-      result = await imageUtil.getImagesSimilarity(img1, img2, options);
+      results.push(await imageUtil.getImagesSimilarity(img1, img2, options));
       break;
     case MATCH_TEMPLATE_MODE.toLowerCase():
       // firstImage/img1 is the full image and secondImage/img2 is the partial one
-      result = await imageUtil.getImageOccurrence(img1, img2, options);
+      results.push(await imageUtil.getImageOccurrence(img1, img2, options));
+      break;
+    case MATCH_TEMPLATE_MULTIPLE_MODE.toLowerCase():
+      // firstImage/img1 is the full image and secondImage/img2 is the partial one
+      results = await imageUtil.getImageOccurrences(img1, img2, options);
       break;
     default:
       throw new errors.InvalidArgumentError(`'${mode}' images comparison mode is unknown. ` +
-        `Only ${JSON.stringify([MATCH_FEATURES_MODE, GET_SIMILARITY_MODE, MATCH_TEMPLATE_MODE])} modes are supported.`);
+        `Only ${JSON.stringify([MATCH_FEATURES_MODE, GET_SIMILARITY_MODE, MATCH_TEMPLATE_MODE, MATCH_TEMPLATE_MULTIPLE_MODE])} modes are supported.`);
   }
-  if (!_.isEmpty(result.visualization)) {
-    result.visualization = result.visualization.toString('base64');
+
+  for (const result of results) {
+    if (!_.isEmpty(result.visualization)) {
+      result.visualization = result.visualization.toString('base64');
+    }
   }
-  return result;
+  return (results.length === 1) ? results[0] : results;
 };
 
 Object.assign(extensions, commands, helpers);
-export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE };
+export { commands, helpers, DEFAULT_MATCH_THRESHOLD, MATCH_TEMPLATE_MODE, MATCH_TEMPLATE_MULTIPLE_MODE };
 export default extensions;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-support": "^2.48.0",
+    "appium-support": "^2.50.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
     "axios": "^0.21.0",

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -4,7 +4,6 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import { BaseDriver, ImageElement } from '../../..';
 import { IMAGE_STRATEGY, CUSTOM_STRATEGY, helpers } from '../../../lib/basedriver/commands/find';
-import { MATCH_TEMPLATE_MULTIPLE_MODE } from '../../../lib/basedriver/commands/images';
 import { imageUtil } from 'appium-support';
 
 
@@ -76,7 +75,7 @@ describe('finding elements by image', function () {
     it('should find image elements happypath', async function () {
       const d = new TestDriver();
       const {compareStub} = basicStub(d);
-      compareStub.withArgs(MATCH_TEMPLATE_MULTIPLE_MODE).returns([{rect, score}]);
+      compareStub.returns([{rect, score}]);
 
       const els = await d.findByImage(template, {multiple: true});
       els.should.have.length(1);

--- a/test/basedriver/commands/find-specs.js
+++ b/test/basedriver/commands/find-specs.js
@@ -4,6 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import { BaseDriver, ImageElement } from '../../..';
 import { IMAGE_STRATEGY, CUSTOM_STRATEGY, helpers } from '../../../lib/basedriver/commands/find';
+import { MATCH_TEMPLATE_MULTIPLE_MODE } from '../../../lib/basedriver/commands/images';
 import { imageUtil } from 'appium-support';
 
 
@@ -74,7 +75,9 @@ describe('finding elements by image', function () {
     });
     it('should find image elements happypath', async function () {
       const d = new TestDriver();
-      basicStub(d);
+      const {compareStub} = basicStub(d);
+      compareStub.withArgs(MATCH_TEMPLATE_MULTIPLE_MODE).returns([{rect, score}]);
+
       const els = await d.findByImage(template, {multiple: true});
       els.should.have.length(1);
       basicImgElVerify(els[0], d);


### PR DESCRIPTION
Hi,

For my appium use case, there may be multiple places on the screen which has the same image and I'd like to find them all.

I am not a javascript dev by trade, so would definitely welcome any comments on this!

Thanks
Alex

Depends on these changes in appium-support: https://github.com/appium/appium-support/pull/212 -> now published in 2.50
~TODO: bump the appium-support version number to bring in those changes~