### PR TITLE
feat: add releaseActions as w3c actions (from 2.0 branch)

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -280,6 +280,7 @@ const METHOD_MAP = {
   },
   '/session/:sessionId/actions': {
     POST: {command: 'performActions', payloadParams: {required: ['actions']}},
+    DELETE: {command: 'releaseActions'},
   },
   '/session/:sessionId/touch/longclick': {
     POST: {command: 'touchLongClick', payloadParams: {required: ['elements']}}

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('52aacae0');
+      hash.should.equal('b1dff09e');
     });
   });
 


### PR DESCRIPTION
Related to https://github.com/appium/appium-xcuitest-driver/pull/1315
2.0 base driver already has this. This PR is for the next 1.x release.