### PR TITLE
feat: add /se for selenium 4

### DIFF
--- a/lib/protocol/routes.js
+++ b/lib/protocol/routes.js
@@ -316,9 +316,19 @@ const METHOD_MAP = {
   '/session/:sessionId/session_storage/size': {
     GET: {}
   },
+  // Selenium 4 clients
+  '/session/:sessionId/se/log': {
+    POST: {command: 'getLog', payloadParams: {required: ['type']}}
+  },
+  // Selenium 4 clients
+  '/session/:sessionId/se/log/types': {
+    GET: {command: 'getLogTypes'}
+  },
+  // mjsonwire, appium clients
   '/session/:sessionId/log': {
     POST: {command: 'getLog', payloadParams: {required: ['type']}}
   },
+  // mjsonwire, appium clients
   '/session/:sessionId/log/types': {
     GET: {command: 'getLogTypes'}
   },

--- a/test/protocol/routes-specs.js
+++ b/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('b1dff09e');
+      hash.should.equal('5d9aaa31');
     });
   });
 


### PR DESCRIPTION
(Will create the same PR to appium/2.0 later)

I noticed selenium 4 clients sent `/se/log` paths since these routes were not in W3C spec.
https://github.com/appium/python-client/issues/630

Some clients like Ruby lib already support the old format in W3C, but it would be better to support `/se/log` paths for possible selenium compatible clients.
https://github.com/appium/ruby_lib_core/blob/1632637fd872c0b80dfb97b8514ada6a7164eebf/lib/appium_lib_core/common/command/w3c.rb#L50

Python client 2 (selenium 4 bases) is still beta, so we can say it works over Appium 1.22.0 after this (and publish a new rc)