### PR TITLE
refactor: Remove swipe-related helpers from the base driver

### DIFF
--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -13,8 +13,9 @@ import { desiredCapabilityConstraints } from './desired-caps';
 import { validateCaps } from './capabilities';
 import B from 'bluebird';
 import _ from 'lodash';
-import { util } from 'appium-support';
-import { ImageElement, makeImageElementCache, getImgElFromArgs } from './image-element';
+import {
+  ImageElement, makeImageElementCache, getImgElFromArgs
+} from './image-element';
 import AsyncLock from 'async-lock';
 import { EventEmitter } from 'events';
 
@@ -426,34 +427,6 @@ class BaseDriver extends Protocol {
       }
     }
     this.clearNewCommandTimeout();
-  }
-
-  async getSwipeOptions (gestures, touchCount = 1) {
-    let startX = this.helpers.getCoordDefault(gestures[0].options.x),
-        startY = this.helpers.getCoordDefault(gestures[0].options.y),
-        endX = this.helpers.getCoordDefault(gestures[2].options.x),
-        endY = this.helpers.getCoordDefault(gestures[2].options.y),
-        duration = this.helpers.getSwipeTouchDuration(gestures[1]),
-        element = gestures[0].options.element,
-        destElement = gestures[2].options.element || gestures[0].options.element;
-
-    // there's no destination element handling in bootstrap and since it applies to all platforms, we handle it here
-    if (util.hasValue(destElement)) {
-      let locResult = await this.getLocationInView(destElement);
-      let sizeResult = await this.getSize(destElement);
-      let offsetX = (Math.abs(endX) < 1 && Math.abs(endX) > 0) ? sizeResult.width * endX : endX;
-      let offsetY = (Math.abs(endY) < 1 && Math.abs(endY) > 0) ? sizeResult.height * endY : endY;
-      endX = locResult.x + offsetX;
-      endY = locResult.y + offsetY;
-      // if the target element was provided, the coordinates for the destination need to be relative to it.
-      if (util.hasValue(element)) {
-        let firstElLocation = await this.getLocationInView(element);
-        endX -= firstElLocation.x;
-        endY -= firstElLocation.y;
-      }
-    }
-    // clients are responsible to use these options correctly
-    return {startX, startY, endX, endY, duration, touchCount, element};
   }
 
   proxyActive (/* sessionId */) {

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -359,28 +359,6 @@ function isPackageOrBundle (app) {
   return (/^([a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+)+$/).test(app);
 }
 
-function getCoordDefault (val) {
-  // going the long way and checking for undefined and null since
-  // we can't be assured `elId` is a string and not an int. Same
-  // thing with destElement below.
-  return util.hasValue(val) ? val : 0.5;
-}
-
-function getSwipeTouchDuration (waitGesture) {
-  // the touch action api uses ms, we want seconds
-  // 0.8 is the default time for the operation
-  let duration = 0.8;
-  if (typeof waitGesture.options.ms !== 'undefined' && waitGesture.options.ms) {
-    duration = waitGesture.options.ms / 1000;
-    if (duration === 0) {
-      // set to a very low number, since they wanted it fast
-      // but below 0.1 becomes 0 steps, which causes errors
-      duration = 0.1;
-    }
-  }
-  return duration;
-}
-
 /**
  * Finds all instances 'firstKey' and create a duplicate with the key 'secondKey',
  * Do the same thing in reverse. If we find 'secondKey', create a duplicate with the key 'firstKey'.
@@ -443,5 +421,5 @@ function parseCapsArray (cap) {
 }
 
 export {
-  configureApp, isPackageOrBundle, getCoordDefault, getSwipeTouchDuration, duplicateKeys, parseCapsArray
+  configureApp, isPackageOrBundle, duplicateKeys, parseCapsArray
 };


### PR DESCRIPTION
Related to https://github.com/appium/appium-android-driver/pull/684

These helpers are only used in android driver and nowhere else. Also, logically, it does not make any sense to have this code in the base driver, since it is not cross-platform and is only specific to android driver