### PR TITLE
feat: Allow single zip bundle to contain multiple app SDK builds

### DIFF
--- a/lib/basedriver/helpers.js
+++ b/lib/basedriver/helpers.js
@@ -279,8 +279,13 @@ async function configureApp (app, supportedAppExtensions) {
           if (archivePath !== app) {
             await fs.rimraf(archivePath);
           }
-          logger.info(`Will reuse previously cached application at '${fullPath}'`);
-          return verifyAppExtension(fullPath, supportedAppExtensions);
+          logger.info(`Will try to reuse previously cached application at '${fullPath}'`);
+          try {
+            return verifyAppExtension(fullPath, supportedAppExtensions);
+          } catch (err) {
+            logger.warn(`Cached applicattion '${fullPath}' does not have ${util.pluralize('extension', supportedAppExtensions.length, false)} '${supportedAppExtensions}', will look for app in archive '${archivePath}'`);
+            return archivePath;
+          }
         }
         logger.info(`The application at '${fullPath}' does not exist anymore ` +
           `or its integrity has been damaged. Deleting it from the cache`);


### PR DESCRIPTION
Use case: A user configures the `app` capability with a `.zip` file.
The file contains builds at the same revision for multple SDKs, simulator and device, therefore it contains at the root both an `.ipa` and `.app` file.

Previously, If there were multiple tests running, they would all reuse the same cached application file that was first unzipped. This means that if the first test was on a real device and the second test ran on a simulator, the cached application became the unzipped `.ipa` file,  producing a `bad app` error when testing on the simulator. And vice-versa.

This change first tries to configure the app with the proper `supportedAppExtensions` (as it was already previously doing) and when it errors detecting the different desired extension, Appium will look inside the `.zip` archive again for a file with the correct extension.

To fully allow for this is, the XCUITest driver also needs this tiny change https://github.com/appium/appium-xcuitest-driver/pull/1408