### PR TITLE
fix: convert element.visualization to string

### DIFF
--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -81,7 +81,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
  *
  **/
 function convertVisualizationToBase64 (element) {
-  if (_.isString(element.visualization)) {
+  if (!_.isEmpty(element.visualization)) {
     element.visualization = element.visualization.toString('base64');
   }
 

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -81,7 +81,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
  *
  **/
 function convertVisualizationToBase64 (element) {
-  if (!_.isEmpty(element.visualization)) {
+  if (!_.isEmpty(element.visualization) && !_.isString(element.visualization)) {
     element.visualization = element.visualization.toString('base64');
   }
 

--- a/lib/basedriver/commands/images.js
+++ b/lib/basedriver/commands/images.js
@@ -81,7 +81,7 @@ commands.compareImages = async function compareImages (mode, firstImage, secondI
  *
  **/
 function convertVisualizationToBase64 (element) {
-  if (!_.isEmpty(element.visualization) && !_.isString(element.visualization)) {
+  if (!_.isEmpty(element.visualization)) {
     element.visualization = element.visualization.toString('base64');
   }
 


### PR DESCRIPTION
Calling `toString('base64')` should only when the visualization is not string and has value.
https://github.com/appium/appium-plugins/runs/2636842428?check_suite_focus=true