### PR TITLE
feat(helpers): leverage system unzip where available

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -2,11 +2,10 @@ import _ from 'lodash';
 import path from 'path';
 import url from 'url';
 import logger from './logger';
-import { tempDir, fs, util, zip, net, timing } from 'appium-support';
+import { system, tempDir, fs, util, zip, net, timing } from 'appium-support';
 import LRU from 'lru-cache';
 import AsyncLock from 'async-lock';
 import axios from 'axios';
-
 
 const IPA_EXT = '.ipa';
 const ZIP_EXTS = ['.zip', IPA_EXT];
@@ -323,7 +322,15 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
   try {
     logger.debug(`Unzipping '${zipPath}'`);
     const timer = new timing.Timer().start();
-    const extractionOpts = {};
+    /**
+     * Attempt to use use the system `unzip` (e.g., `/usr/bin/unzip`) due
+     * to the significant performance improvement it provides over the native
+     * JS "unzip" implementation.
+     * @type {import('appium-support/lib/zip').ExtractAllOptions}
+     */
+    const extractionOpts = {
+      useSystemUnzip: !system.isWindows(),
+    };
     // https://github.com/appium/appium/issues/14100
     if (path.extname(zipPath) === IPA_EXT) {
       logger.debug(`Enforcing UTF-8 encoding on the extracted file names for '${path.basename(zipPath)}'`);


### PR DESCRIPTION
In my testing, I've found that `/usr/bin/unzip` is a 3x speedup over a native-JS implementation (which we currently use).  This can be significant in large files.

To maintain cross-platform compatibility, the `unzipApp()` helper function will fall back to the native JS implementation where `/usr/bin/unzip` is not available (Windows).  It will also retry using the native implementation if `/usr/bin/unzip` fails for any other reason.  Given `.zip` files are _validated_ prior to this call, it's unlikely that would occur unless there is something wrong with system unzip itself.

I've added a couple trivial tests here, but to test it "properly" would require a fair bit of refactoring.

TODO: Port to `@appium/base-driver` and configure CI to run E2E tests on win32.