### PR TITLE
feat: allow instrumentation via base driver

### DIFF
--- a/lib/basedriver/commands/event.js
+++ b/lib/basedriver/commands/event.js
@@ -22,14 +22,14 @@ commands.logCustomEvent = function (vendor, event) {
  */
 commands.getLogEvents = function (type = null) {
   if (_.isEmpty(type)) {
-    return this._meta._eventHistory;
+    return this._meta.eventHistory;
   }
 
   if (!_.isArray(type)) {
     type = [type];
   }
 
-  return _.reduce(this._meta._eventHistory, (acc, eventTimes, eventType) => {
+  return _.reduce(this._meta.eventHistory, (acc, eventTimes, eventType) => {
     if (type.includes(eventType)) {
       acc[eventType] = eventTimes;
     }

--- a/lib/basedriver/commands/event.js
+++ b/lib/basedriver/commands/event.js
@@ -22,14 +22,14 @@ commands.logCustomEvent = function (vendor, event) {
  */
 commands.getLogEvents = function (type = null) {
   if (_.isEmpty(type)) {
-    return this._eventHistory;
+    return this._meta._eventHistory;
   }
 
   if (!_.isArray(type)) {
     type = [type];
   }
 
-  return _.reduce(this._eventHistory, (acc, eventTimes, eventType) => {
+  return _.reduce(this._meta._eventHistory, (acc, eventTimes, eventType) => {
     if (type.includes(eventType)) {
       acc[eventType] = eventTimes;
     }

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -179,6 +179,38 @@ class BaseDriver extends Protocol {
     return _.cloneDeep(this._meta._instrumentation.data);
   }
 
+  wrapInstrumentation (eventName, fn) {
+    const spannerFunction = (...args) => {
+      this.instrumentEventStart(eventName);
+      let result;
+      try {
+        result = fn.call(...args);
+        this.instrumentEventEnd(eventName);
+      } catch (error) {
+        this.instrumentEventEnd(eventName);
+        throw error;
+      }
+      return result;
+    };
+    return spannerFunction;
+  }
+
+  wrapInstrumentationAsync (eventName, fn) {
+    const spannerFunction = async (...args) => {
+      this.instrumentEventStart(eventName);
+      let result;
+      try {
+        result = await fn.call(...args);
+        this.instrumentEventEnd(eventName);
+      } catch (error) {
+        this.instrumentEventEnd(eventName);
+        throw error;
+      }
+      return result;
+    };
+    return spannerFunction;
+  }
+
   /*
    * API start method for driver developers to initialise instrumentation of events
    */
@@ -212,12 +244,12 @@ class BaseDriver extends Protocol {
       node.duration = endTime - node.startTime;
       delete node.startTime;
       node.status = true;
-      this._meta._instrumentation._active._node = null;
+      this._meta._instrumentation.active.node = null;
     } else {
-      const nodeData = this._meta._instrumentation._active._node;
+      const nodeData = this._meta._instrumentation.active.node;
       nodeData.duration = endTime - nodeData.startTime;
       delete nodeData.startTime;
-      if (!this._meta._instrumentation.active.node.parent.status) {
+      if (!(nodeData.parent.status)) {
         this._meta._instrumentation.active.node.parent.status = true;
         this._meta._instrumentation.active.node = this._meta._instrumentation.active.node.parent;
       }

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -19,7 +19,6 @@ import {
 import AsyncLock from 'async-lock';
 import { EventEmitter } from 'events';
 
-
 B.config({
   cancellation: true,
 });
@@ -88,9 +87,16 @@ class BaseDriver extends Protocol {
     // allow subclasses to have internal drivers
     this.managedDrivers = [];
 
-    // store event timings
-    this._eventHistory = {
-      commands: [] // commands get a special place
+    this._meta = {
+      _eventHistory: {
+        commands: [] // commands get a special place
+      },
+      _instrumentation: {
+        _active: {
+          _node: null
+        },
+        _data: {}
+      }
     };
 
     // cache the image elements
@@ -147,7 +153,7 @@ class BaseDriver extends Protocol {
    * inadvertently change data outside of logEvent
    */
   get eventHistory () {
-    return _.cloneDeep(this._eventHistory);
+    return _.cloneDeep(this._meta._eventHistory);
   }
 
   /*
@@ -160,13 +166,51 @@ class BaseDriver extends Protocol {
     if (typeof eventName !== 'string') {
       throw new Error(`Invalid eventName ${eventName}`);
     }
-    if (!this._eventHistory[eventName]) {
-      this._eventHistory[eventName] = [];
+    if (!this._meta._eventHistory[eventName]) {
+      this._meta._eventHistory[eventName] = [];
     }
     const ts = Date.now();
     const logTime = (new Date(ts)).toTimeString();
-    this._eventHistory[eventName].push(ts);
+    this._meta._eventHistory[eventName].push(ts);
     log.debug(`Event '${eventName}' logged at ${ts} (${logTime})`);
+  }
+
+  get instrumentation () {
+    return _.cloneDeep(this._meta._instrumentation._data);
+  }
+
+  instrumentEventStart (eventName, options = {}) {
+    const instrumentationNode = {
+      eventName,
+      options,
+      startTime: Date.now(),
+      children: [],
+      parent: null
+    };
+    if (this._meta._instrumentation._active._node) {
+      const currentActiveNode = this._meta._instrumentation._active._node;
+      currentActiveNode.children.push(instrumentationNode);
+      instrumentationNode.parent = currentActiveNode;
+      this._meta._instrumentation._active._node = instrumentationNode;
+    } else {
+      this._meta._instrumentation._data[eventName] = instrumentationNode;
+      this._meta._instrumentation._active._node = instrumentationNode;
+    }
+  }
+
+  instrumentEventEnd (eventName) {
+    const endTime = Date.now();
+    if (this._meta._instrumentation.data[eventName]) {
+      const node = this._meta._instrumentation.data[eventName];
+      node.duration = endTime - node.startTime;
+      delete node.startTime;
+      this._meta._instrumentation._active._node = null;
+    } else {
+      const nodeData = this._meta._instrumentation._active._node;
+      nodeData.duration = endTime - nodeData.startTime;
+      delete nodeData.startTime;
+      this._meta._instrumentation._active._node = this._meta._instrumentation._active._node.parent;
+    }
   }
 
   /*
@@ -361,7 +405,7 @@ class BaseDriver extends Protocol {
 
     // log timing information about this command
     const endTime = Date.now();
-    this._eventHistory.commands.push({cmd, startTime, endTime});
+    this._meta._eventHistory.commands.push({cmd, startTime, endTime});
     if (cmd === 'createSession') {
       this.logEvent(EVENT_SESSION_START);
     } else if (cmd === 'deleteSession') {

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -88,10 +88,10 @@ class BaseDriver extends Protocol {
     this.managedDrivers = [];
 
     this._meta = {
-      _eventHistory: {
+      eventHistory: {
         commands: [] // commands get a special place
       },
-      _instrumentation: {
+      instrumentation: {
         active: {
           node: null
         },
@@ -153,7 +153,7 @@ class BaseDriver extends Protocol {
    * inadvertently change data outside of logEvent
    */
   get eventHistory () {
-    return _.cloneDeep(this._meta._eventHistory);
+    return _.cloneDeep(this._meta.eventHistory);
   }
 
   /*
@@ -166,71 +166,77 @@ class BaseDriver extends Protocol {
     if (typeof eventName !== 'string') {
       throw new Error(`Invalid eventName ${eventName}`);
     }
-    if (!this._meta._eventHistory[eventName]) {
-      this._meta._eventHistory[eventName] = [];
+    if (!this._meta.eventHistory[eventName]) {
+      this._meta.eventHistory[eventName] = [];
     }
     const ts = Date.now();
     const logTime = (new Date(ts)).toTimeString();
-    this._meta._eventHistory[eventName].push(ts);
+    this._meta.eventHistory[eventName].push(ts);
     log.debug(`Event '${eventName}' logged at ${ts} (${logTime})`);
   }
 
   get instrumentation () {
-    return _.cloneDeep(this._meta._instrumentation.data);
+    return _.cloneDeep(this._meta.instrumentation.data);
   }
 
   wrapInstrumentation (eventName, fn) {
-    const spannerFunction = (...args) => {
-      this.instrumentEventStart(eventName);
-      let result;
-      try {
-        result = fn.call(...args);
-        this.instrumentEventEnd(eventName);
-      } catch (error) {
-        this.instrumentEventEnd(eventName);
-        throw error;
-      }
-      return result;
-    };
-    return spannerFunction;
+    if (this.opts.allowInstrumentation) {
+      const spannerFunction = (...args) => {
+        this.instrumentEventStart(eventName);
+        try {
+          const result = fn.call(...args);
+          this.instrumentEventEnd(eventName);
+          return result;
+        } catch (error) {
+          this.instrumentEventEnd(eventName);
+          throw error;
+        }
+      };
+      return spannerFunction;
+    }
+    return fn;
   }
 
   wrapInstrumentationAsync (eventName, fn) {
-    const spannerFunction = async (...args) => {
-      this.instrumentEventStart(eventName);
-      let result;
-      try {
-        result = await fn.call(...args);
-        this.instrumentEventEnd(eventName);
-      } catch (error) {
-        this.instrumentEventEnd(eventName);
-        throw error;
-      }
-      return result;
-    };
-    return spannerFunction;
+    if (this.opts.allowInstrumentation) {
+      const spannerFunction = async (...args) => {
+        this.instrumentEventStart(eventName);
+        try {
+          const result = await fn.call(...args);
+          this.instrumentEventEnd(eventName);
+          return result;
+        } catch (error) {
+          this.instrumentEventEnd(eventName);
+          throw error;
+        }
+      };
+      return spannerFunction;
+    }
+    return fn;
   }
 
   /*
    * API start method for driver developers to initialise instrumentation of events
    */
   instrumentEventStart (eventName, options = {}) {
-    const instrumentationNode = {
-      eventName,
-      options,
-      startTime: Date.now(),
-      children: [],
-      parent: null,
-      status: false
-    };
-    if (this._meta._instrumentation.active.node) {
-      const currentActiveNode = this._meta._instrumentation.active.node;
-      currentActiveNode.children.push(instrumentationNode);
-      instrumentationNode.parent = currentActiveNode;
-      this._meta._instrumentation.active.node = instrumentationNode;
-    } else {
-      this._meta._instrumentation.data[eventName] = instrumentationNode;
-      this._meta._instrumentation.active.node = instrumentationNode;
+    if (this.opts.allowInstrumentation) {
+      const instrumentationNode = {
+        eventName,
+        options,
+        startTime: Date.now(),
+        children: [],
+        parent: null,
+        status: false
+      };
+      if (this._meta.instrumentation.active.node) {
+        const currentActiveNode = this._meta.instrumentation.active.node;
+        currentActiveNode.children.push(instrumentationNode);
+        instrumentationNode.parent = currentActiveNode;
+        this._meta.instrumentation.active.node = instrumentationNode;
+      } else {
+        this._meta.instrumentation.data[eventName] = instrumentationNode;
+        this._meta.instrumentation.active.node = instrumentationNode;
+      }
     }
   }
 
@@ -238,20 +244,22 @@ class BaseDriver extends Protocol {
    * API end method for driver developers to end the instrumentation of events
    */
   instrumentEventEnd (eventName) {
-    const endTime = Date.now();
-    if (this._meta._instrumentation.data[eventName]) {
-      const node = this._meta._instrumentation.data[eventName];
-      node.duration = endTime - node.startTime;
-      delete node.startTime;
-      node.status = true;
-      this._meta._instrumentation.active.node = null;
-    } else {
-      const nodeData = this._meta._instrumentation.active.node;
-      nodeData.duration = endTime - nodeData.startTime;
-      delete nodeData.startTime;
-      if (!(nodeData.parent.status)) {
-        this._meta._instrumentation.active.node.parent.status = true;
-        this._meta._instrumentation.active.node = this._meta._instrumentation.active.node.parent;
+    if (this.opts.allowInstrumentation) {
+      const endTime = Date.now();
+      if (this._meta.instrumentation.data[eventName]) {
+        const node = this._meta.instrumentation.data[eventName];
+        node.duration = endTime - node.startTime;
+        delete node.startTime;
+        node.status = true;
+        this._meta.instrumentation.active.node = null;
+      } else {
+        const nodeData = this._meta.instrumentation.active.node;
+        nodeData.duration = endTime - nodeData.startTime;
+        delete nodeData.startTime;
+        if (!(nodeData.parent.status)) {
+          this._meta.instrumentation.active.node.parent.status = true;
+          this._meta.instrumentation.active.node = this._meta.instrumentation.active.node.parent;
+        }
       }
     }
   }
@@ -448,7 +456,7 @@ class BaseDriver extends Protocol {
 
     // log timing information about this command
     const endTime = Date.now();
-    this._meta._eventHistory.commands.push({cmd, startTime, endTime});
+    this._meta.eventHistory.commands.push({cmd, startTime, endTime});
     if (cmd === 'createSession') {
       this.logEvent(EVENT_SESSION_START);
     } else if (cmd === 'deleteSession') {

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -92,10 +92,10 @@ class BaseDriver extends Protocol {
         commands: [] // commands get a special place
       },
       _instrumentation: {
-        _active: {
-          _node: null
+        active: {
+          node: null
         },
-        _data: {}
+        data: {}
       }
     };
 
@@ -176,40 +176,51 @@ class BaseDriver extends Protocol {
   }
 
   get instrumentation () {
-    return _.cloneDeep(this._meta._instrumentation._data);
+    return _.cloneDeep(this._meta._instrumentation.data);
   }
 
+  /*
+   * API start method for driver developers to initialise instrumentation of events
+   */
   instrumentEventStart (eventName, options = {}) {
     const instrumentationNode = {
       eventName,
       options,
       startTime: Date.now(),
       children: [],
-      parent: null
+      parent: null,
+      status: false
     };
-    if (this._meta._instrumentation._active._node) {
-      const currentActiveNode = this._meta._instrumentation._active._node;
+    if (this._meta._instrumentation.active.node) {
+      const currentActiveNode = this._meta._instrumentation.active.node;
       currentActiveNode.children.push(instrumentationNode);
       instrumentationNode.parent = currentActiveNode;
-      this._meta._instrumentation._active._node = instrumentationNode;
+      this._meta._instrumentation.active.node = instrumentationNode;
     } else {
-      this._meta._instrumentation._data[eventName] = instrumentationNode;
-      this._meta._instrumentation._active._node = instrumentationNode;
+      this._meta._instrumentation.data[eventName] = instrumentationNode;
+      this._meta._instrumentation.active.node = instrumentationNode;
     }
   }
 
+  /*
+   * API end method for driver developers to end the instrumentation of events
+   */
   instrumentEventEnd (eventName) {
     const endTime = Date.now();
     if (this._meta._instrumentation.data[eventName]) {
       const node = this._meta._instrumentation.data[eventName];
       node.duration = endTime - node.startTime;
       delete node.startTime;
+      node.status = true;
       this._meta._instrumentation._active._node = null;
     } else {
       const nodeData = this._meta._instrumentation._active._node;
       nodeData.duration = endTime - nodeData.startTime;
       delete nodeData.startTime;
-      this._meta._instrumentation._active._node = this._meta._instrumentation._active._node.parent;
+      if (!this._meta._instrumentation.active.node.parent.status){
+        this._meta._instrumentation.active.node.parent.status = true;
+        this._meta._instrumentation.active.node = this._meta._instrumentation.active.node.parent;
+      }
     }
   }
 

--- a/lib/basedriver/driver.js
+++ b/lib/basedriver/driver.js
@@ -217,7 +217,7 @@ class BaseDriver extends Protocol {
       const nodeData = this._meta._instrumentation._active._node;
       nodeData.duration = endTime - nodeData.startTime;
       delete nodeData.startTime;
-      if (!this._meta._instrumentation.active.node.parent.status){
+      if (!this._meta._instrumentation.active.node.parent.status) {
         this._meta._instrumentation.active.node.parent.status = true;
         this._meta._instrumentation.active.node = this._meta._instrumentation.active.node.parent;
       }

--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -724,9 +724,7 @@ for (let ErrorClass of _.values(errors)) {
 
 function isUnknownError (err) {
   return !err.constructor.name ||
-         !_.values(errors).find(function equalNames (error) {
-           return error.name === err.constructor.name;
-         });
+         !_.values(errors).find((error) => error.name === err.constructor.name);
 }
 
 function isErrorType (err, type) {

--- a/test/basedriver/commands/event-specs.js
+++ b/test/basedriver/commands/event-specs.js
@@ -9,13 +9,13 @@ chai.use(chaiAsPromised);
 describe('logging custom events', function () {
   it('should allow logging of events', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.should.eql({commands: []});
     await d.logCustomEvent('myorg', 'myevent');
-    _.keys(d._meta._eventHistory).should.eql(['commands', 'myorg:myevent']);
+    _.keys(d._meta.eventHistory).should.eql(['commands', 'myorg:myevent']);
   });
   it('should get all events including custom ones', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.should.eql({commands: []});
     d.logEvent('appiumEvent');
     await d.logCustomEvent('myorg', 'myevent');
     const events = await d.getLogEvents();
@@ -26,8 +26,8 @@ describe('logging custom events', function () {
 describe('#getLogEvents', function () {
   it('should allow to get all events', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
-    d._meta._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta.eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents().should.eql({
       commands: [], testCommand: ['1', '2', '3']
     });
@@ -35,8 +35,8 @@ describe('#getLogEvents', function () {
 
   it('should filter with testCommand', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
-    d._meta._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta.eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents('testCommand').should.eql({
       testCommand: ['1', '2', '3']
     });
@@ -44,16 +44,16 @@ describe('#getLogEvents', function () {
 
   it('should not filter with wrong but can be a part of the event name', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
-    d._meta._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta.eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents('testCommandDummy').should.eql({});
   });
 
   it('should filter with multiple event keys', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
-    d._meta._eventHistory.testCommand = ['1', '2', '3'];
-    d._meta._eventHistory.testCommand2 = ['4', '5'];
+    d._meta.eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.testCommand = ['1', '2', '3'];
+    d._meta.eventHistory.testCommand2 = ['4', '5'];
     await d.getLogEvents(['testCommand', 'testCommand2']).should.eql({
       testCommand: ['1', '2', '3'], testCommand2: ['4', '5']
     });
@@ -61,8 +61,8 @@ describe('#getLogEvents', function () {
 
   it('should filter with custom events', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
-    d._meta._eventHistory['custom:appiumEvent'] = ['1', '2', '3'];
+    d._meta.eventHistory.should.eql({commands: []});
+    d._meta.eventHistory['custom:appiumEvent'] = ['1', '2', '3'];
     await d.getLogEvents(['custom:appiumEvent']).should.eql({
       'custom:appiumEvent': ['1', '2', '3']
     });
@@ -70,8 +70,8 @@ describe('#getLogEvents', function () {
 
   it('should not filter with no existed event name', async function () {
     const d = new BaseDriver();
-    d._meta._eventHistory.should.eql({commands: []});
-    d._meta._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta.eventHistory.should.eql({commands: []});
+    d._meta.eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents(['noEventName']).should.eql({});
   });
 });

--- a/test/basedriver/commands/event-specs.js
+++ b/test/basedriver/commands/event-specs.js
@@ -9,13 +9,13 @@ chai.use(chaiAsPromised);
 describe('logging custom events', function () {
   it('should allow logging of events', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.should.eql({commands: []});
     await d.logCustomEvent('myorg', 'myevent');
-    _.keys(d._eventHistory).should.eql(['commands', 'myorg:myevent']);
+    _.keys(d._meta._eventHistory).should.eql(['commands', 'myorg:myevent']);
   });
   it('should get all events including custom ones', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.should.eql({commands: []});
     d.logEvent('appiumEvent');
     await d.logCustomEvent('myorg', 'myevent');
     const events = await d.getLogEvents();
@@ -26,8 +26,8 @@ describe('logging custom events', function () {
 describe('#getLogEvents', function () {
   it('should allow to get all events', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
-    d._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents().should.eql({
       commands: [], testCommand: ['1', '2', '3']
     });
@@ -35,8 +35,8 @@ describe('#getLogEvents', function () {
 
   it('should filter with testCommand', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
-    d._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents('testCommand').should.eql({
       testCommand: ['1', '2', '3']
     });
@@ -44,16 +44,16 @@ describe('#getLogEvents', function () {
 
   it('should not filter with wrong but can be a part of the event name', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
-    d._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents('testCommandDummy').should.eql({});
   });
 
   it('should filter with multiple event keys', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
-    d._eventHistory.testCommand = ['1', '2', '3'];
-    d._eventHistory.testCommand2 = ['4', '5'];
+    d._meta._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta._eventHistory.testCommand2 = ['4', '5'];
     await d.getLogEvents(['testCommand', 'testCommand2']).should.eql({
       testCommand: ['1', '2', '3'], testCommand2: ['4', '5']
     });
@@ -61,8 +61,8 @@ describe('#getLogEvents', function () {
 
   it('should filter with custom events', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
-    d._eventHistory['custom:appiumEvent'] = ['1', '2', '3'];
+    d._meta._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory['custom:appiumEvent'] = ['1', '2', '3'];
     await d.getLogEvents(['custom:appiumEvent']).should.eql({
       'custom:appiumEvent': ['1', '2', '3']
     });
@@ -70,8 +70,8 @@ describe('#getLogEvents', function () {
 
   it('should not filter with no existed event name', async function () {
     const d = new BaseDriver();
-    d._eventHistory.should.eql({commands: []});
-    d._eventHistory.testCommand = ['1', '2', '3'];
+    d._meta._eventHistory.should.eql({commands: []});
+    d._meta._eventHistory.testCommand = ['1', '2', '3'];
     await d.getLogEvents(['noEventName']).should.eql({});
   });
 });


### PR DESCRIPTION
Instrumentation Object Schema:
 ```
{
"eventName" : "initializeDriver",
"duration" : 12220
"options" : {},
"children" : [{
                        "eventName" : "driverServerStart",
                        "duration": 8760,
                        "options" : {},
                        "children": []
                     }]
}
```

This data will help when building custom spans using opentelemetry plugin as well as works as a meta field for detailed instrumentation (which can be kept optional)