### PR TITLE
chore: bump min appium-support version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-support": "^2.52.0",
+    "appium-support": "^2.54.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
     "axios": "^0.x",


### PR DESCRIPTION
this version has https://github.com/appium/appium-support/commit/873351aacc0402bcb229bad928abd1ad2f9c4a4b