### PR TITLE
fix: timeout of JWProxy for httpAgent and httpsAgent

### DIFF
--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -41,7 +41,6 @@ class JWProxy {
       keepAlive: opts.keepAlive ?? true,
       maxSockets: 10,
       maxFreeSockets: 5,
-      timeout: this.timeout,
     };
     this.httpAgent = new http.Agent(agentOpts);
     this.httpsAgent = new https.Agent(agentOpts);

--- a/lib/jsonwp-proxy/proxy.js
+++ b/lib/jsonwp-proxy/proxy.js
@@ -41,7 +41,7 @@ class JWProxy {
       keepAlive: opts.keepAlive ?? true,
       maxSockets: 10,
       maxFreeSockets: 5,
-      timeout: 60000,
+      timeout: this.timeout,
     };
     this.httpAgent = new http.Agent(agentOpts);
     this.httpsAgent = new https.Agent(agentOpts);


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/15132

This was when we modify keepalive stuff in https://github.com/appium/appium-base-driver/pull/416/files .
Should the timeout respect the constructor's one?