### PR TITLE
chore: Optimize bundle lookup in the extracted archive

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -350,7 +350,7 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
         ` in it. Make sure your archive contains at least one package having ` +
         `'${supportedAppExtensions}' ${util.pluralize('extension', supportedAppExtensions.length, false)}`);
     }
-    logger.debug(`Extracted bundle ${util.pluralize('item', sortedBundleItems.length, true)} ` +
+    logger.debug(`Extracted ${util.pluralize('bundle item', sortedBundleItems.length, true)} ` +
       `from '${zipPath}' in ${Math.round(timer.getDuration().asMilliSeconds)}ms: ${sortedBundleItems}`);
     const matchedBundle = _.first(sortedBundleItems);
     logger.info(`Assuming '${matchedBundle}' is the correct bundle`);

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -337,13 +337,12 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
       extractionOpts.fileNamesEncoding = 'utf8';
     }
     await zip.extractAllTo(zipPath, tmpRoot, extractionOpts);
-    const sortedBundleItems = (await fs.glob(
-      `**/*.+(${supportedAppExtensions.map((ext) => ext.trimLeft('.')).join('|')})`, {
-        cwd: tmpRoot,
-        strict: false,
-      }))
-      // Get the top level match
-      .sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
+    const globPattern = `**/*.+(${supportedAppExtensions.map((ext) => ext.replace(/^\./, '')).join('|')})`;
+    const sortedBundleItems = (await fs.glob(globPattern, {
+      cwd: tmpRoot,
+      strict: false,
+    // Get the top level match
+    })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
     if (_.isEmpty(sortedBundleItems)) {
       logger.errorAndThrow(`App unzipped OK, but we could not find any '${supportedAppExtensions}' ` +
         util.pluralize('bundle', supportedAppExtensions.length, false) +

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -337,11 +337,11 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
       extractionOpts.fileNamesEncoding = 'utf8';
     }
     await zip.extractAllTo(zipPath, tmpRoot, extractionOpts);
-    const sortedBundleItems = await fs.glob(
+    const sortedBundleItems = (await fs.glob(
       `**/*.+(${supportedAppExtensions.map((ext) => ext.trimLeft('.')).join('|')})`, {
         cwd: tmpRoot,
         strict: false,
-      })
+      }))
       // Get the top level match
       .sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
     if (_.isEmpty(sortedBundleItems)) {

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -337,23 +337,23 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
       extractionOpts.fileNamesEncoding = 'utf8';
     }
     await zip.extractAllTo(zipPath, tmpRoot, extractionOpts);
-    const duration = timer.getDuration();
-    const allExtractedItems = await fs.glob('**', {cwd: tmpRoot});
-    logger.debug(`Extracted ${util.pluralize('item', allExtractedItems.length, true)} ` +
-      `from '${zipPath}' in ${Math.round(duration.asMilliSeconds)}ms`);
-    const allBundleItems = allExtractedItems
-      .filter((relativePath) => supportedAppExtensions.includes(path.extname(relativePath)))
+    const sortedBundleItems = await fs.glob(
+      `**/*.+(${supportedAppExtensions.map((ext) => ext.trimLeft('.')).join('|')})`, {
+        cwd: tmpRoot,
+        strict: false,
+      })
       // Get the top level match
       .sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
-    if (_.isEmpty(allBundleItems)) {
-      throw new Error(`App zip unzipped OK, but we could not find '${supportedAppExtensions}' ` +
+    if (_.isEmpty(sortedBundleItems)) {
+      logger.errorAndThrow(`App unzipped OK, but we could not find any '${supportedAppExtensions}' ` +
         util.pluralize('bundle', supportedAppExtensions.length, false) +
         ` in it. Make sure your archive contains at least one package having ` +
         `'${supportedAppExtensions}' ${util.pluralize('extension', supportedAppExtensions.length, false)}`);
     }
-    const matchedBundle = _.first(allBundleItems);
-    logger.debug(`Matched ${util.pluralize('item', allBundleItems.length, true)} in the extracted archive. ` +
-      `Assuming '${matchedBundle}' is the correct bundle`);
+    logger.debug(`Extracted bundle ${util.pluralize('item', sortedBundleItems.length, true)} ` +
+      `from '${zipPath}' in ${Math.round(timer.getDuration().asMilliSeconds)}ms: ${sortedBundleItems}`);
+    const matchedBundle = _.first(sortedBundleItems);
+    logger.info(`Assuming '${matchedBundle}' is the correct bundle`);
     const dstPath = path.resolve(dstRoot, path.basename(matchedBundle));
     await fs.mv(path.resolve(tmpRoot, matchedBundle), dstPath, {mkdirp: true});
     return dstPath;


### PR DESCRIPTION
Glob can filter items while searching. There is no need to do it again after all items are returned