### PR TITLE
fix: Update apps cache behaviour for expired items

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -267,14 +267,15 @@ async function configureApp (app, supportedAppExtensions) {
       archiveHash = await calculateFileIntegrity(archivePath);
       if (archiveHash === cachedAppInfo?.archiveHash) {
         const {fullPath} = cachedAppInfo;
-        if (await fs.exists(fullPath)) {
+        if (await isAppIntegrityOk(fullPath, cachedAppInfo?.integrity)) {
           if (archivePath !== app) {
             await fs.rimraf(archivePath);
           }
           logger.info(`Will reuse previously cached application at '${fullPath}'`);
           return verifyAppExtension(fullPath, supportedAppExtensions);
         }
-        logger.info(`The application at '${fullPath}' does not exist anymore. Deleting it from the cache`);
+        logger.info(`The application at '${fullPath}' does not exist anymore ` +
+          `or its integrity has been damaged. Deleting it from the cache`);
         APPLICATIONS_CACHE.del(app);
       }
       const tmpRoot = await tempDir.openDir();

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -18,13 +18,14 @@ const CACHED_APPS_MAX_AGE = 1000 * 60 * 60 * 24; // ms
 const APPLICATIONS_CACHE = new LRU({
   maxAge: CACHED_APPS_MAX_AGE, // expire after 24 hours
   updateAgeOnGet: true,
-  dispose: async (app, {fullPath}) => {
-    if (!await fs.exists(fullPath)) {
-      return;
-    }
-
-    logger.info(`The application '${app}' cached at '${fullPath}' has expired`);
-    await fs.rimraf(fullPath);
+  dispose: (app, {fullPath}) => {
+    logger.info(`The application '${app}' cached at '${fullPath}' has ` +
+      `expired after ${CACHED_APPS_MAX_AGE}ms`);
+    setTimeout(0, async () => {
+      if (fullPath && await fs.exists(fullPath)) {
+        await fs.rimraf(fullPath);
+      }
+    });
   },
   noDisposeOnSet: true,
 });
@@ -66,48 +67,50 @@ async function retrieveHeaders (link) {
   return {};
 }
 
-function getCachedApplicationPath (link, currentAppProps = {}) {
+function getCachedApplicationPath (link, currentAppProps = {}, cachedAppInfo = {}) {
   const refresh = () => {
     logger.debug(`A fresh copy of the application is going to be downloaded from ${link}`);
     return null;
   };
 
-  if (APPLICATIONS_CACHE.has(link)) {
-    const {
-      lastModified: currentModified,
-      immutable: currentImmutable,
-      // maxAge is in seconds
-      maxAge: currentMaxAge,
-    } = currentAppProps;
-    const {
-      // Date instance
-      lastModified,
-      // boolean
-      immutable,
-      // Unix time in milliseconds
-      timestamp,
-      fullPath,
-    } = APPLICATIONS_CACHE.get(link);
-    if (lastModified && currentModified) {
-      if (currentModified.getTime() <= lastModified.getTime()) {
-        logger.debug(`The application at ${link} has not been modified since ${lastModified}`);
-        return fullPath;
-      }
-      logger.debug(`The application at ${link} has been modified since ${lastModified}`);
-      return refresh();
-    }
-    if (immutable && currentImmutable) {
-      logger.debug(`The application at ${link} is immutable`);
+  if (!_.isPlainObject(cachedAppInfo) || !_.isPlainObject(currentAppProps)) {
+    return refresh();
+  }
+
+  const {
+    lastModified: currentModified,
+    immutable: currentImmutable,
+    // maxAge is in seconds
+    maxAge: currentMaxAge,
+  } = currentAppProps;
+  const {
+    // Date instance
+    lastModified,
+    // boolean
+    immutable,
+    // Unix time in milliseconds
+    timestamp,
+    fullPath,
+  } = cachedAppInfo;
+  if (lastModified && currentModified) {
+    if (currentModified.getTime() <= lastModified.getTime()) {
+      logger.debug(`The application at ${link} has not been modified since ${lastModified}`);
       return fullPath;
     }
-    if (currentMaxAge && timestamp) {
-      const msLeft = timestamp + currentMaxAge * 1000 - Date.now();
-      if (msLeft > 0) {
-        logger.debug(`The cached application '${path.basename(fullPath)}' will expire in ${msLeft / 1000}s`);
-        return fullPath;
-      }
-      logger.debug(`The cached application '${path.basename(fullPath)}' has expired`);
+    logger.debug(`The application at ${link} has been modified since ${lastModified}`);
+    return refresh();
+  }
+  if (immutable && currentImmutable) {
+    logger.debug(`The application at ${link} is immutable`);
+    return fullPath;
+  }
+  if (currentMaxAge && timestamp) {
+    const msLeft = timestamp + currentMaxAge * 1000 - Date.now();
+    if (msLeft > 0) {
+      logger.debug(`The cached application '${path.basename(fullPath)}' will expire in ${msLeft / 1000}s`);
+      return fullPath;
     }
+    logger.debug(`The cached application '${path.basename(fullPath)}' has expired`);
   }
   return refresh();
 }
@@ -119,6 +122,28 @@ function verifyAppExtension (app, supportedAppExtensions) {
   throw new Error(`New app path '${app}' did not have ` +
     `${util.pluralize('extension', supportedAppExtensions.length, false)}: ` +
     supportedAppExtensions);
+}
+
+async function calculateFolderIntegrity (folderPath) {
+  return (await fs.glob('**/*', {cwd: folderPath, strict: false, nosort: true})).length;
+}
+
+async function calculateFileIntegrity (filePath) {
+  return await fs.hash(filePath);
+}
+
+async function isAppIntegrityOk (currentPath, expectedIntegrity = {}) {
+  if (!await fs.exists(currentPath)) {
+    return false;
+  }
+  const isDir = (await fs.stat(currentPath)).isDirectory();
+  if (isDir && await calculateFolderIntegrity(currentPath) >= expectedIntegrity?.folder) {
+    return true;
+  }
+  if (!isDir && await calculateFileIntegrity(currentPath) === expectedIntegrity?.file) {
+    return true;
+  }
+  return false;
 }
 
 async function configureApp (app, supportedAppExtensions) {
@@ -141,6 +166,8 @@ async function configureApp (app, supportedAppExtensions) {
   const {protocol, pathname} = url.parse(newApp);
   const isUrl = ['http:', 'https:'].includes(protocol);
 
+  const cachedAppInfo = APPLICATIONS_CACHE.get(app);
+
   return await APPLICATIONS_CACHE_GUARD.acquire(app, async () => {
     if (isUrl) {
       // Use the app from remote URL
@@ -160,13 +187,14 @@ async function configureApp (app, supportedAppExtensions) {
         }
         logger.debug(`Cache-Control: ${headers['cache-control']}`);
       }
-      const cachedPath = getCachedApplicationPath(app, remoteAppProps);
+      const cachedPath = getCachedApplicationPath(app, remoteAppProps, cachedAppInfo);
       if (cachedPath) {
-        if (await fs.exists(cachedPath)) {
+        if (await isAppIntegrityOk(cachedPath, cachedAppInfo?.integrity)) {
           logger.info(`Reusing previously downloaded application at '${cachedPath}'`);
           return verifyAppExtension(cachedPath, supportedAppExtensions);
         }
-        logger.info(`The application at '${cachedPath}' does not exist anymore. Deleting it from the cache`);
+        logger.info(`The application at '${cachedPath}' does not exist anymore ` +
+          `or its integrity has been damaged. Deleting it from the internal cache`);
         APPLICATIONS_CACHE.del(app);
       }
 
@@ -236,9 +264,9 @@ async function configureApp (app, supportedAppExtensions) {
 
     if (shouldUnzipApp) {
       const archivePath = newApp;
-      archiveHash = await fs.hash(archivePath);
-      if (APPLICATIONS_CACHE.has(app) && archiveHash === APPLICATIONS_CACHE.get(app).hash) {
-        const {fullPath} = APPLICATIONS_CACHE.get(app);
+      archiveHash = await calculateFileIntegrity(archivePath);
+      if (archiveHash === cachedAppInfo?.archiveHash) {
+        const {fullPath} = cachedAppInfo;
         if (await fs.exists(fullPath)) {
           if (archivePath !== app) {
             await fs.rimraf(archivePath);
@@ -268,17 +296,21 @@ async function configureApp (app, supportedAppExtensions) {
     verifyAppExtension(newApp, supportedAppExtensions);
 
     if (app !== newApp && (archiveHash || _.values(remoteAppProps).some(Boolean))) {
-      if (APPLICATIONS_CACHE.has(app)) {
-        const {fullPath} = APPLICATIONS_CACHE.get(app);
-        // Clean up the obsolete entry first if needed
-        if (fullPath !== newApp && await fs.exists(fullPath)) {
-          await fs.rimraf(fullPath);
-        }
+      const cachedFullPath = cachedAppInfo?.fullPath;
+      if (cachedFullPath && cachedFullPath !== newApp && await fs.exists(cachedFullPath)) {
+        await fs.rimraf(cachedFullPath);
+      }
+      const integrity = {};
+      if ((await fs.stat(newApp)).isDirectory()) {
+        integrity.folder = await calculateFolderIntegrity(newApp);
+      } else {
+        integrity.file = await calculateFileIntegrity(newApp);
       }
       APPLICATIONS_CACHE.set(app, {
         ...remoteAppProps,
         timestamp: Date.now(),
-        hash: archiveHash,
+        archiveHash,
+        integrity,
         fullPath: newApp,
       });
     }

--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -136,7 +136,15 @@ async function isAppIntegrityOk (currentPath, expectedIntegrity = {}) {
   if (!await fs.exists(currentPath)) {
     return false;
   }
+
   const isDir = (await fs.stat(currentPath)).isDirectory();
+  // Folder integrity check is simple:
+  // Verify the previous amount of files is not greater than the current one.
+  // We don't want to use equality comparison because of an assumption that the OS might
+  // create some unwanted service files/cached inside of that folder or its subfolders.
+  // Ofc, validating the hash sum of each file (or at least of file path) would be much
+  // more precise, but we don't need to be very precise here and also don't want to
+  // overuse RAM and have a performance drop.
   if (isDir && await calculateFolderIntegrity(currentPath) >= expectedIntegrity?.folder) {
     return true;
   }

--- a/test/basedriver/helpers-specs.js
+++ b/test/basedriver/helpers-specs.js
@@ -106,6 +106,9 @@ describe('helpers', function () {
       sandbox.stub(fs, 'hash').resolves('0xDEADBEEF');
       sandbox.stub(fs, 'glob').resolves(['/path/to/an.apk']);
       sandbox.stub(fs, 'rimraf').resolves();
+      sandbox.stub(fs, 'stat').resolves({
+        isDirectory: () => false,
+      });
       sandbox.stub(tempDir, 'openDir').resolves('/some/dir');
     });
 


### PR DESCRIPTION
After longer meditation on LRU cache sources it turns out that `has` check does not actually care about expired items removal. Only the `get` check does that.
Also, it could be that the internal structure of the cached file/folder is changed while it's being cached. For now I've added a very simple (and fast) integrity check for cached folders, which makes sure that the amount of items in the folder (files and subfolders) has not been decreased since the last check.

Related to https://github.com/appium/appium/issues/16109